### PR TITLE
patch `eval("require")` calls to avoid runtime warnings

### DIFF
--- a/packages/cloudflare/src/cli/build/bundle-server.ts
+++ b/packages/cloudflare/src/cli/build/bundle-server.ts
@@ -167,6 +167,7 @@ async function updateWorkerBundledCode(
           // TODO: implement for cf (possibly in @opennextjs/aws)
           .replace("patchAsyncStorage();", "//patchAsyncStorage();"),
     ],
+    ['`eval("require")` calls', (code) => code.replaceAll('eval("require")', "require")],
     [
       "`require.resolve` call",
       // workers do not support dynamic require nor require.resolve


### PR DESCRIPTION
resolves #185 
