### PR TITLE
feat: rename the binary from "cloudflare" to "opennextjs-cloudflare"

### DIFF
--- a/.changeset/happy-worms-rest.md
+++ b/.changeset/happy-worms-rest.md
@@ -1,0 +1,11 @@
+---
+"@opennextjs/cloudflare": minor
+---
+
+feat: rename the binary from "cloudflare" to "opennextjs-cloudflare"
+
+**BREAKING CHANGE**:
+After this change the old way of running the tool (e.g. `pnpm cloudflare`) no longer works.
+Going forward use the new binary name (e.g. `pnpm opennextjs-cloudflare`).
+
+See [#161](https://github.com/opennextjs/opennextjs-cloudflare/issues/161)

--- a/examples/api/package.json
+++ b/examples/api/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "build:worker": "pnpm cloudflare",
+    "build:worker": "pnpm opennextjs-cloudflare",
     "dev:worker": "wrangler dev --port 8770 --inspector-port 9330",
     "preview:worker": "pnpm build:worker && pnpm dev:worker",
     "e2e": "playwright test -c e2e/playwright.config.ts",

--- a/examples/create-next-app/package.json
+++ b/examples/create-next-app/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "build:worker": "cloudflare",
+    "build:worker": "opennextjs-cloudflare",
     "dev:worker": "wrangler dev --port 8771 --inspector-port 9331",
     "preview:worker": "pnpm build:worker && pnpm dev:worker",
     "e2e": "playwright test -c e2e/playwright.config.ts"

--- a/examples/vercel-blog-starter/package.json
+++ b/examples/vercel-blog-starter/package.json
@@ -5,7 +5,7 @@
     "dev": "next",
     "build": "next build",
     "start": "next start",
-    "build:worker": "cloudflare",
+    "build:worker": "opennextjs-cloudflare",
     "dev:worker": "wrangler dev --port 8773",
     "preview:worker": "pnpm build:worker && pnpm dev:worker"
   },

--- a/examples/vercel-commerce/package.json
+++ b/examples/vercel-commerce/package.json
@@ -12,7 +12,7 @@
     "prettier": "prettier --write --ignore-unknown .",
     "prettier:check": "prettier --check --ignore-unknown .",
     "test": "pnpm prettier:check",
-    "build:worker": "cloudflare",
+    "build:worker": "opennextjs-cloudflare",
     "dev:worker": "wrangler dev --port 8772",
     "preview:worker": "pnpm build:worker && pnpm dev:worker"
   },

--- a/packages/cloudflare/TODO.md
+++ b/packages/cloudflare/TODO.md
@@ -30,6 +30,6 @@ Changes:
   }
 ```
 
-- Build the app `pnpm cloudflare`
+- Build the app `pnpm opennextjs-cloudflare`
 
 - Serve with `WRANGLER_BUILD_CONDITIONS="" WRANGLER_BUILD_PLATFORM="node" pnpm wrangler dev`

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opennextjs/cloudflare",
   "description": "Cloudflare builder for next apps",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "scripts": {
     "build": "tsup",
     "build:watch": "tsup --watch src",
@@ -11,7 +11,9 @@
     "test": "vitest --run",
     "test:watch": "vitest"
   },
-  "bin": "dist/cli/index.mjs",
+  "bin": {
+    "opennextjs-cloudflare": "dist/cli/index.mjs"
+  },
   "main": "./dist/api/index.mjs",
   "types": "./dist/api/index.d.mts",
   "exports": {
@@ -30,6 +32,7 @@
     "directory": "packages/cloudflare"
   },
   "keywords": [
+    "opennextjs-cloudflare",
     "cloudflare",
     "workers",
     "next.js"


### PR DESCRIPTION
**BREAKING CHANGE**:
After this change the old way of running the tool (e.g. `pnpm cloudflare`) no longer works.
Going forward use the new binary name (e.g. `pnpm opennextjs-cloudflare`).

See [#161](https://github.com/opennextjs/opennextjs-cloudflare/issues/161)