### PR TITLE
prevent eval patch from failing build

### DIFF
--- a/packages/cloudflare/src/cli/build/bundle-server.ts
+++ b/packages/cloudflare/src/cli/build/bundle-server.ts
@@ -167,7 +167,11 @@ async function updateWorkerBundledCode(
           // TODO: implement for cf (possibly in @opennextjs/aws)
           .replace("patchAsyncStorage();", "//patchAsyncStorage();"),
     ],
-    ['`eval("require")` calls', (code) => code.replaceAll('eval("require")', "require")],
+    [
+      '`eval("require")` calls',
+      (code) => code.replaceAll('eval("require")', "require"),
+      { isOptional: true },
+    ],
     [
       "`require.resolve` call",
       // workers do not support dynamic require nor require.resolve
@@ -204,18 +208,18 @@ function createFixRequiresESBuildPlugin(config: Config): Plugin {
  */
 async function patchCodeWithValidations(
   code: string,
-  patches: [string, (code: string) => string | Promise<string>][]
+  patches: [string, (code: string) => string | Promise<string>, opts?: { isOptional?: boolean }][]
 ): Promise<string> {
   console.log(`Applying code patches:`);
   let patchedCode = code;
 
-  for (const [target, patchFunction] of patches) {
+  for (const [target, patchFunction, opts] of patches) {
     console.log(` - patching ${target}`);
 
     const prePatchCode = patchedCode;
     patchedCode = await patchFunction(patchedCode);
 
-    if (prePatchCode === patchedCode) {
+    if (!opts?.isOptional && prePatchCode === patchedCode) {
       throw new Error(`Failed to patch ${target}`);
     }
   }


### PR DESCRIPTION
The e2es are currently failing to run due to the eval patch not being required for Next.js 14 (which the e2es are currently using).

<img width="1070" alt="image" src="https://github.com/user-attachments/assets/cc61f240-2b1c-42d2-81b6-38cfcf3c1dad" />

This PR makes that patch optional, i.e. doesn't throw an error if the patch hasn't made any changes.