### PR TITLE
remove node-version field from the GitHub bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report.yml
@@ -46,14 +46,6 @@ body:
       required: true
 
   - type: input
-    id: node-version
-    attributes:
-      label: "Node.js version"
-      placeholder: "18.x"
-    validations:
-      required: true
-
-  - type: input
     id: wrangler-version
     attributes:
       label: "Wrangler version"


### PR DESCRIPTION
Quite minor but I don't think we should ask for the node version since that's already included in the [`next info` output]( https://github.com/opennextjs/opennextjs-cloudflare/blob/021ddb7ef630e0162b9fb55226b82ce6bfd13efc/.github/ISSUE_TEMPLATE/1.bug_report.yml?plain=1#L64-L71) and both fields are required.

Alternatively we could make the `next info` field not required.