### PR TITLE
add default to exports

### DIFF
--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -17,7 +17,8 @@
   "exports": {
     ".": {
       "import": "./dist/api/index.mjs",
-      "types": "./dist/api/index.d.mts"
+      "types": "./dist/api/index.d.mts",
+      "default": "./dist/api/index.mjs"
     }
   },
   "files": [


### PR DESCRIPTION
I'm trying to write a script that works alongside my Next.js project, and since Next.js is still CJS - I'm unable to use `"type": "module"` in my package.json

This package is required as part of my database setup, and it even works outside Next.js, but for whatever cursed CJS → ESM compat reason, I can't import it.

default is a generic fallback - and allows me to import it. 