### PR TITLE
feat: use incremental cache during rendering

### DIFF
--- a/packages/cloudflare/src/cli/build/build-worker.ts
+++ b/packages/cloudflare/src/cli/build/build-worker.ts
@@ -8,6 +8,7 @@ import { inlineEvalManifest } from "./patches/to-investigate/inline-eval-manifes
 import { inlineMiddlewareManifestRequire } from "./patches/to-investigate/inline-middleware-manifest-require";
 import { inlineNextRequire } from "./patches/to-investigate/inline-next-require";
 import { patchCache } from "./patches/investigated/patch-cache";
+import { patchExceptionBubbling } from "./patches/to-investigate/patch-exception-bubbling";
 import { patchFindDir } from "./patches/to-investigate/patch-find-dir";
 import { patchReadFile } from "./patches/to-investigate/patch-read-file";
 import { patchRequire } from "./patches/investigated/patch-require";
@@ -164,6 +165,7 @@ async function updateWorkerBundledCode(workerOutputFile: string, config: Config)
   patchedCode = inlineEvalManifest(patchedCode, config);
   patchedCode = patchCache(patchedCode, config);
   patchedCode = inlineMiddlewareManifestRequire(patchedCode, config);
+  patchedCode = patchExceptionBubbling(patchedCode);
 
   await writeFile(workerOutputFile, patchedCode);
 }

--- a/packages/cloudflare/src/cli/build/build-worker.ts
+++ b/packages/cloudflare/src/cli/build/build-worker.ts
@@ -5,6 +5,7 @@ import { Config } from "../config";
 import { copyPackageCliFiles } from "./patches/investigated/copy-package-cli-files";
 import { fileURLToPath } from "node:url";
 import { inlineEvalManifest } from "./patches/to-investigate/inline-eval-manifest";
+import { inlineMiddlewareManifestRequire } from "./patches/to-investigate/inline-middleware-manifest-require";
 import { inlineNextRequire } from "./patches/to-investigate/inline-next-require";
 import { patchCache } from "./patches/investigated/patch-cache";
 import { patchFindDir } from "./patches/to-investigate/patch-find-dir";
@@ -90,10 +91,6 @@ export async function buildWorker(config: Config): Promise<void> {
       // Note: we need the __non_webpack_require__ variable declared as it is used by next-server:
       // https://github.com/vercel/next.js/blob/be0c3283/packages/next/src/server/next-server.ts#L116-L119
       __non_webpack_require__: "require",
-      // The next.js server can run in minimal mode: https://github.com/vercel/next.js/blob/aa90fe9bb/packages/next/src/server/base-server.ts#L510-L511
-      // this avoids some extra (/problematic) `require` calls, such as here: https://github.com/vercel/next.js/blob/aa90fe9bb/packages/next/src/server/next-server.ts#L1259
-      // that's wht we enable it
-      "process.env.NEXT_PRIVATE_MINIMAL_MODE": "true",
       // Ask mhart if he can explain why the `define`s below are necessary
       "process.env.NEXT_RUNTIME": '"nodejs"',
       "process.env.NODE_ENV": '"production"',
@@ -166,6 +163,7 @@ async function updateWorkerBundledCode(workerOutputFile: string, config: Config)
   patchedCode = patchFindDir(patchedCode, config);
   patchedCode = inlineEvalManifest(patchedCode, config);
   patchedCode = patchCache(patchedCode, config);
+  patchedCode = inlineMiddlewareManifestRequire(patchedCode, config);
 
   await writeFile(workerOutputFile, patchedCode);
 }

--- a/packages/cloudflare/src/cli/build/patches/investigated/patch-cache.ts
+++ b/packages/cloudflare/src/cli/build/patches/investigated/patch-cache.ts
@@ -5,7 +5,7 @@ import path from "node:path";
  * Install the cloudflare KV cache handler
  */
 export function patchCache(code: string, config: Config): string {
-  console.log("# patchCached");
+  console.log("# patchCache");
 
   const cacheHandler = path.join(config.paths.internalPackage, "cli", "cache-handler.mjs");
 

--- a/packages/cloudflare/src/cli/build/patches/to-investigate/inline-middleware-manifest-require.ts
+++ b/packages/cloudflare/src/cli/build/patches/to-investigate/inline-middleware-manifest-require.ts
@@ -21,7 +21,7 @@ export function inlineMiddlewareManifestRequire(code: string, config: Config) {
   );
 
   if (patchedCode === code) {
-    throw new Error("Cache patch not applied");
+    throw new Error("Cache patch `inlineMiddlewareManifestRequire` not applied");
   }
 
   return patchedCode;

--- a/packages/cloudflare/src/cli/build/patches/to-investigate/inline-middleware-manifest-require.ts
+++ b/packages/cloudflare/src/cli/build/patches/to-investigate/inline-middleware-manifest-require.ts
@@ -1,0 +1,19 @@
+import { existsSync, readFileSync } from "node:fs";
+import { Config } from "../../../config";
+import path from "node:path";
+
+/**
+ * Inlines the middleware manifest from the build output to prevent a dynamic require statement
+ * as they result in runtime failures.
+ */
+export function inlineMiddlewareManifestRequire(code: string, config: Config) {
+  console.log("# inlineMiddlewareManifestRequire");
+
+  const middlewareManifestPath = path.join(config.paths.standaloneAppServer, "middleware-manifest.json");
+
+  const middlewareManifest = existsSync(middlewareManifestPath)
+    ? JSON.parse(readFileSync(middlewareManifestPath, "utf-8"))
+    : {};
+
+  return code.replace(/require\(this.middlewareManifestPath\)/, JSON.stringify(middlewareManifest));
+}

--- a/packages/cloudflare/src/cli/build/patches/to-investigate/inline-middleware-manifest-require.ts
+++ b/packages/cloudflare/src/cli/build/patches/to-investigate/inline-middleware-manifest-require.ts
@@ -15,5 +15,14 @@ export function inlineMiddlewareManifestRequire(code: string, config: Config) {
     ? JSON.parse(readFileSync(middlewareManifestPath, "utf-8"))
     : {};
 
-  return code.replace(/require\(this.middlewareManifestPath\)/, JSON.stringify(middlewareManifest));
+  const patchedCode = code.replace(
+    "require(this.middlewareManifestPath)",
+    JSON.stringify(middlewareManifest)
+  );
+
+  if (patchedCode === code) {
+    throw new Error("Cache patch not applied");
+  }
+
+  return patchedCode;
 }

--- a/packages/cloudflare/src/cli/build/patches/to-investigate/inline-middleware-manifest-require.ts
+++ b/packages/cloudflare/src/cli/build/patches/to-investigate/inline-middleware-manifest-require.ts
@@ -21,7 +21,7 @@ export function inlineMiddlewareManifestRequire(code: string, config: Config) {
   );
 
   if (patchedCode === code) {
-    throw new Error("Cache patch `inlineMiddlewareManifestRequire` not applied");
+    throw new Error("Patch `inlineMiddlewareManifestRequire` not applied");
   }
 
   return patchedCode;

--- a/packages/cloudflare/src/cli/build/patches/to-investigate/patch-exception-bubbling.ts
+++ b/packages/cloudflare/src/cli/build/patches/to-investigate/patch-exception-bubbling.ts
@@ -10,7 +10,7 @@ export function patchExceptionBubbling(code: string) {
   const patchedCode = code.replace('_nextBubbleNoFallback = "1"', "_nextBubbleNoFallback = undefined");
 
   if (patchedCode === code) {
-    throw new Error("Cache patch not applied");
+    throw new Error("Cache patch `patchExceptionBubbling` not applied");
   }
 
   return patchedCode;

--- a/packages/cloudflare/src/cli/build/patches/to-investigate/patch-exception-bubbling.ts
+++ b/packages/cloudflare/src/cli/build/patches/to-investigate/patch-exception-bubbling.ts
@@ -10,7 +10,7 @@ export function patchExceptionBubbling(code: string) {
   const patchedCode = code.replace('_nextBubbleNoFallback = "1"', "_nextBubbleNoFallback = undefined");
 
   if (patchedCode === code) {
-    throw new Error("Cache patch `patchExceptionBubbling` not applied");
+    throw new Error("Patch `patchExceptionBubbling` not applied");
   }
 
   return patchedCode;

--- a/packages/cloudflare/src/cli/build/patches/to-investigate/patch-exception-bubbling.ts
+++ b/packages/cloudflare/src/cli/build/patches/to-investigate/patch-exception-bubbling.ts
@@ -1,0 +1,11 @@
+/**
+ * When using SSG and `dynamicParams = false`, Next.js throws a NoFallbackError. This error is
+ * bubbled up by default in Node.js servers, however this causes issues in the workerd with
+ * the current response handling and streaming implementation we have, and leads to hanging
+ * promises.
+ */
+export function patchExceptionBubbling(code: string) {
+  console.log("# patchExceptionBubbling");
+
+  return code.replace(/_nextBubbleNoFallback = "1"/, "_nextBubbleNoFallback = undefined");
+}

--- a/packages/cloudflare/src/cli/build/patches/to-investigate/patch-exception-bubbling.ts
+++ b/packages/cloudflare/src/cli/build/patches/to-investigate/patch-exception-bubbling.ts
@@ -7,5 +7,11 @@
 export function patchExceptionBubbling(code: string) {
   console.log("# patchExceptionBubbling");
 
-  return code.replace(/_nextBubbleNoFallback = "1"/, "_nextBubbleNoFallback = undefined");
+  const patchedCode = code.replace('_nextBubbleNoFallback = "1"', "_nextBubbleNoFallback = undefined");
+
+  if (patchedCode === code) {
+    throw new Error("Cache patch not applied");
+  }
+
+  return patchedCode;
 }


### PR DESCRIPTION
Changes:

- Removes the `NEXT_PRIVATE_MINIMAL_MODE` env var.
- Inlines the middleware manifest instead of it being dynamic require.
- Removes the no fallback exception bubbling as this results in hanging promises when SSG routes disable fallback dynamic params.

---

We currently enable the private version of minimal mode, alongside the public version of minimal mode. This is problematic as it is intended to be used by cloud providers when they have an additional layer on top of the worker that handles routing systems, cdn caching, static routes, etc.. That's why Vercel uses it. As a result, we're disabling specific behaviour without building our own system that will handle that.

There's two ways to look at this;
1. Enable the internal minimal mode -> build our own routing system, cdn caching logic, static routes/isr handling, etc.
2. Disable the internal minimal mode -> let Next.js handle routing and provide a custom cache handler to the incremental cache, and things _should_ work.

The option that is probably going to be easier to maintain and support in the long run is number 2 - disabling the internal minimal mode and just providing a custom cache handler that the incremental cache can use, which we are already partly doing.

---

Here's what happens in the base server when making a request to a route that is SSG/ISR.

- Finds a match for the route.
- Starts the logic for rendering a route module.
  - Calls the response cache with a callback that will SSR the page. [(src)](https://github.com/vercel/next.js/blob/c53ef9b3cd63845ba8165c720d84669e97d0b513/packages/next/src/server/base-server.ts#L3069)
  - Response cache calls the incremental cache. [(src)](https://github.com/vercel/next.js/blob/c53ef9b3cd63845ba8165c720d84669e97d0b513/packages/next/src/server/response-cache/index.ts#L96)
    - Incremental cache interfaces with the custom cache handler to find a cache entry for the key.
  - If cache entry should be used / is fresh
    - the response cache returns instead of calling the render callback. [(src)](https://github.com/vercel/next.js/blob/c53ef9b3cd63845ba8165c720d84669e97d0b513/packages/next/src/server/response-cache/index.ts#L111-L120)
  - If cache entry is stale / cache miss
    - the response cache calls the render callback that it was given. [(src)](https://github.com/vercel/next.js/blob/c53ef9b3cd63845ba8165c720d84669e97d0b513/packages/next/src/server/response-cache/index.ts#L124)
    - it tries to put the response from SSR into the incremental cache.
    - if there was no response from the render callback due to 404 and there is no fallback function for it to invoke, it bubbled a NoFallbackException back to the worker.
- Response returned to user.

The problem with using the private minimal mode for this is that the incremental cache is [disabled](https://github.com/vercel/next.js/blob/c53ef9b3cd63845ba8165c720d84669e97d0b513/packages/next/src/server/response-cache/index.ts#L96-L102) in the response cache, blocking ssg/isr from functioning!
