### PR TITLE
fix: host not included in route handler urls

### DIFF
--- a/.changeset/short-cats-kneel.md
+++ b/.changeset/short-cats-kneel.md
@@ -1,0 +1,7 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+fix: host not included in route handler urls
+
+Next.js was unable to re-construct the correct URLs for the request in a route handler due to being unable to retrieve the hostname. This was due to the internal Next.js option `trustHostHeader` being disabled in OpenNext when there is external middleware - this option is needed for the Next.js server in our environment.

--- a/examples/api/app/api/request/route.ts
+++ b/examples/api/app/api/request/route.ts
@@ -1,0 +1,5 @@
+import { NextRequest } from "next/server";
+
+export const GET = (request: NextRequest) => {
+  return new Response(JSON.stringify({ nextUrl: request.nextUrl.href, url: request.url }));
+};

--- a/examples/api/e2e/base.spec.ts
+++ b/examples/api/e2e/base.spec.ts
@@ -35,3 +35,10 @@ test("sets environment variables from the Next.js env file", async ({ page }) =>
   const res = await page.request.get("/api/env");
   await expect(res.json()).resolves.toEqual(expect.objectContaining({ TEST_ENV_VAR: "TEST_VALUE" }));
 });
+
+test("returns correct information about the request from a route handler", async ({ page }) => {
+  const res = await page.request.get("/api/request");
+  // Next.js can fall back to `localhost:3000` or `n` if it doesn't get the host - neither of these are expected.
+  const expectedURL = expect.stringMatching(/https?:\/\/localhost:(?!3000)\d+\/api\/request/);
+  await expect(res.json()).resolves.toEqual({ nextUrl: expectedURL, url: expectedURL });
+});

--- a/packages/cloudflare/src/cli/build/open-next/createServerBundle.ts
+++ b/packages/cloudflare/src/cli/build/open-next/createServerBundle.ts
@@ -182,8 +182,7 @@ async function generateBundle(
       target: /core(\/|\\)util\.js/g,
       deletes: [
         ...(disableNextPrebundledReact ? ["requireHooks"] : []),
-        ...(disableRouting ? ["trustHostHeader"] : []),
-        ...(!isBefore13413 ? ["requestHandlerHost"] : []),
+        ...(isBefore13413 ? ["trustHostHeader"] : ["requestHandlerHost"]),
         ...(isAfter141 ? ["experimentalIncrementalCacheHandler"] : ["stableIncrementalCache"]),
       ],
     }),


### PR DESCRIPTION
fixes #210

Research into what happens internally in Next.js is available in https://github.com/opennextjs/opennextjs-cloudflare/issues/210#issuecomment-2573260525.

OpenNext is removing the `trustHostHeader: true` option from the Next.js config if routing is disabled, and it considers routing disabled when `config.middleware.external` is truthy. This value is required to be true in the OpenNext config used for deploying to Cloudflare.

This PR changes the check to not strip it if there is external middleware.