### PR TITLE
refactor: use ALS for `process.env` object

### DIFF
--- a/.changeset/funny-impalas-attend.md
+++ b/.changeset/funny-impalas-attend.md
@@ -1,0 +1,7 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+refactor: use ALS for `process.env` object.
+
+The adaptor was previously manipulating the global process.env object on every request, without accounting for other requests. ALS has been introduced to change this behavior, so that each process.env object is scoped to the request.

--- a/packages/cloudflare/src/cli/templates/utils/create-als-proxy.ts
+++ b/packages/cloudflare/src/cli/templates/utils/create-als-proxy.ts
@@ -5,11 +5,14 @@ import type { AsyncLocalStorage } from "node:async_hooks";
  *
  * @param als AsyncLocalStorage instance
  */
-export function createALSProxy<T extends object>(als: AsyncLocalStorage<T>) {
-  return new Proxy({} as T, {
-    ownKeys: () => Reflect.ownKeys(als.getStore()!),
-    getOwnPropertyDescriptor: (_, ...args) => Reflect.getOwnPropertyDescriptor(als.getStore()!, ...args),
-    get: (_, property) => Reflect.get(als.getStore()!, property),
-    set: (_, property, value) => Reflect.set(als.getStore()!, property, value),
-  });
+export function createALSProxy<T>(als: AsyncLocalStorage<T>) {
+  return new Proxy(
+    {},
+    {
+      ownKeys: () => Reflect.ownKeys(als.getStore()!),
+      getOwnPropertyDescriptor: (_, ...args) => Reflect.getOwnPropertyDescriptor(als.getStore()!, ...args),
+      get: (_, property) => Reflect.get(als.getStore()!, property),
+      set: (_, property, value) => Reflect.set(als.getStore()!, property, value),
+    }
+  );
 }

--- a/packages/cloudflare/src/cli/templates/utils/create-als-proxy.ts
+++ b/packages/cloudflare/src/cli/templates/utils/create-als-proxy.ts
@@ -1,9 +1,9 @@
 import type { AsyncLocalStorage } from "node:async_hooks";
 
 /**
- * Creates a proxy for to use for an instance of AsyncLocalStorage.
+ * Creates a proxy that exposes values from an AsyncLocalStorage store
  *
- * @param als AsyncLocalStorage instance.
+ * @param als AsyncLocalStorage instance
  */
 export function createALSProxy<T>(als: AsyncLocalStorage<T>) {
   return new Proxy(

--- a/packages/cloudflare/src/cli/templates/utils/create-als-proxy.ts
+++ b/packages/cloudflare/src/cli/templates/utils/create-als-proxy.ts
@@ -5,14 +5,11 @@ import type { AsyncLocalStorage } from "node:async_hooks";
  *
  * @param als AsyncLocalStorage instance
  */
-export function createALSProxy<T>(als: AsyncLocalStorage<T>) {
-  return new Proxy(
-    {},
-    {
-      ownKeys: () => Reflect.ownKeys(als.getStore()!),
-      getOwnPropertyDescriptor: (_, ...args) => Reflect.getOwnPropertyDescriptor(als.getStore()!, ...args),
-      get: (_, property) => Reflect.get(als.getStore()!, property),
-      set: (_, property, value) => Reflect.set(als.getStore()!, property, value),
-    }
-  );
+export function createALSProxy<T extends object>(als: AsyncLocalStorage<T>) {
+  return new Proxy({} as T, {
+    ownKeys: () => Reflect.ownKeys(als.getStore()!),
+    getOwnPropertyDescriptor: (_, ...args) => Reflect.getOwnPropertyDescriptor(als.getStore()!, ...args),
+    get: (_, property) => Reflect.get(als.getStore()!, property),
+    set: (_, property, value) => Reflect.set(als.getStore()!, property, value),
+  });
 }

--- a/packages/cloudflare/src/cli/templates/utils/create-als-proxy.ts
+++ b/packages/cloudflare/src/cli/templates/utils/create-als-proxy.ts
@@ -1,0 +1,18 @@
+import type { AsyncLocalStorage } from "node:async_hooks";
+
+/**
+ * Creates a proxy for to use for an instance of AsyncLocalStorage.
+ *
+ * @param als AsyncLocalStorage instance.
+ */
+export function createALSProxy<T>(als: AsyncLocalStorage<T>) {
+  return new Proxy(
+    {},
+    {
+      ownKeys: () => Reflect.ownKeys(als.getStore()!),
+      getOwnPropertyDescriptor: (_, ...args) => Reflect.getOwnPropertyDescriptor(als.getStore()!, ...args),
+      get: (_, property) => Reflect.get(als.getStore()!, property),
+      set: (_, property, value) => Reflect.set(als.getStore()!, property, value),
+    }
+  );
+}

--- a/packages/cloudflare/src/cli/templates/utils/index.ts
+++ b/packages/cloudflare/src/cli/templates/utils/index.ts
@@ -1,0 +1,1 @@
+export * from "./create-als-proxy";

--- a/packages/cloudflare/src/cli/templates/worker.ts
+++ b/packages/cloudflare/src/cli/templates/worker.ts
@@ -13,14 +13,18 @@ import { createALSProxy } from "./utils";
 
 const NON_BODY_RESPONSES = new Set([101, 204, 205, 304]);
 
-const processALS = new AsyncLocalStorage<typeof process>();
+const processEnvALS = new AsyncLocalStorage<Record<string, unknown>>();
 const cloudflareContextALS = new AsyncLocalStorage<CloudflareContext>();
 
 // Note: this symbol needs to be kept in sync with the one defined in `src/api/get-cloudflare-context.ts`
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (globalThis as any)[Symbol.for("__cloudflare-context__")] = createALSProxy(cloudflareContextALS);
 
-globalThis.process = createALSProxy(processALS);
+globalThis.process = {
+  ...globalThis.process,
+  // @ts-expect-error - populated when we run inside the ALS context
+  env: createALSProxy(processEnvALS),
+};
 
 // Injected at build time
 const nextConfig: NextConfig = JSON.parse(process.env.__NEXT_PRIVATE_STANDALONE_CONFIG ?? "{}");
@@ -29,45 +33,42 @@ let requestHandler: NodeRequestHandler | null = null;
 
 export default {
   async fetch(request, env, ctx) {
-    return processALS.run(
-      { ...globalThis.process, env: { ...globalThis.process.env, NODE_ENV: "production", ...env } },
-      () => {
-        return cloudflareContextALS.run({ env, ctx, cf: request.cf }, async () => {
-          if (requestHandler == null) {
-            // Note: "next/dist/server/next-server" is a cjs module so we have to `require` it not to confuse esbuild
-            //       (since esbuild can run in projects with different module resolutions)
-            // eslint-disable-next-line @typescript-eslint/no-require-imports
-            const NextNodeServer = require("next/dist/server/next-server")
-              .default as typeof import("next/dist/server/next-server").default;
+    return processEnvALS.run({ NODE_ENV: "production", ...env }, () => {
+      return cloudflareContextALS.run({ env, ctx, cf: request.cf }, async () => {
+        if (requestHandler == null) {
+          // Note: "next/dist/server/next-server" is a cjs module so we have to `require` it not to confuse esbuild
+          //       (since esbuild can run in projects with different module resolutions)
+          // eslint-disable-next-line @typescript-eslint/no-require-imports
+          const NextNodeServer = require("next/dist/server/next-server")
+            .default as typeof import("next/dist/server/next-server").default;
 
-            requestHandler = new NextNodeServer({
-              conf: nextConfig,
-              customServer: false,
-              dev: false,
-              dir: "",
-              minimalMode: false,
-            }).getRequestHandler();
+          requestHandler = new NextNodeServer({
+            conf: nextConfig,
+            customServer: false,
+            dev: false,
+            dir: "",
+            minimalMode: false,
+          }).getRequestHandler();
+        }
+
+        const url = new URL(request.url);
+
+        if (url.pathname === "/_next/image") {
+          const imageUrl =
+            url.searchParams.get("url") ?? "https://developers.cloudflare.com/_astro/logo.BU9hiExz.svg";
+          if (imageUrl.startsWith("/")) {
+            return env.ASSETS.fetch(new URL(imageUrl, request.url));
           }
+          return fetch(imageUrl, { cf: { cacheEverything: true } });
+        }
 
-          const url = new URL(request.url);
+        const { req, res, webResponse } = getWrappedStreams(request, ctx);
 
-          if (url.pathname === "/_next/image") {
-            const imageUrl =
-              url.searchParams.get("url") ?? "https://developers.cloudflare.com/_astro/logo.BU9hiExz.svg";
-            if (imageUrl.startsWith("/")) {
-              return env.ASSETS.fetch(new URL(imageUrl, request.url));
-            }
-            return fetch(imageUrl, { cf: { cacheEverything: true } });
-          }
+        ctx.waitUntil(Promise.resolve(requestHandler(new NodeNextRequest(req), new NodeNextResponse(res))));
 
-          const { req, res, webResponse } = getWrappedStreams(request, ctx);
-
-          ctx.waitUntil(Promise.resolve(requestHandler(new NodeNextRequest(req), new NodeNextResponse(res))));
-
-          return await webResponse();
-        });
-      }
-    );
+        return await webResponse();
+      });
+    });
   },
 } as ExportedHandler<{ ASSETS: Fetcher }>;
 

--- a/packages/cloudflare/src/cli/templates/worker.ts
+++ b/packages/cloudflare/src/cli/templates/worker.ts
@@ -20,11 +20,8 @@ const cloudflareContextALS = new AsyncLocalStorage<CloudflareContext>();
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (globalThis as any)[Symbol.for("__cloudflare-context__")] = createALSProxy(cloudflareContextALS);
 
-globalThis.process = {
-  ...globalThis.process,
-  // @ts-expect-error - populated when we run inside the ALS context
-  env: createALSProxy(processEnvALS),
-};
+// @ts-expect-error - populated when we run inside the ALS context
+globalThis.process.env = createALSProxy(processEnvALS);
 
 // Injected at build time
 const nextConfig: NextConfig = JSON.parse(process.env.__NEXT_PRIVATE_STANDALONE_CONFIG ?? "{}");

--- a/packages/cloudflare/src/cli/templates/worker.ts
+++ b/packages/cloudflare/src/cli/templates/worker.ts
@@ -1,7 +1,6 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import type { IncomingMessage } from "node:http";
 import Stream from "node:stream";
-import { createALSProxy } from "./utils";
 
 import type { ExportedHandler, Fetcher } from "@cloudflare/workers-types";
 import type { NextConfig } from "next";
@@ -10,6 +9,7 @@ import { MockedResponse } from "next/dist/server/lib/mock-request";
 import type { NodeRequestHandler } from "next/dist/server/next-server";
 
 import type { CloudflareContext } from "../../api";
+import { createALSProxy } from "./utils";
 
 const NON_BODY_RESPONSES = new Set([101, 204, 205, 304]);
 

--- a/packages/cloudflare/src/cli/templates/worker.ts
+++ b/packages/cloudflare/src/cli/templates/worker.ts
@@ -13,11 +13,18 @@ import type { CloudflareContext } from "../../api";
 
 const NON_BODY_RESPONSES = new Set([101, 204, 205, 304]);
 
+const processEnvALS = new AsyncLocalStorage<Record<string, unknown>>();
 const cloudflareContextALS = new AsyncLocalStorage<CloudflareContext>();
 
 // Note: this symbol needs to be kept in sync with the one defined in `src/api/get-cloudflare-context.ts`
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (globalThis as any)[Symbol.for("__cloudflare-context__")] = createALSProxy(cloudflareContextALS);
+
+globalThis.process = {
+  ...globalThis.process,
+  // @ts-expect-error - populated when we run inside the ALS context
+  env: createALSProxy(processEnvALS),
+};
 
 // Injected at build time
 const nextConfig: NextConfig = JSON.parse(process.env.__NEXT_PRIVATE_STANDALONE_CONFIG ?? "{}");
@@ -26,40 +33,41 @@ let requestHandler: NodeRequestHandler | null = null;
 
 export default {
   async fetch(request, env, ctx) {
-    return cloudflareContextALS.run({ env, ctx, cf: request.cf }, async () => {
-      if (requestHandler == null) {
-        globalThis.process.env = { ...globalThis.process.env, ...env };
-        // Note: "next/dist/server/next-server" is a cjs module so we have to `require` it not to confuse esbuild
-        //       (since esbuild can run in projects with different module resolutions)
-        // eslint-disable-next-line @typescript-eslint/no-require-imports
-        const NextNodeServer = require("next/dist/server/next-server")
-          .default as typeof import("next/dist/server/next-server").default;
+    return processEnvALS.run({ NODE_ENV: "production", ...env }, () => {
+      return cloudflareContextALS.run({ env, ctx, cf: request.cf }, async () => {
+        if (requestHandler == null) {
+          // Note: "next/dist/server/next-server" is a cjs module so we have to `require` it not to confuse esbuild
+          //       (since esbuild can run in projects with different module resolutions)
+          // eslint-disable-next-line @typescript-eslint/no-require-imports
+          const NextNodeServer = require("next/dist/server/next-server")
+            .default as typeof import("next/dist/server/next-server").default;
 
-        requestHandler = new NextNodeServer({
-          conf: nextConfig,
-          customServer: false,
-          dev: false,
-          dir: "",
-          minimalMode: false,
-        }).getRequestHandler();
-      }
-
-      const url = new URL(request.url);
-
-      if (url.pathname === "/_next/image") {
-        const imageUrl =
-          url.searchParams.get("url") ?? "https://developers.cloudflare.com/_astro/logo.BU9hiExz.svg";
-        if (imageUrl.startsWith("/")) {
-          return env.ASSETS.fetch(new URL(imageUrl, request.url));
+          requestHandler = new NextNodeServer({
+            conf: nextConfig,
+            customServer: false,
+            dev: false,
+            dir: "",
+            minimalMode: false,
+          }).getRequestHandler();
         }
-        return fetch(imageUrl, { cf: { cacheEverything: true } });
-      }
 
-      const { req, res, webResponse } = getWrappedStreams(request, ctx);
+        const url = new URL(request.url);
 
-      ctx.waitUntil(Promise.resolve(requestHandler(new NodeNextRequest(req), new NodeNextResponse(res))));
+        if (url.pathname === "/_next/image") {
+          const imageUrl =
+            url.searchParams.get("url") ?? "https://developers.cloudflare.com/_astro/logo.BU9hiExz.svg";
+          if (imageUrl.startsWith("/")) {
+            return env.ASSETS.fetch(new URL(imageUrl, request.url));
+          }
+          return fetch(imageUrl, { cf: { cacheEverything: true } });
+        }
 
-      return await webResponse();
+        const { req, res, webResponse } = getWrappedStreams(request, ctx);
+
+        ctx.waitUntil(Promise.resolve(requestHandler(new NodeNextRequest(req), new NodeNextResponse(res))));
+
+        return await webResponse();
+      });
     });
   },
 } as ExportedHandler<{ ASSETS: Fetcher }>;


### PR DESCRIPTION
**Context**
process.env is currently assigned via spreading env when there is no request handler. The env values available should be scoped to a request, and dealt with on a per-request basis.

**Changes**
- Pulls out ALS proxy creation into a utility.
- Assigns a proxy for an ALS to process.
- Runs the worker inside the ALS with the worker env object spread on the ALS.

I recommend hiding whitespace changes when looking at the diff in this pr.