### PR TITLE
feat: integrate OpenNext static assets

### DIFF
--- a/packages/cloudflare/src/cli/build/build-worker.ts
+++ b/packages/cloudflare/src/cli/build/build-worker.ts
@@ -1,5 +1,5 @@
-import { existsSync, readFileSync } from "node:fs";
-import { cp, readFile, writeFile } from "node:fs/promises";
+import { readFileSync } from "node:fs";
+import { readFile, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 

--- a/packages/cloudflare/src/cli/build/build-worker.ts
+++ b/packages/cloudflare/src/cli/build/build-worker.ts
@@ -29,19 +29,6 @@ const packageDistDir = join(dirname(fileURLToPath(import.meta.url)), "..");
  * @param config
  */
 export async function buildWorker(config: Config): Promise<void> {
-  console.log(`\x1b[35m⚙️ Copying files...\n\x1b[0m`);
-
-  // Copy over client-side generated files
-  await cp(join(config.paths.source.dotNext, "static"), join(config.paths.output.assets, "_next", "static"), {
-    recursive: true,
-  });
-
-  // Copy over any static files (e.g. images) from the source project
-  const publicDir = join(config.paths.source.root, "public");
-  if (existsSync(publicDir)) {
-    await cp(publicDir, config.paths.output.assets, { recursive: true });
-  }
-
   // Copy over prerendered assets (e.g. SSG routes)
   copyPrerenderedRoutes(config);
 

--- a/packages/cloudflare/src/cli/build/index.ts
+++ b/packages/cloudflare/src/cli/build/index.ts
@@ -13,6 +13,7 @@ import type { OpenNextConfig } from "@opennextjs/aws/types/open-next.js";
 import type { ProjectOptions } from "../config";
 import { containsDotNextDir, getConfig } from "../config";
 import { buildWorker } from "./build-worker";
+import { createStaticAssets } from "@opennextjs/aws/build/createAssets.js";
 
 /**
  * Builds the application in a format that can be passed to workerd
@@ -63,6 +64,8 @@ export async function build(projectOpts: ProjectOptions): Promise<void> {
 
   // Compile middleware
   await createMiddleware(options, { forceOnlyBuildOnce: true });
+
+  createStaticAssets(options);
 
   // Copy the .next directory to the output directory so it can be mutated.
   cpSync(join(projectOpts.sourceDir, ".next"), join(projectOpts.outputDir, ".next"), { recursive: true });

--- a/packages/cloudflare/src/cli/build/index.ts
+++ b/packages/cloudflare/src/cli/build/index.ts
@@ -4,6 +4,7 @@ import { dirname, join } from "node:path";
 
 import { buildNextjsApp, setStandaloneBuildMode } from "@opennextjs/aws/build/buildNextApp.js";
 import { compileOpenNextConfig } from "@opennextjs/aws/build/compileConfig.js";
+import { createStaticAssets } from "@opennextjs/aws/build/createAssets.js";
 import { createMiddleware } from "@opennextjs/aws/build/createMiddleware.js";
 import * as buildHelper from "@opennextjs/aws/build/helper.js";
 import { printHeader, showWarningOnWindows } from "@opennextjs/aws/build/utils.js";
@@ -13,7 +14,6 @@ import type { OpenNextConfig } from "@opennextjs/aws/types/open-next.js";
 import type { ProjectOptions } from "../config";
 import { containsDotNextDir, getConfig } from "../config";
 import { buildWorker } from "./build-worker";
-import { createStaticAssets } from "@opennextjs/aws/build/createAssets.js";
 
 /**
  * Builds the application in a format that can be passed to workerd

--- a/packages/cloudflare/src/cli/templates/worker.ts
+++ b/packages/cloudflare/src/cli/templates/worker.ts
@@ -64,17 +64,6 @@ export default {
         }).getRequestHandler();
       }
 
-      const url = new URL(request.url);
-
-      if (url.pathname === "/_next/image") {
-        const imageUrl =
-          url.searchParams.get("url") ?? "https://developers.cloudflare.com/_astro/logo.BU9hiExz.svg";
-        if (imageUrl.startsWith("/")) {
-          return env.ASSETS.fetch(new URL(imageUrl, request.url));
-        }
-        return fetch(imageUrl, { cf: { cacheEverything: true } });
-      }
-
       const { req, res, webResponse } = getWrappedStreams(request, ctx);
 
       ctx.waitUntil(Promise.resolve(requestHandler(new NodeNextRequest(req), new NodeNextResponse(res))));


### PR DESCRIPTION
- Rely on OpenNext to copy the static assets
- Remove useless code in the worker - assets are served when path matches