### PR TITLE
refactor: use the new regex utility for cross-platform paths

### DIFF
--- a/.changeset/rare-hornets-shake.md
+++ b/.changeset/rare-hornets-shake.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+refactor: use the new regex utility for constructing cross-platform paths

--- a/packages/cloudflare/src/cli/build/bundle-server.ts
+++ b/packages/cloudflare/src/cli/build/bundle-server.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import type { BuildOptions } from "@opennextjs/aws/build/helper.js";
+import { getCrossPlatformPathRegex } from "@opennextjs/aws/utils/regex.js";
 import { build, Plugin } from "esbuild";
 
 import { Config } from "../config.js";
@@ -183,7 +184,7 @@ function createFixRequiresESBuildPlugin(config: Config): Plugin {
     name: "replaceRelative",
     setup(build) {
       // Note: we (empty) shim require-hook modules as they generate problematic code that uses requires
-      build.onResolve({ filter: /^\.(\/|\\)require-hook$/ }, () => ({
+      build.onResolve({ filter: getCrossPlatformPathRegex("^\\./require-hook$", { escape: false }) }, () => ({
         path: path.join(config.paths.internal.templates, "shims", "empty.js"),
       }));
     },

--- a/packages/cloudflare/src/cli/build/bundle-server.ts
+++ b/packages/cloudflare/src/cli/build/bundle-server.ts
@@ -184,7 +184,7 @@ function createFixRequiresESBuildPlugin(config: Config): Plugin {
     name: "replaceRelative",
     setup(build) {
       // Note: we (empty) shim require-hook modules as they generate problematic code that uses requires
-      build.onResolve({ filter: getCrossPlatformPathRegex("^\\./require-hook$", { escape: false }) }, () => ({
+      build.onResolve({ filter: getCrossPlatformPathRegex(String.raw`^\./require-hook$`, { escape: false }) }, () => ({
         path: path.join(config.paths.internal.templates, "shims", "empty.js"),
       }));
     },

--- a/packages/cloudflare/src/cli/build/bundle-server.ts
+++ b/packages/cloudflare/src/cli/build/bundle-server.ts
@@ -184,9 +184,12 @@ function createFixRequiresESBuildPlugin(config: Config): Plugin {
     name: "replaceRelative",
     setup(build) {
       // Note: we (empty) shim require-hook modules as they generate problematic code that uses requires
-      build.onResolve({ filter: getCrossPlatformPathRegex(String.raw`^\./require-hook$`, { escape: false }) }, () => ({
-        path: path.join(config.paths.internal.templates, "shims", "empty.js"),
-      }));
+      build.onResolve(
+        { filter: getCrossPlatformPathRegex(String.raw`^\./require-hook$`, { escape: false }) },
+        () => ({
+          path: path.join(config.paths.internal.templates, "shims", "empty.js"),
+        })
+      );
     },
   };
 }

--- a/packages/cloudflare/src/cli/build/open-next/createServerBundle.ts
+++ b/packages/cloudflare/src/cli/build/open-next/createServerBundle.ts
@@ -16,6 +16,7 @@ import { openNextEdgePlugins } from "@opennextjs/aws/plugins/edge.js";
 import { openNextReplacementPlugin } from "@opennextjs/aws/plugins/replacement.js";
 import { openNextResolvePlugin } from "@opennextjs/aws/plugins/resolve.js";
 import type { FunctionOptions, SplittedFunctionOptions } from "@opennextjs/aws/types/open-next.js";
+import { getCrossPlatformPathRegex } from "@opennextjs/aws/utils/regex.js";
 
 import { normalizePath } from "../utils/index.js";
 
@@ -173,7 +174,7 @@ async function generateBundle(
   const plugins = [
     openNextReplacementPlugin({
       name: `requestHandlerOverride ${name}`,
-      target: /core(\/|\\)requestHandler\.js/g,
+      target: getCrossPlatformPathRegex("core/requestHandler.js"),
       deletes: [
         ...(disableNextPrebundledReact ? ["applyNextjsPrebundledReact"] : []),
         ...(disableRouting ? ["withRouting"] : []),
@@ -181,7 +182,7 @@ async function generateBundle(
     }),
     openNextReplacementPlugin({
       name: `utilOverride ${name}`,
-      target: /core(\/|\\)util\.js/g,
+      target: getCrossPlatformPathRegex("core/util.js"),
       deletes: [
         ...(disableNextPrebundledReact ? ["requireHooks"] : []),
         ...(isBefore13413 ? ["trustHostHeader"] : ["requestHandlerHost"]),


### PR DESCRIPTION
Migrates our esbuild filter usage to use the new utility.