### PR TITLE
Add support for wrangler environment selection in next dev mode

### DIFF
--- a/.changeset/lemon-zoos-chew.md
+++ b/.changeset/lemon-zoos-chew.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+Add support for specifying wrangler environment when using next dev so that bindings and vars are properly loaded. This can be specified with the env variable NEXT_DEV_WRANGLER_ENV.

--- a/packages/cloudflare/src/api/get-cloudflare-context.ts
+++ b/packages/cloudflare/src/api/get-cloudflare-context.ts
@@ -71,7 +71,10 @@ async function getCloudflareContextInNextDev<
     const { getPlatformProxy } = await import(
       /* webpackIgnore: true */ `${"__wrangler".replaceAll("_", "")}`
     );
-    const { env, cf, ctx } = await getPlatformProxy();
+    const { env, cf, ctx } = await getPlatformProxy({
+      // This allows the selection of a wrangler environment while running in next dev mode
+      environment: process.env.NEXT_DEV_WRANGLER_ENV,
+    });
     global[cloudflareContextInNextDevSymbol] = {
       env,
       cf: cf as unknown as CfProperties,


### PR DESCRIPTION
I opted for an environment variable as it was the closest to the `--env` flag that you'd use with wrangler.  I also considered exposing it as via an API method and saving the result in a module level variable as well as a global variable, but I figured keeping this configuration as close to how you'd do in wrangler made the most sense.  Happy to discuss though!

Addresses #239