### PR TITLE
make sure `patchFindDir` works with Next.js 15 and add patching validation check

### DIFF
--- a/packages/cloudflare/src/cli/build/patches/to-investigate/patch-find-dir.ts
+++ b/packages/cloudflare/src/cli/build/patches/to-investigate/patch-find-dir.ts
@@ -11,18 +11,24 @@ import { Config } from "../../../config";
  */
 export function patchFindDir(code: string, config: Config): string {
   console.log("# patchFindDir");
-  return code.replace(
-    "function findDir(dir, name) {",
-    `function findDir(dir, name) {
-			if (dir.endsWith(".next/server")) {
-			if (name === "app") {
+  const patchedCode = code.replace(
+    /function findDir\((dir\d*), (name\d*)\) {/,
+    `function findDir($1, $2) {
+			if ($1.endsWith(".next/server")) {
+			if ($2 === "app") {
 			  return ${existsSync(`${join(config.paths.output.standaloneAppServer, "app")}`)};
 	    }
-			if (name === "pages") {
+			if ($2 === "pages") {
 			  return ${existsSync(`${join(config.paths.output.standaloneAppServer, "pages")}`)};
 	    }
 		}
-		throw new Error("Unknown findDir call: " + dir + " " + name);
+		throw new Error("Unknown findDir call: " + $1 + " " + $2);
 		`
   );
+
+  if (patchedCode === code) {
+    throw new Error("Patch `patchFindDir` not applied");
+  }
+
+  return patchedCode;
 }

--- a/packages/cloudflare/src/cli/build/patches/to-investigate/patch-find-dir.ts
+++ b/packages/cloudflare/src/cli/build/patches/to-investigate/patch-find-dir.ts
@@ -12,17 +12,17 @@ import { Config } from "../../../config";
 export function patchFindDir(code: string, config: Config): string {
   console.log("# patchFindDir");
   const patchedCode = code.replace(
-    /function findDir\((dir\d*), (name\d*)\) {/,
-    `function findDir($1, $2) {
-			if ($1.endsWith(".next/server")) {
-			if ($2 === "app") {
+    /function findDir\((?<dir>dir\d*), (?<name>name\d*)\) {/,
+    `function findDir($dir, $name) {
+			if ($dir.endsWith(".next/server")) {
+			if ($name === "app") {
 			  return ${existsSync(`${join(config.paths.output.standaloneAppServer, "app")}`)};
 	    }
-			if ($2 === "pages") {
+			if ($name === "pages") {
 			  return ${existsSync(`${join(config.paths.output.standaloneAppServer, "pages")}`)};
 	    }
 		}
-		throw new Error("Unknown findDir call: " + $1 + " " + $2);
+		throw new Error("Unknown findDir call: " + $dir + " " + $name);
 		`
   );
 


### PR DESCRIPTION
resolves #172 

___


The `patchFindDir` function: https://github.com/opennextjs/opennextjs-cloudflare/blob/acec1c3ce61602a5bbb3f1330b5d1e0d0110b3f6/packages/cloudflare/src/cli/build/patches/to-investigate/patch-find-dir.ts#L12

Stopped working since a new `name` variable got introduced in the Next.js source code, causing the bundled code to rename the function's `name` parameter to `name2` instead:
![Screenshot 2024-12-17 at 19 33 16](https://github.com/user-attachments/assets/0cb8ed23-2ce2-4732-9140-07493588f6a5)


I fixed this by updating the code replacement to also accept the variables with a numerical suffix. I also added a check to make sure that the patching is applied (if we already had the check in place that would have saved me lots of time here! 😭)

A few notes:
 - I wanted to update the code to use AST manipulation, but since this patch is in the `to-investigate` directory I guess that we assume that this is temporary, so maybe it's not worth investing time to update the code to use ASTs? (if it is I am more than happy to do so!)
 - again, having the `patchedCode !== code` check would have saved me lots of time here, we need to add it to all the patch functions to avoid wasting time again, I will do that in a followup PR
 - potentially we can hit this issue with other patching functions, I can update those as well to accept numerical suffixes in their variables/paramenters, but I think that adding the `patchedCode !== code` check would be good enough for now