### PR TITLE
refactor: move prerender manifest retrieval to own utility

### DIFF
--- a/packages/cloudflare/env.d.ts
+++ b/packages/cloudflare/env.d.ts
@@ -6,6 +6,7 @@ declare global {
       SKIP_NEXT_APP_BUILD?: string;
       NEXT_PRIVATE_DEBUG_CACHE?: string;
       __OPENNEXT_KV_BINDING_NAME: string;
+      __NEXT_PRERENDER_MANIFEST_PREVIEW_CONFIG?: string;
       [key: string]: string | Fetcher;
     }
   }

--- a/packages/cloudflare/src/cli/build/build-worker.ts
+++ b/packages/cloudflare/src/cli/build/build-worker.ts
@@ -47,6 +47,7 @@ export async function buildWorker(config: Config): Promise<void> {
   }
 
   const prerenderManifest = getPrerenderManifest(config);
+
   // Copy over prerendered assets (e.g. SSG routes)
   copyPrerenderedRoutes(config, prerenderManifest);
 
@@ -99,6 +100,12 @@ export async function buildWorker(config: Config): Promise<void> {
       "process.env.NEXT_RUNTIME": '"nodejs"',
       "process.env.NODE_ENV": '"production"',
       "process.env.NEXT_MINIMAL": "true",
+      ...(prerenderManifest?.preview && {
+        // Used for Next.js Draft Mode internal variables - https://nextjs.org/docs/app/building-your-application/configuring/draft-mode
+        "process.env.__NEXT_PRERENDER_MANIFEST_PREVIEW_CONFIG": JSON.stringify(
+          JSON.stringify(prerenderManifest.preview)
+        ),
+      }),
     },
     // We need to set platform to node so that esbuild doesn't complain about the node imports
     platform: "node",

--- a/packages/cloudflare/src/cli/build/build-worker.ts
+++ b/packages/cloudflare/src/cli/build/build-worker.ts
@@ -1,9 +1,9 @@
 import { Plugin, build } from "esbuild";
+import { copyPrerenderedRoutes, getPrerenderManifest } from "./utils";
 import { cp, readFile, writeFile } from "node:fs/promises";
 import { existsSync, readFileSync } from "node:fs";
 import { Config } from "../config";
 import { copyPackageCliFiles } from "./patches/investigated/copy-package-cli-files";
-import { copyPrerenderedRoutes } from "./utils";
 import { fileURLToPath } from "node:url";
 import { inlineEvalManifest } from "./patches/to-investigate/inline-eval-manifest";
 import { inlineMiddlewareManifestRequire } from "./patches/to-investigate/inline-middleware-manifest-require";
@@ -46,8 +46,9 @@ export async function buildWorker(config: Config): Promise<void> {
     });
   }
 
+  const prerenderManifest = getPrerenderManifest(config);
   // Copy over prerendered assets (e.g. SSG routes)
-  copyPrerenderedRoutes(config);
+  copyPrerenderedRoutes(config, prerenderManifest);
 
   copyPackageCliFiles(packageDistDir, config);
 

--- a/packages/cloudflare/src/cli/build/utils/copy-prerendered-routes.ts
+++ b/packages/cloudflare/src/cli/build/utils/copy-prerendered-routes.ts
@@ -1,8 +1,8 @@
 import { NEXT_META_SUFFIX, SEED_DATA_DIR } from "../../constants/incremental-cache";
-import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { copyFileSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { Config } from "../../config";
-import type { PrerenderManifest } from "next/dist/build";
+import type { Config } from "../../config";
+import type { PrerenderManifest } from "./get-prerender-manifest";
 import { readPathsRecursively } from "./read-paths-recursively";
 
 /**
@@ -13,19 +13,15 @@ import { readPathsRecursively } from "./read-paths-recursively";
  * the incremental cache to determine whether an entry is _fresh_ or not.
  *
  * @param config Build config.
+ * @param manifest Prerender manifest.
  */
-export function copyPrerenderedRoutes(config: Config) {
+export function copyPrerenderedRoutes(config: Config, manifest: PrerenderManifest | null) {
   console.log("# copyPrerenderedRoutes");
 
   const serverAppDirPath = join(config.paths.standaloneAppServer, "app");
-  const prerenderManifestPath = join(config.paths.standaloneAppDotNext, "prerender-manifest.json");
   const outputPath = join(config.paths.outputDir, "assets", SEED_DATA_DIR);
 
-  const prerenderManifest: PrerenderManifest = existsSync(prerenderManifestPath)
-    ? JSON.parse(readFileSync(prerenderManifestPath, "utf8"))
-    : {};
-  const prerenderedRoutes = Object.keys(prerenderManifest.routes);
-
+  const prerenderedRoutes = Object.keys(manifest?.routes ?? {});
   const prerenderedAssets = readPathsRecursively(serverAppDirPath)
     .map((fullPath) => ({ fullPath, relativePath: fullPath.replace(serverAppDirPath, "") }))
     .filter(({ relativePath }) =>

--- a/packages/cloudflare/src/cli/build/utils/get-prerender-manifest.ts
+++ b/packages/cloudflare/src/cli/build/utils/get-prerender-manifest.ts
@@ -1,0 +1,21 @@
+import { existsSync, readFileSync } from "node:fs";
+import { Config } from "../../config";
+import { PrerenderManifest } from "next/dist/build";
+import { join } from "node:path";
+
+/**
+ * Reads the prerender manifest from the Next.js standalone output.
+ *
+ * @param config Build config
+ */
+export function getPrerenderManifest(config: Config): PrerenderManifest | null {
+  const prerenderManifestPath = join(config.paths.standaloneAppDotNext, "prerender-manifest.json");
+
+  if (!existsSync(prerenderManifestPath)) {
+    return null;
+  }
+
+  return JSON.parse(readFileSync(prerenderManifestPath, "utf8"));
+}
+
+export type { PrerenderManifest };

--- a/packages/cloudflare/src/cli/build/utils/index.ts
+++ b/packages/cloudflare/src/cli/build/utils/index.ts
@@ -1,2 +1,3 @@
 export * from "./ts-parse-file";
 export * from "./copy-prerendered-routes";
+export * from "./get-prerender-manifest";


### PR DESCRIPTION
**Context**

Draft mode tries to access certain environment variables in the edge runtime to be able to work. These variables are available in the prerender manifest and need to be injected into the worker some how.

fixes #94 (?)

**Changes**
- Move prerender manifest retrieval to a utility.
- Inject the preview mode config.
- Add the draft mode env vars to process.env inside the worker.