### PR TITLE
update the `patchExceptionBubbling` patch

### DIFF
--- a/.changeset/cold-plants-deliver.md
+++ b/.changeset/cold-plants-deliver.md
@@ -2,4 +2,4 @@
 "@opennextjs/cloudflare": patch
 ---
 
-update the bubble no fallback patch
+update the `patchExceptionBubbling` patch

--- a/.changeset/cold-plants-deliver.md
+++ b/.changeset/cold-plants-deliver.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+update the bubble no fallback patch

--- a/packages/cloudflare/src/cli/build/patches/to-investigate/patch-exception-bubbling.ts
+++ b/packages/cloudflare/src/cli/build/patches/to-investigate/patch-exception-bubbling.ts
@@ -14,5 +14,5 @@ export function patchExceptionBubbling(code: string) {
 
   // The Next.js transpiled code contains something like `(0, _requestmeta.addRequestMeta)(req, "bubbleNoFallback", true);`
   // and we want to update it to `(0, _requestmeta.addRequestMeta)(req, "bubbleNoFallback", false);`
-  return code.replace(/\((.*?.addRequestMeta\)\(.*?,\s+"bubbleNoFallback"),\s+true\)/, "($1, false)");
+  return code.replace(/\((.*?.addRequestMeta\)\([^,(]*?,\s+"bubbleNoFallback"),\s+true\)/, "($1, false)");
 }

--- a/packages/cloudflare/src/cli/build/patches/to-investigate/patch-exception-bubbling.ts
+++ b/packages/cloudflare/src/cli/build/patches/to-investigate/patch-exception-bubbling.ts
@@ -14,5 +14,5 @@ export function patchExceptionBubbling(code: string) {
 
   // The Next.js transpiled code contains something like `(0, _requestmeta.addRequestMeta)(req, "bubbleNoFallback", true);`
   // and we want to update it to `(0, _requestmeta.addRequestMeta)(req, "bubbleNoFallback", false);`
-  return code.replace(/(\(.*?,.*?\.addRequestMeta\)\(.*?,\s+"bubbleNoFallback",\s+)true\)/, "$1false)");
+  return code.replace(/\((.*?.addRequestMeta\)\(.*?,\s+"bubbleNoFallback"),\s+true\)/, "($1, false)");
 }

--- a/packages/cloudflare/src/cli/build/patches/to-investigate/patch-exception-bubbling.ts
+++ b/packages/cloudflare/src/cli/build/patches/to-investigate/patch-exception-bubbling.ts
@@ -5,5 +5,14 @@
  * promises.
  */
 export function patchExceptionBubbling(code: string) {
-  return code.replace('_nextBubbleNoFallback = "1"', "_nextBubbleNoFallback = undefined");
+  // The code before had: `query._nextBubbleNoFallback = '1'`, that has ben refactored to
+  // `addRequestMeta(req, 'bubbleNoFallback', true)` in https://github.com/vercel/next.js/pull/74100
+  // we need to support both for backward compatibility, that's why we have the following if statement
+  if (code.includes("_nextBubbleNoFallback")) {
+    return code.replace('_nextBubbleNoFallback = "1"', "_nextBubbleNoFallback = undefined");
+  }
+
+  // The Next.js transpiled code contains something like `(0, _requestmeta.addRequestMeta)(req, "bubbleNoFallback", true);`
+  // and we want to update it to `(0, _requestmeta.addRequestMeta)(req, "bubbleNoFallback", false);`
+  return code.replace(/(\(.*?,.*?\.addRequestMeta\)\(.*?,\s+"bubbleNoFallback",\s+)true\)/, "$1false)");
 }

--- a/packages/cloudflare/src/cli/build/patches/to-investigate/patch-exception-bubbling.ts
+++ b/packages/cloudflare/src/cli/build/patches/to-investigate/patch-exception-bubbling.ts
@@ -14,5 +14,5 @@ export function patchExceptionBubbling(code: string) {
 
   // The Next.js transpiled code contains something like `(0, _requestmeta.addRequestMeta)(req, "bubbleNoFallback", true);`
   // and we want to update it to `(0, _requestmeta.addRequestMeta)(req, "bubbleNoFallback", false);`
-  return code.replace(/\((.*?.addRequestMeta\)\([^,(]*?,\s+"bubbleNoFallback"),\s+true\)/, "($1, false)");
+  return code.replace(/\((.*?.addRequestMeta\)\(.*?,\s+"bubbleNoFallback"),\s+true\)/, "($1, false)");
 }


### PR DESCRIPTION
fixes #221 

The `nextBubbleNoFallback` patch needs updating since the code has been changed in the Next.js source, this PR updates the patch by supporting the current and canary code

> [!Important]
> I am pretty sure this change is correct but I could not validate it properly since I tested it with a simple hello-world app using `next@15.2.0-canary.0` and with the new patch applied the error does disappears but the app still doesn't work since some other (unrelated) errors pop up
>
> note that this patch is under `to-investigate` so it might be ok to just progress with this and investigate/validate it more properly whenever possible