### PR TITLE
fix: patch both `trace/tracer.js` files

### DIFF
--- a/packages/cloudflare/src/cli/build/open-next/createServerBundle.ts
+++ b/packages/cloudflare/src/cli/build/open-next/createServerBundle.ts
@@ -17,6 +17,8 @@ import { openNextReplacementPlugin } from "@opennextjs/aws/plugins/replacement.j
 import { openNextResolvePlugin } from "@opennextjs/aws/plugins/resolve.js";
 import type { FunctionOptions, SplittedFunctionOptions } from "@opennextjs/aws/types/open-next.js";
 
+import { patchTracerFile } from "../patches/to-investigate/wrangler-deps.js";
+
 export async function createServerBundle(options: buildHelper.BuildOptions) {
   const { config } = options;
   const foundRoutes = new Set<string>();
@@ -151,6 +153,21 @@ async function generateBundle(
     fnOptions.routes ?? ["app/page.tsx"],
     isBundled
   );
+
+  const tracerFilePath = path.join(
+    outputPath,
+    "node_modules",
+    "next",
+    "dist",
+    "server",
+    "lib",
+    "trace",
+    "tracer.js"
+  );
+
+  if (fs.existsSync(tracerFilePath)) {
+    patchTracerFile(tracerFilePath);
+  }
 
   // Build Lambda code
   // note: bundle in OpenNext package b/c the adapter relies on the


### PR DESCRIPTION
fixes #219 

___

Currently [we patch the `.open-next/.next/standalone/node_modules/next/dist/server/lib/trace/tracer.js` file](https://github.com/opennextjs/opennextjs-cloudflare/blob/4b6a50b63912ba2a6d0a7cd168e13da1b7c50536/packages/cloudflare/src/cli/build/patches/to-investigate/wrangler-deps.ts#L26-L43) but it turns out that we get another copy of the `tracer.js` file at `.open-next/server-functions/defaults/node_modules/next/dist/server/lib/trace/tracer.js` (from [`copyTracedFiles`](https://github.com/opennextjs/opennextjs-cloudflare/blob/4b6a50b63912ba2a6d0a7cd168e13da1b7c50536/packages/cloudflare/src/cli/build/open-next/createServerBundle.ts#L147-L153)) that needs patching.

So this PR is making sure that both files do get patched.

___

### TODO
 - [ ] test this if possible (thus far I haven't even yet managed to get a minimal repro for the issue 😓)
 - [ ] understand and document clearly why we get the two tracer files and if that can be amended instead of patching both files (without a huge refactoring)