### PR TITLE
fix: copying excess files to output directory

### DIFF
--- a/.changeset/sixty-years-cheat.md
+++ b/.changeset/sixty-years-cheat.md
@@ -1,0 +1,7 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+fix: copying excess files to output directory
+
+In previous versions, we copied the entire `.next` directory to the `.worker-next` output directory. Going forward, it will only copy the `.next/standalone` directory to this location.

--- a/packages/cloudflare/src/cli/build/index.ts
+++ b/packages/cloudflare/src/cli/build/index.ts
@@ -27,8 +27,12 @@ export async function build(projectOpts: ProjectOptions): Promise<void> {
   // Clean the output directory
   await cleanDirectory(projectOpts.outputDir);
 
-  // Copy the .next directory to the output directory so it can be mutated.
-  cpSync(join(projectOpts.sourceDir, ".next"), join(projectOpts.outputDir, ".next"), { recursive: true });
+  // Copy the .next/standalone directory to the output directory so it can be mutated.
+  cpSync(
+    join(projectOpts.sourceDir, ".next", "standalone"),
+    join(projectOpts.outputDir, ".next", "standalone"),
+    { recursive: true }
+  );
 
   const config = getConfig(projectOpts);
 

--- a/packages/cloudflare/src/cli/config.ts
+++ b/packages/cloudflare/src/cli/config.ts
@@ -27,8 +27,6 @@ export type Config = {
       root: string;
       // Path to the OpenNext static assets directory
       assets: string;
-      // Path to the app's `.next` directory in the OpenNext output directory
-      dotNext: string;
       // Path to the application standalone root directory
       standaloneRoot: string;
       // Path to the application standalone directory (where `next build` saves the standalone app)
@@ -92,7 +90,6 @@ export function getConfig(projectOpts: ProjectOptions): Config {
       output: {
         root: projectOpts.outputDir,
         assets: join(projectOpts.outputDir, "assets"),
-        dotNext,
         standaloneRoot,
         standaloneApp,
         standaloneAppDotNext,


### PR DESCRIPTION
**Context**
We currently copy everything in .next to the output directory when we only utilise .next/standalone.

**Changes**
- Copies the standalone directory instead of the .next directory.