### PR TITLE
move all cloudflare adapter generated files under the `.worker-next` directory

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,4 @@
 {
   "editor.formatOnSave": true,
-  "cSpell.words": [
-    "nextjs"
-  ]
+  "cSpell.words": ["nextjs"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
-  "editor.formatOnSave": true
+  "editor.formatOnSave": true,
+  "cSpell.words": [
+    "nextjs"
+  ]
 }

--- a/packages/cloudflare/src/build/build-worker.ts
+++ b/packages/cloudflare/src/build/build-worker.ts
@@ -2,6 +2,8 @@ import { NextjsAppPaths } from "../nextjs-paths";
 import { build, Plugin } from "esbuild";
 import { existsSync, readFileSync } from "node:fs";
 import { cp, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { patchRequire } from "./patches/investigated/patch-require";
 import { copyTemplates } from "./patches/investigated/copy-templates";
@@ -13,6 +15,9 @@ import { inlineEvalManifest } from "./patches/to-investigate/inline-eval-manifes
 import { patchWranglerDeps } from "./patches/to-investigate/wrangler-deps";
 import { updateWebpackChunksFile } from "./patches/investigated/update-webpack-chunks-file";
 
+/** The directory containing the Cloudflare template files. */
+const templateSrcDir = path.join(path.dirname(fileURLToPath(import.meta.url)), "templates");
+
 /**
  * Using the Next.js build output in the `.next` directory builds a workerd compatible output
  *
@@ -20,10 +25,9 @@ import { updateWebpackChunksFile } from "./patches/investigated/update-webpack-c
  * @param nextjsAppPaths
  */
 export async function buildWorker(
-  inputNextAppDir: string,
+  appDir: string,
   outputDir: string,
-  nextjsAppPaths: NextjsAppPaths,
-  templateSrcDir: string
+  nextjsAppPaths: NextjsAppPaths
 ): Promise<void> {
   const templateDir = copyTemplates(templateSrcDir, nextjsAppPaths);
 
@@ -132,8 +136,8 @@ Request = globalThis.Request;
   });
 
   // Copy over any static files (e.g. images) from the source project
-  if (existsSync(`${inputNextAppDir}/public`)) {
-    await cp(`${inputNextAppDir}/public`, `${outputDir}/assets`, {
+  if (existsSync(`${appDir}/public`)) {
+    await cp(`${appDir}/public`, `${outputDir}/assets`, {
       recursive: true,
     });
   }

--- a/packages/cloudflare/src/nextjs-paths.ts
+++ b/packages/cloudflare/src/nextjs-paths.ts
@@ -7,7 +7,6 @@ import path, { relative } from "node:path";
  * NOTE: WIP, we still need to discern which paths are relevant here!
  */
 export type NextjsAppPaths = {
-  appDir: string;
   /**
    * The path to the application's `.next` directory (where `next build` saves the build output)
    */
@@ -32,18 +31,17 @@ export type NextjsAppPaths = {
 /**
  * Collects all the paths necessary for dealing with the Next.js applications output
  *
- * @param nextAppDir The path to the Next.js app
+ * @param baseDir The path to the directory that contains the .next directory
  * @returns the various paths.
  */
-export function getNextjsAppPaths(nextAppDir: string): NextjsAppPaths {
-  const dotNextDir = getDotNextDirPath(nextAppDir);
+export function getNextjsAppPaths(baseDir: string): NextjsAppPaths {
+  const dotNextDir = getDotNextDirPath(baseDir);
 
   const appPath = getNextjsApplicationPath(dotNextDir).replace(/\/$/, "");
 
   const standaloneAppDir = path.join(dotNextDir, "standalone", appPath);
 
   return {
-    appDir: nextAppDir,
     dotNextDir,
     standaloneAppDir,
     standaloneAppDotNextDir: path.join(standaloneAppDir, ".next"),


### PR DESCRIPTION
In particular, rather than mutating the original `.next` files, we always make a copy to the `.worker-next/.next` directory and then mutate those.