### PR TITLE
ci: actually publish updates packages to npm

### DIFF
--- a/.changeset/serious-buckets-wink.md
+++ b/.changeset/serious-buckets-wink.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+ci: actually publish updates packages to npm

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -27,6 +27,8 @@ jobs:
       - name: Create Version PR or Publish to NPM
         id: changesets
         uses: changesets/action@v1
+        with:
+          publish: pnpm exec changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}


### PR DESCRIPTION
I got carried away and assumed that the default publish in changesets-action would do the pnpm publish automatically.
But actually we do need to provide that here.