### PR TITLE
adjust wrangler patching logic to use the correct `node_modules/next/dist` directory

### DIFF
--- a/packages/cloudflare/src/cli/config.ts
+++ b/packages/cloudflare/src/cli/config.ts
@@ -18,6 +18,8 @@ export type Config = {
     builderOutput: string;
     // Path to the app's `.next` directory (where `next build` saves the build output)
     dotNext: string;
+    // Path to the application standalone root directory
+    standaloneRoot: string;
     // Path to the application standalone directory (where `next build` saves the standalone app)
     standaloneApp: string;
     // Path to the `.next` directory specific to the standalone application
@@ -47,7 +49,8 @@ export type Config = {
 export function getConfig(appDir: string, outputDir: string): Config {
   const dotNext = path.join(outputDir, ".next");
   const appPath = getNextjsApplicationPath(dotNext).replace(/\/$/, "");
-  const standaloneApp = path.join(dotNext, "standalone", appPath);
+  const standaloneRoot = path.join(dotNext, "standalone");
+  const standaloneApp = path.join(standaloneRoot, appPath);
   const standaloneAppDotNext = path.join(standaloneApp, ".next");
   const standaloneAppServer = path.join(standaloneAppDotNext, "server");
 
@@ -59,6 +62,7 @@ export function getConfig(appDir: string, outputDir: string): Config {
       nextApp: appDir,
       builderOutput: outputDir,
       dotNext,
+      standaloneRoot,
       standaloneApp,
       standaloneAppDotNext,
       standaloneAppServer,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1617,9 +1617,6 @@ packages:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
     engines: {node: '>= 6'}
 
-  caniuse-lite@1.0.30001651:
-    resolution: {integrity: sha512-9Cf+Xv1jJNe1xPZLGuUXLNkE1BoDkqRqYyFJ9TDYSqhduqA4hu4oR9HluGoWYQC/aj8WHjsGVV+bwkh0+tegRg==}
-
   caniuse-lite@1.0.30001664:
     resolution: {integrity: sha512-AmE7k4dXiNKQipgn7a2xg558IRqPN3jMQY/rOsbxDhrd0tyChwbITBfiwtnqz8bi2M5mIWbxAYBvk7W7QBUS2g==}
 
@@ -4586,7 +4583,7 @@ snapshots:
   autoprefixer@10.4.20(postcss@8.4.47):
     dependencies:
       browserslist: 4.24.0
-      caniuse-lite: 1.0.30001651
+      caniuse-lite: 1.0.30001664
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.1.0
@@ -4651,8 +4648,6 @@ snapshots:
   callsites@3.1.0: {}
 
   camelcase-css@2.0.1: {}
-
-  caniuse-lite@1.0.30001651: {}
 
   caniuse-lite@1.0.30001664: {}
 
@@ -5861,7 +5856,7 @@ snapshots:
       '@swc/counter': 0.1.3
       '@swc/helpers': 0.5.12
       busboy: 1.6.0
-      caniuse-lite: 1.0.30001651
+      caniuse-lite: 1.0.30001664
       graceful-fs: 4.2.11
       postcss: 8.4.31
       react: 19.0.0-rc-3208e73e-20240730


### PR DESCRIPTION
 Next.js saves the `node_modules/next/dist` directory for the app in either the normal standalone dir or in the
 standalone root path, this depends on where the next dependency is actually saved (https://github.com/vercel/next.js/blob/39e06c75/packages/next/src/build/webpack-config.ts#L103-L104) and can depend on the package manager used, if it is using workspaces, etc...
 
Currently we're always using the normal standalone dir but this is incorrect and causes the package not to work in certain projects, this PR fixes such issue.

___

> [!NOTE]
> I would have liked to add an e2e test for this, but since this is quite dependent on the package manager being used and the project structure I think that adding an e2e would be tricky (e.g. I'd have to force pnpm to put some dependecies in some locations somehow) and not too valuable (e.g. can I replicate what npm does in pnpm? what about yarn, etc...)
___

fixes #42 