### PR TITLE
fix: delete init.cache rather than assign undefined

### DIFF
--- a/.changeset/khaki-shirts-deliver.md
+++ b/.changeset/khaki-shirts-deliver.md
@@ -1,0 +1,7 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+fix: delete init.cache rather than assign undefined
+
+Assigning undefined to init.cache throws when using NextAuth

--- a/packages/cloudflare/src/cli/build/bundle-server.ts
+++ b/packages/cloudflare/src/cli/build/bundle-server.ts
@@ -94,7 +94,7 @@ fetch = globalThis.fetch;
 const CustomRequest = class extends globalThis.Request {
   constructor(input, init) {
     if (init) {
-      init.cache = undefined;
+      delete init.cache;
       // https://github.com/cloudflare/workerd/issues/2746
       // https://github.com/cloudflare/workerd/issues/3245
       Object.defineProperty(init, "body", {


### PR DESCRIPTION
Fix an issue with NextAuth (#206)

Creating a PR so that users can test, but need to come with a proper test