### PR TITLE
fix: exclude `.env.local` files for `test` mode

### DIFF
--- a/.changeset/bright-parents-juggle.md
+++ b/.changeset/bright-parents-juggle.md
@@ -1,0 +1,7 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+fix: exclude `.env.local` files for `test` mode
+
+Aligns with the Next.js behavior of not extracting variables from the `.env.local` file in test environments.

--- a/packages/cloudflare/src/cli/build/utils/extract-project-env-vars.spec.ts
+++ b/packages/cloudflare/src/cli/build/utils/extract-project-env-vars.spec.ts
@@ -13,6 +13,8 @@ describe("extractProjectEnvVars", () => {
     mockFs({
       ".env": "ENV_VAR=value",
       ".env.local": "ENV_LOCAL_VAR=value",
+      ".env.test": "ENV_TEST_VAR=value",
+      ".env.test.local": "ENV_TEST_LOCAL_VAR=value",
       ".env.development": "ENV_DEV_VAR=value",
       ".env.development.local": "ENV_DEV_LOCAL_VAR=value",
       ".env.production": "ENV_PROD_VAR=value",
@@ -64,6 +66,15 @@ describe("extractProjectEnvVars", () => {
       ENV_PROD_LOCAL_VAR: "value",
       ENV_PROD_LOCAL_VAR_REF: "value",
       ENV_PROD_VAR: "value",
+      ENV_VAR: "value",
+    });
+  });
+
+  it("should exclude .env.local files when extracting test env vars", () => {
+    const result = extractProjectEnvVars("test", options);
+    expect(result).toEqual({
+      ENV_TEST_LOCAL_VAR: "value",
+      ENV_TEST_VAR: "value",
       ENV_VAR: "value",
     });
   });

--- a/packages/cloudflare/src/cli/build/utils/extract-project-env-vars.ts
+++ b/packages/cloudflare/src/cli/build/utils/extract-project-env-vars.ts
@@ -17,7 +17,7 @@ function readEnvFile(filePath: string) {
  *
  * Merged variables respect the following priority order.
  * 1. `.env.{mode}.local`
- * 2. `.env.local`
+ * 2. `.env.local` (when mode is not equal to `test`)
  * 3. `.env.{mode}`
  * 4. `.env`
  *
@@ -27,7 +27,7 @@ function readEnvFile(filePath: string) {
  * the env files at the root of the monorepo.
  */
 export function extractProjectEnvVars(mode: string, { monorepoRoot, appPath }: BuildOptions) {
-  return [".env", `.env.${mode}`, ".env.local", `.env.${mode}.local`]
+  return [".env", `.env.${mode}`, ...(mode !== "test" ? [".env.local"] : []), `.env.${mode}.local`]
     .flatMap((fileName) => [
       ...(monorepoRoot !== appPath ? [readEnvFile(path.join(monorepoRoot, fileName))] : []),
       readEnvFile(path.join(appPath, fileName)),


### PR DESCRIPTION
Align the behavior with [what NextJs does](https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables#test-environment-variables)