### PR TITLE
feat: Update ESLint config to fix imports/exports

### DIFF
--- a/packages/cloudflare/eslint.config.mjs
+++ b/packages/cloudflare/eslint.config.mjs
@@ -1,6 +1,8 @@
+import pluginJs from "@eslint/js";
+import importPlugin from "eslint-plugin-import";
+import simpleImportSort from "eslint-plugin-simple-import-sort";
 import eslintPluginUnicorn from "eslint-plugin-unicorn";
 import globals from "globals";
-import pluginJs from "@eslint/js";
 import tseslint from "typescript-eslint";
 
 export default [
@@ -18,13 +20,20 @@ export default [
   pluginJs.configs.recommended,
   ...tseslint.configs.recommended,
   {
+    name: "open-next",
     plugins: {
       unicorn: eslintPluginUnicorn,
+      "simple-import-sort": simpleImportSort,
+      import: importPlugin,
     },
     rules: {
       "@typescript-eslint/ban-ts-comment": "off",
       "unicorn/prefer-node-protocol": "error",
-      "sort-imports": "error",
+      "simple-import-sort/imports": "error",
+      "simple-import-sort/exports": "error",
+      "import/first": "error",
+      "import/newline-after-import": "error",
+      "import/no-duplicates": "error",
     },
   },
 ];

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -46,6 +46,8 @@
     "@types/node": "catalog:",
     "esbuild": "catalog:",
     "eslint": "catalog:",
+    "eslint-plugin-import": "^2.31.0",
+    "eslint-plugin-simple-import-sort": "^12.1.1",
     "eslint-plugin-unicorn": "catalog:",
     "glob": "catalog:",
     "globals": "catalog:",

--- a/packages/cloudflare/src/cli/args.ts
+++ b/packages/cloudflare/src/cli/args.ts
@@ -1,6 +1,6 @@
-import { type Stats, mkdirSync, statSync } from "node:fs";
-import { parseArgs } from "node:util";
+import { mkdirSync, type Stats, statSync } from "node:fs";
 import { resolve } from "node:path";
+import { parseArgs } from "node:util";
 
 export function getArgs(): {
   skipNextBuild: boolean;

--- a/packages/cloudflare/src/cli/build/build-next-app.ts
+++ b/packages/cloudflare/src/cli/build/build-next-app.ts
@@ -1,5 +1,6 @@
-import { type AgentName as PackageManager, detect } from "package-manager-detector";
 import { execSync } from "node:child_process";
+
+import { type AgentName as PackageManager, detect } from "package-manager-detector";
 
 /**
  * Builds the Next.js app in the standard Next.js cli way (this outputs a `.next` directory)

--- a/packages/cloudflare/src/cli/build/build-worker.ts
+++ b/packages/cloudflare/src/cli/build/build-worker.ts
@@ -1,21 +1,23 @@
-import { Plugin, build } from "esbuild";
+import { existsSync, readFileSync } from "node:fs";
 import { cp, readFile, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
-import { existsSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { build, Plugin } from "esbuild";
+
 import { Config } from "../config";
 import { copyPackageCliFiles } from "./patches/investigated/copy-package-cli-files";
-import { copyPrerenderedRoutes } from "./utils";
-import { fileURLToPath } from "node:url";
+import { patchCache } from "./patches/investigated/patch-cache";
+import { patchRequire } from "./patches/investigated/patch-require";
+import { updateWebpackChunksFile } from "./patches/investigated/update-webpack-chunks-file";
 import { inlineEvalManifest } from "./patches/to-investigate/inline-eval-manifest";
 import { inlineMiddlewareManifestRequire } from "./patches/to-investigate/inline-middleware-manifest-require";
 import { inlineNextRequire } from "./patches/to-investigate/inline-next-require";
-import { patchCache } from "./patches/investigated/patch-cache";
 import { patchExceptionBubbling } from "./patches/to-investigate/patch-exception-bubbling";
 import { patchFindDir } from "./patches/to-investigate/patch-find-dir";
 import { patchReadFile } from "./patches/to-investigate/patch-read-file";
-import { patchRequire } from "./patches/investigated/patch-require";
 import { patchWranglerDeps } from "./patches/to-investigate/wrangler-deps";
-import { updateWebpackChunksFile } from "./patches/investigated/update-webpack-chunks-file";
+import { copyPrerenderedRoutes } from "./utils";
 
 /** The dist directory of the Cloudflare adapter package */
 const packageDistDir = join(dirname(fileURLToPath(import.meta.url)), "..");

--- a/packages/cloudflare/src/cli/build/index.ts
+++ b/packages/cloudflare/src/cli/build/index.ts
@@ -1,10 +1,11 @@
-import { containsDotNextDir, getConfig } from "../config";
+import { cpSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { join } from "node:path";
+
 import type { ProjectOptions } from "../config";
+import { containsDotNextDir, getConfig } from "../config";
 import { buildNextjsApp } from "./build-next-app";
 import { buildWorker } from "./build-worker";
-import { cpSync } from "node:fs";
-import { join } from "node:path";
-import { rm } from "node:fs/promises";
 
 /**
  * Builds the application in a format that can be passed to workerd

--- a/packages/cloudflare/src/cli/build/patches/investigated/copy-package-cli-files.ts
+++ b/packages/cloudflare/src/cli/build/patches/investigated/copy-package-cli-files.ts
@@ -1,6 +1,7 @@
-import { Config } from "../../../config";
 import { cpSync } from "node:fs";
 import { join } from "node:path";
+
+import { Config } from "../../../config";
 
 /**
  * Copies the template files present in the cloudflare adapter package into the standalone node_modules folder

--- a/packages/cloudflare/src/cli/build/patches/investigated/patch-cache.ts
+++ b/packages/cloudflare/src/cli/build/patches/investigated/patch-cache.ts
@@ -1,6 +1,8 @@
-import { Config } from "../../../config";
-import { build } from "esbuild";
 import { join } from "node:path";
+
+import { build } from "esbuild";
+
+import { Config } from "../../../config";
 
 /**
  * Sets up the OpenNext cache handler in a Next.js build.

--- a/packages/cloudflare/src/cli/build/patches/investigated/update-webpack-chunks-file/get-chunk-installation-identifiers.test.ts
+++ b/packages/cloudflare/src/cli/build/patches/investigated/update-webpack-chunks-file/get-chunk-installation-identifiers.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, test } from "vitest";
-import { getChunkInstallationIdentifiers } from "./get-chunk-installation-identifiers";
 import { readFile } from "node:fs/promises";
+
+import { describe, expect, test } from "vitest";
+
 import { tsParseFile } from "../../../utils";
+import { getChunkInstallationIdentifiers } from "./get-chunk-installation-identifiers";
 
 describe("getChunkInstallationIdentifiers", () => {
   test("gets chunk identifiers from unminified code", async () => {

--- a/packages/cloudflare/src/cli/build/patches/investigated/update-webpack-chunks-file/get-file-content-with-updated-webpack-f-require-code.test.ts
+++ b/packages/cloudflare/src/cli/build/patches/investigated/update-webpack-chunks-file/get-file-content-with-updated-webpack-f-require-code.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, test } from "vitest";
-import { getFileContentWithUpdatedWebpackFRequireCode } from "./get-file-content-with-updated-webpack-f-require-code";
 import { readFile } from "node:fs/promises";
+
+import { describe, expect, test } from "vitest";
+
 import { tsParseFile } from "../../../utils";
+import { getFileContentWithUpdatedWebpackFRequireCode } from "./get-file-content-with-updated-webpack-f-require-code";
 
 describe("getFileContentWithUpdatedWebpackFRequireCode", () => {
   test("returns the updated content of the f.require function from unminified webpack runtime code", async () => {

--- a/packages/cloudflare/src/cli/build/patches/investigated/update-webpack-chunks-file/get-updated-webpack-chunks-file-content.test.ts
+++ b/packages/cloudflare/src/cli/build/patches/investigated/update-webpack-chunks-file/get-updated-webpack-chunks-file-content.test.ts
@@ -1,6 +1,8 @@
-import { describe, expect, test } from "vitest";
-import { getUpdatedWebpackChunksFileContent } from "./get-updated-webpack-chunks-file-content";
 import { readFile } from "node:fs/promises";
+
+import { describe, expect, test } from "vitest";
+
+import { getUpdatedWebpackChunksFileContent } from "./get-updated-webpack-chunks-file-content";
 
 describe("getUpdatedWebpackChunksFileContent", () => {
   test("returns the updated content of a webpack runtime chunks unminified file", async () => {

--- a/packages/cloudflare/src/cli/build/patches/investigated/update-webpack-chunks-file/get-updated-webpack-chunks-file-content.ts
+++ b/packages/cloudflare/src/cli/build/patches/investigated/update-webpack-chunks-file/get-updated-webpack-chunks-file-content.ts
@@ -1,6 +1,6 @@
+import { tsParseFile } from "../../../utils";
 import { getChunkInstallationIdentifiers } from "./get-chunk-installation-identifiers";
 import { getFileContentWithUpdatedWebpackFRequireCode } from "./get-file-content-with-updated-webpack-f-require-code";
-import { tsParseFile } from "../../../utils";
 
 /**
  * Updates the content of the webpack runtime file in a manner so that it doesn't perform runtime dynamic `require` calls which fail in our runtime.

--- a/packages/cloudflare/src/cli/build/patches/investigated/update-webpack-chunks-file/index.ts
+++ b/packages/cloudflare/src/cli/build/patches/investigated/update-webpack-chunks-file/index.ts
@@ -1,7 +1,8 @@
-import { readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
 import { Config } from "../../../../config";
 import { getUpdatedWebpackChunksFileContent } from "./get-updated-webpack-chunks-file-content";
-import { join } from "node:path";
 
 /**
  * Fixes the webpack-runtime.js file by removing its webpack dynamic requires.

--- a/packages/cloudflare/src/cli/build/patches/to-investigate/inline-eval-manifest.ts
+++ b/packages/cloudflare/src/cli/build/patches/to-investigate/inline-eval-manifest.ts
@@ -1,6 +1,8 @@
 import { join, posix } from "node:path";
-import { Config } from "../../../config";
+
 import { globSync } from "glob";
+
+import { Config } from "../../../config";
 import { normalizePath } from "../../utils";
 
 /**

--- a/packages/cloudflare/src/cli/build/patches/to-investigate/inline-middleware-manifest-require.ts
+++ b/packages/cloudflare/src/cli/build/patches/to-investigate/inline-middleware-manifest-require.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
-import { Config } from "../../../config";
 import { join } from "node:path";
+
+import { Config } from "../../../config";
 
 /**
  * Inlines the middleware manifest from the build output to prevent a dynamic require statement

--- a/packages/cloudflare/src/cli/build/patches/to-investigate/inline-next-require.ts
+++ b/packages/cloudflare/src/cli/build/patches/to-investigate/inline-next-require.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
-import { Config } from "../../../config";
 import { join } from "node:path";
+
+import { Config } from "../../../config";
 
 /**
  * The following avoid various Next.js specific files `require`d at runtime since we can just read

--- a/packages/cloudflare/src/cli/build/patches/to-investigate/patch-find-dir.ts
+++ b/packages/cloudflare/src/cli/build/patches/to-investigate/patch-find-dir.ts
@@ -1,6 +1,7 @@
-import { Config } from "../../../config";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
+
+import { Config } from "../../../config";
 
 /**
  * Here we patch `findDir` so that the next server can detect whether the `app` or `pages` directory exists

--- a/packages/cloudflare/src/cli/build/patches/to-investigate/patch-read-file.ts
+++ b/packages/cloudflare/src/cli/build/patches/to-investigate/patch-read-file.ts
@@ -1,8 +1,10 @@
-import { join, posix } from "node:path";
-import { Config } from "../../../config";
-import { globSync } from "glob";
-import { normalizePath } from "../../utils";
 import { readFileSync } from "node:fs";
+import { join, posix } from "node:path";
+
+import { globSync } from "glob";
+
+import { Config } from "../../../config";
+import { normalizePath } from "../../utils";
 
 export function patchReadFile(code: string, config: Config): string {
   console.log("# patchReadFile");

--- a/packages/cloudflare/src/cli/build/patches/to-investigate/wrangler-deps.ts
+++ b/packages/cloudflare/src/cli/build/patches/to-investigate/wrangler-deps.ts
@@ -1,6 +1,7 @@
 import { readFileSync, statSync, writeFileSync } from "node:fs";
-import { Config } from "../../../config";
 import { join } from "node:path";
+
+import { Config } from "../../../config";
 
 export function patchWranglerDeps(config: Config) {
   console.log("# patchWranglerDeps");

--- a/packages/cloudflare/src/cli/build/utils/copy-prerendered-routes.ts
+++ b/packages/cloudflare/src/cli/build/utils/copy-prerendered-routes.ts
@@ -1,8 +1,10 @@
-import { NEXT_META_SUFFIX, SEED_DATA_DIR } from "../../constants/incremental-cache";
 import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { Config } from "../../config";
+
 import type { PrerenderManifest } from "next/dist/build";
+
+import { Config } from "../../config";
+import { NEXT_META_SUFFIX, SEED_DATA_DIR } from "../../constants/incremental-cache";
 import { readPathsRecursively } from "./read-paths-recursively";
 
 /**

--- a/packages/cloudflare/src/cli/build/utils/index.ts
+++ b/packages/cloudflare/src/cli/build/utils/index.ts
@@ -1,3 +1,3 @@
-export * from "./ts-parse-file";
 export * from "./copy-prerendered-routes";
 export * from "./normalize-path";
+export * from "./ts-parse-file";

--- a/packages/cloudflare/src/cli/build/utils/read-paths-recursively.ts
+++ b/packages/cloudflare/src/cli/build/utils/read-paths-recursively.ts
@@ -1,5 +1,5 @@
-import { join } from "node:path";
 import { readdirSync } from "node:fs";
+import { join } from "node:path";
 
 /**
  * Recursively reads all file paths in a directory.

--- a/packages/cloudflare/src/cli/config.ts
+++ b/packages/cloudflare/src/cli/config.ts
@@ -1,5 +1,5 @@
-import { join, relative } from "node:path";
 import { readdirSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
 
 const PACKAGE_NAME = "@opennextjs/cloudflare";
 

--- a/packages/cloudflare/src/cli/index.ts
+++ b/packages/cloudflare/src/cli/index.ts
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
-import { build } from "./build";
 import { existsSync } from "node:fs";
-import { getArgs } from "./args";
 import { resolve } from "node:path";
+
+import { getArgs } from "./args";
+import { build } from "./build";
 
 const nextAppDir = resolve(".");
 

--- a/packages/cloudflare/src/cli/templates/cache-handler/open-next-cache-handler.ts
+++ b/packages/cloudflare/src/cli/templates/cache-handler/open-next-cache-handler.ts
@@ -1,8 +1,11 @@
+import type { KVNamespace } from "@cloudflare/workers-types";
 import type {
   CacheHandler,
   CacheHandlerContext,
   CacheHandlerValue,
 } from "next/dist/server/lib/incremental-cache";
+import type { IncrementalCacheValue } from "next/dist/server/response-cache";
+
 import {
   NEXT_BODY_SUFFIX,
   NEXT_DATA_SUFFIX,
@@ -12,8 +15,6 @@ import {
   SEED_DATA_DIR,
 } from "../../constants/incremental-cache";
 import { getSeedBodyFile, getSeedMetaFile, getSeedTextFile, parseCtx } from "./utils";
-import type { IncrementalCacheValue } from "next/dist/server/response-cache";
-import type { KVNamespace } from "@cloudflare/workers-types";
 
 type CacheEntry = {
   lastModified: number;

--- a/packages/cloudflare/src/cli/templates/cache-handler/utils.ts
+++ b/packages/cloudflare/src/cli/templates/cache-handler/utils.ts
@@ -1,4 +1,5 @@
 import type { IncrementalCache } from "next/dist/server/lib/incremental-cache";
+
 import { NEXT_META_SUFFIX } from "../../constants/incremental-cache";
 
 type PrerenderedRouteMeta = {

--- a/packages/cloudflare/src/cli/templates/worker.ts
+++ b/packages/cloudflare/src/cli/templates/worker.ts
@@ -1,12 +1,14 @@
-import type { ExportedHandler, Fetcher } from "@cloudflare/workers-types";
-import { NodeNextRequest, NodeNextResponse } from "next/dist/server/base-http/node";
 import { AsyncLocalStorage } from "node:async_hooks";
-import type { CloudflareContext } from "../../api";
 import type { IncomingMessage } from "node:http";
-import { MockedResponse } from "next/dist/server/lib/mock-request";
-import type { NextConfig } from "next";
-import type { NodeRequestHandler } from "next/dist/server/next-server";
 import Stream from "node:stream";
+
+import type { ExportedHandler, Fetcher } from "@cloudflare/workers-types";
+import type { NextConfig } from "next";
+import { NodeNextRequest, NodeNextResponse } from "next/dist/server/base-http/node";
+import { MockedResponse } from "next/dist/server/lib/mock-request";
+import type { NodeRequestHandler } from "next/dist/server/next-server";
+
+import type { CloudflareContext } from "../../api";
 
 const NON_BODY_RESPONSES = new Set([101, 204, 205, 304]);
 

--- a/packages/cloudflare/tsup.config.ts
+++ b/packages/cloudflare/tsup.config.ts
@@ -1,4 +1,5 @@
 import { cp } from "node:fs/promises";
+
 import { defineConfig } from "tsup";
 
 const cliConfig = defineConfig({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -310,6 +310,12 @@ importers:
       eslint:
         specifier: 'catalog:'
         version: 9.11.1(jiti@1.21.6)
+      eslint-plugin-import:
+        specifier: ^2.31.0
+        version: 2.31.0(@typescript-eslint/parser@8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.5.4))(eslint@9.11.1(jiti@1.21.6))
+      eslint-plugin-simple-import-sort:
+        specifier: ^12.1.1
+        version: 12.1.1(eslint@9.11.1(jiti@1.21.6))
       eslint-plugin-unicorn:
         specifier: 'catalog:'
         version: 55.0.0(eslint@9.11.1(jiti@1.21.6))
@@ -2255,12 +2261,43 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
 
+  eslint-module-utils@2.12.0:
+    resolution: {integrity: sha512-wALZ0HFoytlyh/1+4wuZ9FJCD/leWHQzzrxJ8+rebyReSLk7LApMyd3WJaLVoN+D5+WIdJyDK1c6JnE65V4Zyg==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint:
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
+
   eslint-plugin-import@2.30.0:
     resolution: {integrity: sha512-/mHNE9jINJfiD2EKkg1BKyPyUk4zdnT54YgbOgfjSakWT5oyX/qQLVNTkehyfpcMxZXMy1zyonZ2v7hZTX43Yw==}
     engines: {node: '>=4'}
     peerDependencies:
       '@typescript-eslint/parser': '*'
       eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+
+  eslint-plugin-import@2.31.0:
+    resolution: {integrity: sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9
     peerDependenciesMeta:
       '@typescript-eslint/parser':
         optional: true
@@ -2282,6 +2319,11 @@ packages:
     engines: {node: '>=4'}
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
+
+  eslint-plugin-simple-import-sort@12.1.1:
+    resolution: {integrity: sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==}
+    peerDependencies:
+      eslint: '>=5.0.0'
 
   eslint-plugin-unicorn@55.0.0:
     resolution: {integrity: sha512-n3AKiVpY2/uDcGrS3+QsYDkjPfaOrNrsfQxU9nt5nitd9KuvVXrfAvgCO9DYPSfap+Gqjw9EOrXIsBp5tlHZjA==}
@@ -6291,6 +6333,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint@9.11.1(jiti@1.21.6)):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.5.4)
+      eslint: 9.11.1(jiti@1.21.6)
+      eslint-import-resolver-node: 0.3.9
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-plugin-import@2.30.0(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
@@ -6314,6 +6366,35 @@ snapshots:
       tsconfig-paths: 3.15.0
     optionalDependencies:
       '@typescript-eslint/parser': 8.7.0(eslint@8.57.1)(typescript@5.5.4)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.5.4))(eslint@9.11.1(jiti@1.21.6)):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.8
+      array.prototype.findlastindex: 1.2.5
+      array.prototype.flat: 1.3.2
+      array.prototype.flatmap: 1.3.2
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 9.11.1(jiti@1.21.6)
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint@9.11.1(jiti@1.21.6))
+      hasown: 2.0.2
+      is-core-module: 2.15.1
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.0
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.8
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.5.4)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -6364,6 +6445,10 @@ snapshots:
       semver: 6.3.1
       string.prototype.matchall: 4.0.11
       string.prototype.repeat: 1.0.0
+
+  eslint-plugin-simple-import-sort@12.1.1(eslint@9.11.1(jiti@1.21.6)):
+    dependencies:
+      eslint: 9.11.1(jiti@1.21.6)
 
   eslint-plugin-unicorn@55.0.0(eslint@9.11.1(jiti@1.21.6)):
     dependencies:


### PR DESCRIPTION
The previously used `sort-imports` can not fix the code.

Changed the plugins to ones that can auto-fix the code (i.e. on save, or via `lint:fix`). 
Getting an error without auto-fix was becoming frustrating.

