### PR TITLE
refactor: project options type shared with build + config init

### DIFF
--- a/packages/cloudflare/src/cli/build/build-worker.ts
+++ b/packages/cloudflare/src/cli/build/build-worker.ts
@@ -32,16 +32,16 @@ export async function buildWorker(config: Config): Promise<void> {
   // Copy over client-side generated files
   await cp(
     path.join(config.paths.dotNext, "static"),
-    path.join(config.paths.builderOutput, "assets", "_next", "static"),
+    path.join(config.paths.outputDir, "assets", "_next", "static"),
     {
       recursive: true,
     }
   );
 
   // Copy over any static files (e.g. images) from the source project
-  const publicDir = path.join(config.paths.nextApp, "public");
+  const publicDir = path.join(config.paths.sourceDir, "public");
   if (existsSync(publicDir)) {
-    await cp(publicDir, path.join(config.paths.builderOutput, "assets"), {
+    await cp(publicDir, path.join(config.paths.outputDir, "assets"), {
       recursive: true,
     });
   }
@@ -52,7 +52,7 @@ export async function buildWorker(config: Config): Promise<void> {
   copyPackageCliFiles(packageDistDir, config);
 
   const workerEntrypoint = path.join(config.paths.internalTemplates, "worker.ts");
-  const workerOutputFile = path.join(config.paths.builderOutput, "index.mjs");
+  const workerOutputFile = path.join(config.paths.outputDir, "index.mjs");
 
   const nextConfigStr =
     readFileSync(path.join(config.paths.standaloneApp, "/server.js"), "utf8")?.match(

--- a/packages/cloudflare/src/cli/build/index.ts
+++ b/packages/cloudflare/src/cli/build/index.ts
@@ -1,8 +1,9 @@
 import { containsDotNextDir, getConfig } from "../config";
+import type { ProjectOptions } from "../config";
 import { buildNextjsApp } from "./build-next-app";
 import { buildWorker } from "./build-worker";
 import { cpSync } from "node:fs";
-import path from "node:path";
+import { join } from "node:path";
 import { rm } from "node:fs/promises";
 
 /**
@@ -10,36 +11,28 @@ import { rm } from "node:fs/promises";
  *
  * It saves the output in a `.worker-next` directory
  *
- * @param appDir the directory of the Next.js app to build
- * @param opts.outputDir the directory where to save the output (defaults to the app's directory)
- * @param opts.skipBuild boolean indicating whether the Next.js build should be skipped (i.e. if the `.next` dir is already built)
+ * @param opts The options for the project
  */
-export async function build(appDir: string, opts: BuildOptions): Promise<void> {
+export async function build(opts: ProjectOptions): Promise<void> {
   if (!opts.skipBuild) {
     // Build the next app
-    await buildNextjsApp(appDir);
+    await buildNextjsApp(opts.sourceDir);
   }
 
-  if (!containsDotNextDir(appDir)) {
-    throw new Error(`.next folder not found in ${appDir}`);
+  if (!containsDotNextDir(opts.sourceDir)) {
+    throw new Error(`.next folder not found in ${opts.sourceDir}`);
   }
 
-  // Create a clean output directory
-  const outputDir = path.resolve(opts.outputDir ?? appDir, ".worker-next");
-  await cleanDirectory(outputDir);
+  // Clean the output directory
+  await cleanDirectory(opts.outputDir);
 
   // Copy the .next directory to the output directory so it can be mutated.
-  cpSync(path.join(appDir, ".next"), path.join(outputDir, ".next"), { recursive: true });
+  cpSync(join(opts.sourceDir, ".next"), join(opts.outputDir, ".next"), { recursive: true });
 
-  const config = getConfig(appDir, outputDir);
+  const config = getConfig(opts);
 
   await buildWorker(config);
 }
-
-type BuildOptions = {
-  skipBuild: boolean;
-  outputDir?: string;
-};
 
 async function cleanDirectory(path: string): Promise<void> {
   return await rm(path, { recursive: true, force: true });

--- a/packages/cloudflare/src/cli/build/index.ts
+++ b/packages/cloudflare/src/cli/build/index.ts
@@ -11,25 +11,25 @@ import { rm } from "node:fs/promises";
  *
  * It saves the output in a `.worker-next` directory
  *
- * @param opts The options for the project
+ * @param projectOpts The options for the project
  */
-export async function build(opts: ProjectOptions): Promise<void> {
-  if (!opts.skipBuild) {
+export async function build(projectOpts: ProjectOptions): Promise<void> {
+  if (!projectOpts.skipBuild) {
     // Build the next app
-    await buildNextjsApp(opts.sourceDir);
+    await buildNextjsApp(projectOpts.sourceDir);
   }
 
-  if (!containsDotNextDir(opts.sourceDir)) {
-    throw new Error(`.next folder not found in ${opts.sourceDir}`);
+  if (!containsDotNextDir(projectOpts.sourceDir)) {
+    throw new Error(`.next folder not found in ${projectOpts.sourceDir}`);
   }
 
   // Clean the output directory
-  await cleanDirectory(opts.outputDir);
+  await cleanDirectory(projectOpts.outputDir);
 
   // Copy the .next directory to the output directory so it can be mutated.
-  cpSync(join(opts.sourceDir, ".next"), join(opts.outputDir, ".next"), { recursive: true });
+  cpSync(join(projectOpts.sourceDir, ".next"), join(projectOpts.outputDir, ".next"), { recursive: true });
 
-  const config = getConfig(opts);
+  const config = getConfig(projectOpts);
 
   await buildWorker(config);
 }

--- a/packages/cloudflare/src/cli/build/patches/investigated/patch-cache.ts
+++ b/packages/cloudflare/src/cli/build/patches/investigated/patch-cache.ts
@@ -10,7 +10,7 @@ export async function patchCache(code: string, config: Config): Promise<string> 
 
   const cacheHandlerFileName = "cache-handler.mjs";
   const cacheHandlerEntrypoint = join(config.paths.internalTemplates, "cache-handler", "index.ts");
-  const cacheHandlerOutputFile = join(config.paths.builderOutput, cacheHandlerFileName);
+  const cacheHandlerOutputFile = join(config.paths.outputDir, cacheHandlerFileName);
 
   await build({
     entryPoints: [cacheHandlerEntrypoint],

--- a/packages/cloudflare/src/cli/build/utils/copy-prerendered-routes.ts
+++ b/packages/cloudflare/src/cli/build/utils/copy-prerendered-routes.ts
@@ -19,7 +19,7 @@ export function copyPrerenderedRoutes(config: Config) {
 
   const serverAppDirPath = join(config.paths.standaloneAppServer, "app");
   const prerenderManifestPath = join(config.paths.standaloneAppDotNext, "prerender-manifest.json");
-  const outputPath = join(config.paths.builderOutput, "assets", SEED_DATA_DIR);
+  const outputPath = join(config.paths.outputDir, "assets", SEED_DATA_DIR);
 
   const prerenderManifest: PrerenderManifest = existsSync(prerenderManifestPath)
     ? JSON.parse(readFileSync(prerenderManifestPath, "utf8"))
@@ -38,7 +38,7 @@ export function copyPrerenderedRoutes(config: Config) {
 
     if (fullPath.endsWith(NEXT_META_SUFFIX)) {
       const data = JSON.parse(readFileSync(fullPath, "utf8"));
-      writeFileSync(destPath, JSON.stringify({ ...data, lastModified: config.buildTimestamp }));
+      writeFileSync(destPath, JSON.stringify({ ...data, lastModified: config.build.timestamp }));
     } else {
       copyFileSync(fullPath, destPath);
     }

--- a/packages/cloudflare/src/cli/config.ts
+++ b/packages/cloudflare/src/cli/config.ts
@@ -15,7 +15,7 @@ export type Config = {
     // Timestamp for when the build was started
     timestamp: number;
     // Whether to skip building the Next.js app or not
-    shouldSkip: boolean;
+    skipNextBuild: boolean;
   };
 
   paths: {
@@ -50,14 +50,11 @@ export type Config = {
 /**
  * Computes the configuration.
  *
- * @param opts.sourceDir Next app root folder
- * @param opts.outputDir The directory where to save the output (defaults to the app's directory)
- * @param opts.skipBuild Whether the Next.js build should be skipped (i.e. if the `.next` dir is already built)
- *
+ * @param projectOpts The options for the project
  * @returns The configuration, see `Config`
  */
-export function getConfig(opts: ProjectOptions): Config {
-  const dotNext = path.join(opts.outputDir, ".next");
+export function getConfig(projectOpts: ProjectOptions): Config {
+  const dotNext = path.join(projectOpts.outputDir, ".next");
   const appPath = getNextjsApplicationPath(dotNext).replace(/\/$/, "");
   const standaloneRoot = path.join(dotNext, "standalone");
   const standaloneApp = path.join(standaloneRoot, appPath);
@@ -71,12 +68,12 @@ export function getConfig(opts: ProjectOptions): Config {
   return {
     build: {
       timestamp: Date.now(),
-      shouldSkip: !!opts.skipBuild,
+      skipNextBuild: !!projectOpts.skipBuild,
     },
 
     paths: {
-      sourceDir: opts.sourceDir,
-      outputDir: opts.outputDir,
+      sourceDir: projectOpts.sourceDir,
+      outputDir: projectOpts.outputDir,
       dotNext,
       standaloneRoot,
       standaloneApp,
@@ -103,8 +100,11 @@ export function containsDotNextDir(folder: string): boolean {
 }
 
 export type ProjectOptions = {
+  // Next app root folder
   sourceDir: string;
+  // The directory to save the output to (defaults to the app's directory)
   outputDir: string;
+  // Whether the Next.js build should be skipped (i.e. if the `.next` dir is already built)
   skipBuild?: boolean;
 };
 

--- a/packages/cloudflare/src/cli/index.ts
+++ b/packages/cloudflare/src/cli/index.ts
@@ -15,7 +15,8 @@ if (!["js", "cjs", "mjs", "ts"].some((ext) => existsSync(`./next.config.${ext}`)
 
 const { skipBuild, outputDir } = getArgs();
 
-await build(nextAppDir, {
-  outputDir,
-  skipBuild: !!skipBuild,
+await build({
+  sourceDir: nextAppDir,
+  outputDir: resolve(outputDir ?? nextAppDir, ".worker-next"),
+  skipBuild,
 });


### PR DESCRIPTION
**Context**

We have what seems to be a pre-options and then options. It would help in the long-term to have a single set of options that we use to stub the project setup and the config creation, especially if we add more CLI options in the future. Therefore, the types are slightly refactored to share the same thing between the creation of the project config and the project setup function.

I don't mind if you want to keep it as is, but I think it would be simpler to have a single object used between the two.

I wanted to move the config creation to before the project setup outside but it currently depends on the build happening in order to generate the config unfortunately for the .next server directory.

**Changes**

- Shares the same input between the two.
- Renames `builderOutput` to `outputDir` and `nextApp` to `sourceDir`, as it's the output directory and the source directory.


basically centralises where i need to make a change if i want to add a new cli arg (e.g. https://github.com/opennextjs/opennextjs-cloudflare/pull/89) and use it in the config, otherwise you need to update multiple types and args normally