### PR TITLE
create a wrangler config file for the user in case one is not already present (alongside ways to opt out of this)

### DIFF
--- a/.changeset/lazy-balloons-report.md
+++ b/.changeset/lazy-balloons-report.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+create a wrangler.toml file for the user in case one is not already presentwq

--- a/.changeset/lazy-balloons-report.md
+++ b/.changeset/lazy-balloons-report.md
@@ -2,7 +2,7 @@
 "@opennextjs/cloudflare": patch
 ---
 
-checks and creates a wrangler.jsonc file for the user in case one wrangler.(toml|json|jsonc) file is not already present
+checks and creates a `wrangler.jsonc` file for the user in case a `wrangler.(toml|json|jsonc)` file is not already present
 
 also introduce a new `--skipWranglerConfigCheck` cli flag and a `SKIP_WRANGLER_CONFIG_CHECK`
 environment variable that allows users to opt out of the above check (since developers might

--- a/.changeset/lazy-balloons-report.md
+++ b/.changeset/lazy-balloons-report.md
@@ -2,7 +2,7 @@
 "@opennextjs/cloudflare": patch
 ---
 
-checks and creates a `wrangler.jsonc` file for the user in case a `wrangler.(toml|json|jsonc)` file is not already present
+check and create a `wrangler.jsonc` file for the user in case a `wrangler.(toml|json|jsonc)` file is not already present
 
 also introduce a new `--skipWranglerConfigCheck` cli flag and a `SKIP_WRANGLER_CONFIG_CHECK`
 environment variable that allows users to opt out of the above check (since developers might

--- a/.changeset/lazy-balloons-report.md
+++ b/.changeset/lazy-balloons-report.md
@@ -2,4 +2,8 @@
 "@opennextjs/cloudflare": patch
 ---
 
-create a wrangler.toml file for the user in case one is not already presentwq
+checks and creates a wrangler.jsonc file for the user in case one wrangler.(toml|json|jsonc) file is not already present
+
+also introduce a new `--skipWranglerConfigCheck` cli flag and a `SKIP_WRANGLER_CONFIG_CHECK`
+environment variable that allows users to opt out of the above check (since developers might
+want to use custom names for their config files)

--- a/.changeset/lazy-balloons-report.md
+++ b/.changeset/lazy-balloons-report.md
@@ -6,4 +6,4 @@ check and create a `wrangler.jsonc` file for the user in case a `wrangler.(toml|
 
 also introduce a new `--skipWranglerConfigCheck` cli flag and a `SKIP_WRANGLER_CONFIG_CHECK`
 environment variable that allows users to opt out of the above check (since developers might
-want to use custom names for their config files)
+want to use custom locations for their config files)

--- a/.prettierrc
+++ b/.prettierrc
@@ -4,5 +4,14 @@
   "semi": true,
   "useTabs": false,
   "tabWidth": 2,
-  "trailingComma": "es5"
+  "trailingComma": "es5",
+  "overrides": [
+    {
+      "// comment": "wrangler doesn't seem to accept wrangler.jsonc with trailing commas",
+      "files": ["**/wrangler.jsonc"],
+      "options": {
+        "trailingComma": "none"
+      }
+    }
+  ]
 }

--- a/packages/cloudflare/env.d.ts
+++ b/packages/cloudflare/env.d.ts
@@ -3,6 +3,7 @@ declare global {
     interface ProcessEnv {
       __NEXT_PRIVATE_STANDALONE_CONFIG?: string;
       SKIP_NEXT_APP_BUILD?: string;
+      SKIP_WRANGLER_CONFIG_CHECK?: string;
       NEXT_PRIVATE_DEBUG_CACHE?: string;
       OPEN_NEXT_ORIGIN: string;
       NODE_ENV?: string;

--- a/packages/cloudflare/src/cli/args.ts
+++ b/packages/cloudflare/src/cli/args.ts
@@ -4,10 +4,11 @@ import { parseArgs } from "node:util";
 
 export function getArgs(): {
   skipNextBuild: boolean;
+  skipWranglerConfigCheck: boolean;
   outputDir?: string;
   minify: boolean;
 } {
-  const { skipBuild, output, noMinify } = parseArgs({
+  const { skipBuild, skipWranglerConfigCheck, output, noMinify } = parseArgs({
     options: {
       skipBuild: {
         type: "boolean",
@@ -19,6 +20,10 @@ export function getArgs(): {
         short: "o",
       },
       noMinify: {
+        type: "boolean",
+        default: false,
+      },
+      skipWranglerConfigCheck: {
         type: "boolean",
         default: false,
       },
@@ -35,6 +40,9 @@ export function getArgs(): {
   return {
     outputDir,
     skipNextBuild: skipBuild || ["1", "true", "yes"].includes(String(process.env.SKIP_NEXT_APP_BUILD)),
+    skipWranglerConfigCheck:
+      skipWranglerConfigCheck ||
+      ["1", "true", "yes"].includes(String(process.env.SKIP_WRANGLER_CONFIG_CHECK)),
     minify: !noMinify,
   };
 }

--- a/packages/cloudflare/src/cli/build/index.ts
+++ b/packages/cloudflare/src/cli/build/index.ts
@@ -247,7 +247,7 @@ export async function getLatestCompatDate(): Promise<string | undefined> {
     const match = latestWorkerdVersion.match(/\d+\.(\d{4})(\d{2})(\d{2})\.\d+/);
 
     if (match) {
-      const [, year, month, date] = match ?? [];
+      const [, year, month, date] = match;
       const compatDate = `${year}-${month}-${date}`;
 
       return compatDate;

--- a/packages/cloudflare/src/cli/build/index.ts
+++ b/packages/cloudflare/src/cli/build/index.ts
@@ -184,9 +184,10 @@ function ensureCloudflareConfig(config: OpenNextConfig) {
 }
 
 /**
- * Creates a `wrangler.jsonc` file for the user if it doesn't exist, but only after asking for the user's confirmation.
+ * Creates a `wrangler.jsonc` file for the user if a wrangler config file doesn't already exist,
+ * but only after asking for the user's confirmation.
  *
- * If the user refuses an error is thrown (since the file is mandatory).
+ * If the user refuses a warning is shown (which offers ways to opt out of this check to the user).
  *
  * @param projectOpts The options for the project
  */

--- a/packages/cloudflare/src/cli/config.ts
+++ b/packages/cloudflare/src/cli/config.ts
@@ -114,6 +114,8 @@ export type ProjectOptions = {
   outputDir: string;
   // Whether the Next.js build should be skipped (i.e. if the `.next` dir is already built)
   skipNextBuild: boolean;
+  // Whether the check to see if a wrangler config file exists should be skipped
+  skipWranglerConfigCheck: boolean;
   // Whether minification of the worker should be enabled
   minify: boolean;
 };

--- a/packages/cloudflare/src/cli/index.ts
+++ b/packages/cloudflare/src/cli/index.ts
@@ -6,11 +6,12 @@ import { build } from "./build/index.js";
 
 const nextAppDir = process.cwd();
 
-const { skipNextBuild, outputDir, minify } = getArgs();
+const { skipNextBuild, skipWranglerConfigCheck, outputDir, minify } = getArgs();
 
 await build({
   sourceDir: nextAppDir,
   outputDir: resolve(outputDir ?? nextAppDir, ".open-next"),
   skipNextBuild,
+  skipWranglerConfigCheck,
   minify,
 });

--- a/packages/cloudflare/templates/defaults/wrangler.jsonc
+++ b/packages/cloudflare/templates/defaults/wrangler.jsonc
@@ -5,7 +5,7 @@
   "compatibility_flags": ["nodejs_compat"],
   "assets": {
     "directory": ".open-next/assets",
-    "binding": "ASSETS",
+    "binding": "ASSETS"
   },
   "kv_namespaces": [
     // Create a KV binding with the binding name "NEXT_CACHE_WORKERS_KV"
@@ -14,5 +14,5 @@
     //   "binding": "NEXT_CACHE_WORKERS_KV",
     //   "id": "<BINDING_ID>"
     // }
-  ],
+  ]
 }

--- a/packages/cloudflare/templates/defaults/wrangler.jsonc
+++ b/packages/cloudflare/templates/defaults/wrangler.jsonc
@@ -1,0 +1,12 @@
+{
+  "main": ".open-next/worker.js",
+  "name": "app-name",
+  "compatibility_date": "2024-12-30",
+  "compatibility_flags": [
+    "nodejs_compat"
+  ],
+  "assets": {
+    "directory": ".open-next/assets",
+    "binding": "ASSETS"
+  }
+}

--- a/packages/cloudflare/templates/defaults/wrangler.jsonc
+++ b/packages/cloudflare/templates/defaults/wrangler.jsonc
@@ -8,5 +8,13 @@
   "assets": {
     "directory": ".open-next/assets",
     "binding": "ASSETS"
-  }
+  },
+  "kv_namespaces": [
+    // Create a KV binding with the binding name "NEXT_CACHE_WORKERS_KV"
+    // to enable the KV based caching:
+    // {
+    //   "binding": "NEXT_CACHE_WORKERS_KV",
+    //   "id": "<BINDING_ID>"
+    // }
+  ]
 }

--- a/packages/cloudflare/templates/defaults/wrangler.jsonc
+++ b/packages/cloudflare/templates/defaults/wrangler.jsonc
@@ -2,12 +2,10 @@
   "main": ".open-next/worker.js",
   "name": "app-name",
   "compatibility_date": "2024-12-30",
-  "compatibility_flags": [
-    "nodejs_compat"
-  ],
+  "compatibility_flags": ["nodejs_compat"],
   "assets": {
     "directory": ".open-next/assets",
-    "binding": "ASSETS"
+    "binding": "ASSETS",
   },
   "kv_namespaces": [
     // Create a KV binding with the binding name "NEXT_CACHE_WORKERS_KV"
@@ -16,5 +14,5 @@
     //   "binding": "NEXT_CACHE_WORKERS_KV",
     //   "id": "<BINDING_ID>"
     // }
-  ]
+  ],
 }

--- a/packages/cloudflare/templates/defaults/wrangler.toml
+++ b/packages/cloudflare/templates/defaults/wrangler.toml
@@ -1,0 +1,7 @@
+main = ".open-next/worker.js"
+name = "app-name"
+
+compatibility_date = "2024-12-30"
+compatibility_flags = ["nodejs_compat"]
+
+assets = { directory = ".open-next/assets", binding = "ASSETS" }

--- a/packages/cloudflare/templates/defaults/wrangler.toml
+++ b/packages/cloudflare/templates/defaults/wrangler.toml
@@ -1,7 +1,0 @@
-main = ".open-next/worker.js"
-name = "app-name"
-
-compatibility_date = "2024-12-30"
-compatibility_flags = ["nodejs_compat"]
-
-assets = { directory = ".open-next/assets", binding = "ASSETS" }


### PR DESCRIPTION
Similarly to https://github.com/opennextjs/opennextjs-cloudflare/pull/193 I thought it'd be a nice touch if we created the `wrangler.toml` file for the user instead of telling them to create and populate it themselves 🙂 

___

Related docs update: https://github.com/opennextjs/docs/pull/45