### PR TITLE
Expand missing next.config error message

### DIFF
--- a/.changeset/swift-geckos-turn.md
+++ b/.changeset/swift-geckos-turn.md
@@ -1,0 +1,9 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+enhancement: Expand missing next.config error message
+
+Found out that next dev can run the a Next.js app without next.config but
+if we are using the adapter we throw an error if we don't find the config.
+So expanded the error for users.

--- a/packages/cloudflare/src/cli/index.ts
+++ b/packages/cloudflare/src/cli/index.ts
@@ -10,7 +10,10 @@ console.log(`Building the Next.js app in the current folder (${nextAppDir})`);
 
 if (!["js", "cjs", "mjs", "ts"].some((ext) => existsSync(`./next.config.${ext}`))) {
   // TODO: we can add more validation later
-  throw new Error("Error: Not in a Next.js app project");
+  console.error(
+    "Error: next.config file not found. Please make sure you run the command inside a Next.js app"
+  );
+  process.exit(1);
 }
 
 const { skipBuild, outputDir } = getArgs();


### PR DESCRIPTION
Fixes https://github.com/opennextjs/opennextjs-cloudflare/issues/82

Expanded the error to point towards adding the next.config to run the application.