### PR TITLE
fix: patch @vercel/og usage to use the edge runtime version

### DIFF
--- a/.changeset/quick-timers-fail.md
+++ b/.changeset/quick-timers-fail.md
@@ -1,0 +1,7 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+fix: @vercel/og failing due to using the node version.
+
+Patches usage of the @vercel/og library to require the edge runtime version, and enables importing of the fallback font.

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main, experimental]
   pull_request:
-    branches: [main, experimental]
 
 jobs:
   checks:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 jobs:
   test:

--- a/.github/workflows/prereleases.yml
+++ b/.github/workflows/prereleases.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main, experimental]
   pull_request:
-    branches: [main, experimental]
 
 jobs:
   release:

--- a/examples/api/app/og/route.tsx
+++ b/examples/api/app/og/route.tsx
@@ -1,0 +1,65 @@
+import { ImageResponse } from "next/og";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    return new ImageResponse(
+      (
+        <div
+          style={{
+            backgroundColor: "black",
+            backgroundSize: "150px 150px",
+            height: "100%",
+            width: "100%",
+            display: "flex",
+            textAlign: "center",
+            alignItems: "center",
+            justifyContent: "center",
+            flexDirection: "column",
+            flexWrap: "nowrap",
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              justifyItems: "center",
+            }}
+          >
+            <img
+              alt="Vercel"
+              height={200}
+              src="data:image/svg+xml,%3Csvg width='116' height='100' fill='white' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M57.5 0L115 100H0L57.5 0z' /%3E%3C/svg%3E"
+              style={{ margin: "0 30px" }}
+              width={232}
+            />
+          </div>
+          <div
+            style={{
+              fontSize: 60,
+              fontStyle: "normal",
+              letterSpacing: "-0.025em",
+              color: "white",
+              marginTop: 30,
+              padding: "0 120px",
+              lineHeight: 1.4,
+              whiteSpace: "pre-wrap",
+            }}
+          >
+            'next/og'
+          </div>
+        </div>
+      ),
+      {
+        width: 1200,
+        height: 630,
+      }
+    );
+  } catch (e: any) {
+    return new Response("Failed to generate the image", {
+      status: 500,
+    });
+  }
+}

--- a/examples/api/e2e/base.spec.ts
+++ b/examples/api/e2e/base.spec.ts
@@ -1,4 +1,16 @@
 import { test, expect } from "@playwright/test";
+import type { BinaryLike } from "node:crypto";
+import { createHash } from "node:crypto";
+
+const OG_MD5 = "2f7b724d62d8c7739076da211aa62e7b";
+
+export function validateMd5(data: Buffer, expectedHash: string) {
+  return (
+    createHash("md5")
+      .update(data as BinaryLike)
+      .digest("hex") === expectedHash
+  );
+}
 
 test("the application's noop index page is visible and it allows navigating to the hello-world api route", async ({
   page,
@@ -47,4 +59,5 @@ test("generates an og image successfully", async ({ page }) => {
   const res = await page.request.get("/og");
   expect(res.status()).toEqual(200);
   expect(res.headers()["content-type"]).toEqual("image/png");
+  expect(validateMd5(await res.body(), OG_MD5)).toEqual(true);
 });

--- a/examples/api/e2e/base.spec.ts
+++ b/examples/api/e2e/base.spec.ts
@@ -42,3 +42,9 @@ test("returns correct information about the request from a route handler", async
   const expectedURL = expect.stringMatching(/https?:\/\/localhost:(?!3000)\d+\/api\/request/);
   await expect(res.json()).resolves.toEqual({ nextUrl: expectedURL, url: expectedURL });
 });
+
+test("generates an og image successfully", async ({ page }) => {
+  const res = await page.request.get("/og");
+  expect(res.status()).toEqual(200);
+  expect(res.headers()["content-type"]).toEqual("image/png");
+});

--- a/packages/cloudflare/src/cli/build/bundle-server.ts
+++ b/packages/cloudflare/src/cli/build/bundle-server.ts
@@ -176,7 +176,7 @@ async function updateWorkerBundledCode(workerOutputFile: string, buildOpts: Buil
 
   const bundle = parse(Lang.TypeScript, patchedCode).root();
 
-  const edits = patchOptionalDependencies(bundle);
+  const { edits } = patchOptionalDependencies(bundle);
 
   await writeFile(workerOutputFile, bundle.commitEdits(edits));
 }

--- a/packages/cloudflare/src/cli/build/bundle-server.ts
+++ b/packages/cloudflare/src/cli/build/bundle-server.ts
@@ -34,7 +34,7 @@ export async function bundleServer(buildOpts: BuildOptions): Promise<void> {
 
   patches.patchWranglerDeps(buildOpts);
   await patches.updateWebpackChunksFile(buildOpts);
-  await patches.patchVercelOgLibrary(buildOpts);
+  patches.patchVercelOgLibrary(buildOpts);
 
   const outputPath = path.join(outputDir, "server-functions", "default");
   const packagePath = getPackagePath(buildOpts);

--- a/packages/cloudflare/src/cli/build/bundle-server.ts
+++ b/packages/cloudflare/src/cli/build/bundle-server.ts
@@ -33,7 +33,8 @@ export async function bundleServer(buildOpts: BuildOptions): Promise<void> {
   console.log(`\x1b[35m⚙️ Bundling the OpenNext server...\n\x1b[0m`);
 
   patches.patchWranglerDeps(buildOpts);
-  patches.updateWebpackChunksFile(buildOpts);
+  await patches.updateWebpackChunksFile(buildOpts);
+  await patches.patchVercelOgLibrary(buildOpts);
 
   const outputPath = path.join(outputDir, "server-functions", "default");
   const packagePath = getPackagePath(buildOpts);

--- a/packages/cloudflare/src/cli/build/patches/ast/optional-deps.ts
+++ b/packages/cloudflare/src/cli/build/patches/ast/optional-deps.ts
@@ -1,6 +1,6 @@
 import { type SgNode } from "@ast-grep/napi";
 
-import { getRuleEdits } from "./util.js";
+import { applyRule } from "./util.js";
 
 /**
  * Handle optional dependencies.
@@ -31,5 +31,5 @@ fix: |-
 `;
 
 export function patchOptionalDependencies(root: SgNode) {
-  return getRuleEdits(optionalDepRule, root);
+  return applyRule(optionalDepRule, root);
 }

--- a/packages/cloudflare/src/cli/build/patches/ast/util.ts
+++ b/packages/cloudflare/src/cli/build/patches/ast/util.ts
@@ -8,7 +8,7 @@ import yaml from "yaml";
 export type RuleConfig = NapiConfig & { fix?: string };
 
 /**
- * Returns the `Edit`s for an ast-grep rule in yaml format
+ * Returns the `Edit`s and `Match`es for an ast-grep rule in yaml format
  *
  * The rule must have a `fix` to rewrite the matched node.
  *
@@ -17,9 +17,9 @@ export type RuleConfig = NapiConfig & { fix?: string };
  * @param rule The rule. Either a yaml string or an instance of `RuleConfig`
  * @param root The root node
  * @param once only apply once
- * @returns A list of edits.
+ * @returns A list of edits and a list of matches.
  */
-export function getRuleEdits(rule: string | RuleConfig, root: SgNode, { once = false } = {}) {
+export function applyRule(rule: string | RuleConfig, root: SgNode, { once = false } = {}) {
   const ruleConfig: RuleConfig = typeof rule === "string" ? yaml.parse(rule) : rule;
   if (ruleConfig.transform) {
     throw new Error("transform is not supported");
@@ -50,7 +50,7 @@ export function getRuleEdits(rule: string | RuleConfig, root: SgNode, { once = f
     );
   });
 
-  return edits;
+  return { edits, matches };
 }
 
 /**
@@ -71,6 +71,6 @@ export function patchCode(
   { lang = Lang.TypeScript, once = false } = {}
 ): string {
   const node = parse(lang, code).root();
-  const edits = getRuleEdits(rule, node, { once });
+  const { edits } = applyRule(rule, node, { once });
   return node.commitEdits(edits);
 }

--- a/packages/cloudflare/src/cli/build/patches/ast/util.ts
+++ b/packages/cloudflare/src/cli/build/patches/ast/util.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+
 import { type Edit, Lang, type NapiConfig, parse, type SgNode } from "@ast-grep/napi";
 import yaml from "yaml";
 
@@ -51,6 +53,17 @@ export function applyRule(rule: string | RuleConfig, root: SgNode, { once = fals
   });
 
   return { edits, matches };
+}
+
+/**
+ * Parse a file and obtain its root.
+ *
+ * @param path The file path
+ * @param lang The language to parse. Defaults to TypeScript.
+ * @returns The root for the file.
+ */
+export function parseFile(path: string, lang = Lang.TypeScript) {
+  return parse(lang, readFileSync(path, { encoding: "utf-8" })).root();
 }
 
 /**

--- a/packages/cloudflare/src/cli/build/patches/ast/vercel-og.spec.ts
+++ b/packages/cloudflare/src/cli/build/patches/ast/vercel-og.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { patchCode } from "./util";
+import { vercelOgFallbackFontRule, vercelOgImportRule } from "./vercel-og";
+
+describe("vercelOgImportRule", () => {
+  it("should rewrite a node import to an edge import", () => {
+    const code = `e.exports=import("next/dist/compiled/@vercel/og/index.node.js")`;
+    expect(patchCode(code, vercelOgImportRule)).toMatchInlineSnapshot(
+      `"e.exports=import("next/dist/compiled/@vercel/og/index.edge.js")"`
+    );
+  });
+});
+
+describe("vercelOgFallbackFontRule", () => {
+  it("should replace a fetch call for a font with an import", () => {
+    const code = `var fallbackFont = fetch(new URL("./noto-sans-v27-latin-regular.ttf", import.meta.url)).then((res) => res.arrayBuffer());`;
+    expect(patchCode(code, vercelOgFallbackFontRule)).toMatchInlineSnapshot(`
+      "async function getFallbackFont() {
+        return (await import("./noto-sans-v27-latin-regular.ttf.bin")).default
+      }
+
+      var fallbackFont = getFallbackFont()"
+    `);
+  });
+});

--- a/packages/cloudflare/src/cli/build/patches/ast/vercel-og.spec.ts
+++ b/packages/cloudflare/src/cli/build/patches/ast/vercel-og.spec.ts
@@ -17,10 +17,11 @@ describe("vercelOgFallbackFontRule", () => {
     const code = `var fallbackFont = fetch(new URL("./noto-sans-v27-latin-regular.ttf", import.meta.url)).then((res) => res.arrayBuffer());`;
     expect(patchCode(code, vercelOgFallbackFontRule)).toMatchInlineSnapshot(`
       "async function getFallbackFont() {
-        return (await import("./noto-sans-v27-latin-regular.ttf.bin")).default
+        // .bin is used so that a loader does not need to be configured for .ttf files
+        return (await import("./noto-sans-v27-latin-regular.ttf.bin")).default;
       }
 
-      var fallbackFont = getFallbackFont()"
+      var fallbackFont = getFallbackFont();"
     `);
   });
 });

--- a/packages/cloudflare/src/cli/build/patches/ast/vercel-og.ts
+++ b/packages/cloudflare/src/cli/build/patches/ast/vercel-og.ts
@@ -1,0 +1,51 @@
+import { SgNode } from "@ast-grep/napi";
+
+import { applyRule } from "./util.js";
+
+export const vercelOgImportRule = `
+rule:
+  pattern: $NODE
+  kind: string
+  regex: "next/dist/compiled/@vercel/og/index.node.js"
+inside:
+  kind: arguments
+  inside:
+    kind: call_expression
+    stopBy: end
+    has:
+      field: function
+      regex: "import"
+
+fix: |-
+  "next/dist/compiled/@vercel/og/index.edge.js"
+`;
+
+export function patchVercelOgImport(root: SgNode) {
+  return applyRule(vercelOgImportRule, root);
+}
+
+export const vercelOgFallbackFontRule = `
+rule:
+  kind: variable_declaration
+  all:
+    - has:
+        kind: variable_declarator
+        has:
+          kind: identifier
+          regex: ^fallbackFont$
+    - has:
+        kind: call_expression
+        pattern: fetch(new URL("$PATH", $$$REST))
+        stopBy: end
+
+fix: |-
+  async function getFallbackFont() {
+    return (await import("$PATH.bin")).default
+  }
+
+  var fallbackFont = getFallbackFont()
+`;
+
+export function patchVercelOgFallbackFont(root: SgNode) {
+  return applyRule(vercelOgFallbackFontRule, root);
+}

--- a/packages/cloudflare/src/cli/build/patches/ast/vercel-og.ts
+++ b/packages/cloudflare/src/cli/build/patches/ast/vercel-og.ts
@@ -20,6 +20,12 @@ fix: |-
   "next/dist/compiled/@vercel/og/index.edge.js"
 `;
 
+/**
+ * Patches Node.js imports for the library to be Edge imports.
+ *
+ * @param root Root node.
+ * @returns Results of applying the rule.
+ */
 export function patchVercelOgImport(root: SgNode) {
   return applyRule(vercelOgImportRule, root);
 }
@@ -46,6 +52,12 @@ fix: |-
   var fallbackFont = getFallbackFont()
 `;
 
+/**
+ * Patches the default font fetching to use a .bin import.
+ *
+ * @param root Root node.
+ * @returns Results of applying the rule.
+ */
 export function patchVercelOgFallbackFont(root: SgNode) {
   return applyRule(vercelOgFallbackFontRule, root);
 }

--- a/packages/cloudflare/src/cli/build/patches/ast/vercel-og.ts
+++ b/packages/cloudflare/src/cli/build/patches/ast/vercel-og.ts
@@ -6,7 +6,7 @@ export const vercelOgImportRule = `
 rule:
   pattern: $NODE
   kind: string
-  regex: "next/dist/compiled/@vercel/og/index.node.js"
+  regex: "next/dist/compiled/@vercel/og/index\\\\.node\\\\.js"
 inside:
   kind: arguments
   inside:

--- a/packages/cloudflare/src/cli/build/patches/ast/vercel-og.ts
+++ b/packages/cloudflare/src/cli/build/patches/ast/vercel-og.ts
@@ -46,10 +46,11 @@ rule:
 
 fix: |-
   async function getFallbackFont() {
-    return (await import("$PATH.bin")).default
+    // .bin is used so that a loader does not need to be configured for .ttf files
+    return (await import("$PATH.bin")).default;
   }
 
-  var fallbackFont = getFallbackFont()
+  var fallbackFont = getFallbackFont();
 `;
 
 /**

--- a/packages/cloudflare/src/cli/build/patches/investigated/index.ts
+++ b/packages/cloudflare/src/cli/build/patches/investigated/index.ts
@@ -1,4 +1,5 @@
 export * from "./copy-package-cli-files.js";
 export * from "./patch-cache.js";
 export * from "./patch-require.js";
+export * from "./patch-vercel-og-library.js";
 export * from "./update-webpack-chunks-file/index.js";

--- a/packages/cloudflare/src/cli/build/patches/investigated/patch-vercel-og-library.spec.ts
+++ b/packages/cloudflare/src/cli/build/patches/investigated/patch-vercel-og-library.spec.ts
@@ -1,0 +1,69 @@
+import { mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+import { BuildOptions } from "@opennextjs/aws/build/helper.js";
+import mockFs from "mock-fs";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { patchVercelOgLibrary } from "./patch-vercel-og-library";
+
+const nodeModulesVercelOgDir = "node_modules/.pnpm/next@14.2.11/node_modules/next/dist/compiled/@vercel/og";
+const nextServerOgNftPath = "examples/api/.next/server/app/og/route.js.nft.json";
+const openNextFunctionDir = "examples/api/.open-next/server-functions/default/examples/api";
+const openNextOgRoutePath = path.join(openNextFunctionDir, ".next/server/app/og/route.js");
+const openNextVercelOgDir = path.join(openNextFunctionDir, "node_modules/next/dist/compiled/@vercel/og");
+
+const buildOpts = {
+  appBuildOutputPath: "examples/api",
+  monorepoRoot: "",
+  outputDir: "examples/api/.open-next",
+} as BuildOptions;
+
+describe("patchVercelOgLibrary", () => {
+  beforeAll(() => {
+    mockFs();
+
+    mkdirSync(nodeModulesVercelOgDir, { recursive: true });
+    mkdirSync(path.dirname(nextServerOgNftPath), { recursive: true });
+    mkdirSync(path.dirname(openNextOgRoutePath), { recursive: true });
+    mkdirSync(openNextVercelOgDir, { recursive: true });
+
+    writeFileSync(
+      nextServerOgNftPath,
+      JSON.stringify({ version: 1, files: [`../../../../../../${nodeModulesVercelOgDir}/index.node.js`] })
+    );
+    writeFileSync(
+      path.join(nodeModulesVercelOgDir, "index.edge.js"),
+      `var fallbackFont = fetch(new URL("./noto-sans-v27-latin-regular.ttf", import.meta.url)).then((res) => res.arrayBuffer());`
+    );
+    writeFileSync(openNextOgRoutePath, `e.exports=import("next/dist/compiled/@vercel/og/index.node.js")`);
+    writeFileSync(path.join(openNextVercelOgDir, "index.node.js"), "");
+    writeFileSync(path.join(openNextVercelOgDir, "noto-sans-v27-latin-regular.ttf"), "");
+  });
+
+  afterAll(() => mockFs.restore());
+
+  it("should patch the open-next files correctly", () => {
+    patchVercelOgLibrary(buildOpts);
+
+    expect(readdirSync(openNextVercelOgDir)).toMatchInlineSnapshot(`
+      [
+        "index.edge.js",
+        "noto-sans-v27-latin-regular.ttf.bin",
+      ]
+    `);
+
+    expect(readFileSync(path.join(openNextVercelOgDir, "index.edge.js"), { encoding: "utf-8" }))
+      .toMatchInlineSnapshot(`
+      "async function getFallbackFont() {
+        return (await import("./noto-sans-v27-latin-regular.ttf.bin")).default
+      }
+
+      var fallbackFont = getFallbackFont()"
+    `);
+
+    expect(readFileSync(openNextOgRoutePath, { encoding: "utf-8" })).toMatchInlineSnapshot(
+      `"e.exports=import("next/dist/compiled/@vercel/og/index.edge.js")"`
+    );
+  });
+});

--- a/packages/cloudflare/src/cli/build/patches/investigated/patch-vercel-og-library.spec.ts
+++ b/packages/cloudflare/src/cli/build/patches/investigated/patch-vercel-og-library.spec.ts
@@ -49,6 +49,7 @@ describe("patchVercelOgLibrary", () => {
     expect(readdirSync(openNextVercelOgDir)).toMatchInlineSnapshot(`
       [
         "index.edge.js",
+        "index.node.js",
         "noto-sans-v27-latin-regular.ttf.bin",
       ]
     `);

--- a/packages/cloudflare/src/cli/build/patches/investigated/patch-vercel-og-library.spec.ts
+++ b/packages/cloudflare/src/cli/build/patches/investigated/patch-vercel-og-library.spec.ts
@@ -57,10 +57,11 @@ describe("patchVercelOgLibrary", () => {
     expect(readFileSync(path.join(openNextVercelOgDir, "index.edge.js"), { encoding: "utf-8" }))
       .toMatchInlineSnapshot(`
       "async function getFallbackFont() {
-        return (await import("./noto-sans-v27-latin-regular.ttf.bin")).default
+        // .bin is used so that a loader does not need to be configured for .ttf files
+        return (await import("./noto-sans-v27-latin-regular.ttf.bin")).default;
       }
 
-      var fallbackFont = getFallbackFont()"
+      var fallbackFont = getFallbackFont();"
     `);
 
     expect(readFileSync(openNextOgRoutePath, { encoding: "utf-8" })).toMatchInlineSnapshot(

--- a/packages/cloudflare/src/cli/build/patches/investigated/patch-vercel-og-library.ts
+++ b/packages/cloudflare/src/cli/build/patches/investigated/patch-vercel-og-library.ts
@@ -10,6 +10,16 @@ import { patchVercelOgFallbackFont, patchVercelOgImport } from "../ast/vercel-og
 
 type TraceInfo = { version: number; files: string[] };
 
+/**
+ * Patches the usage of @vercel/og to be compatible with Cloudflare Workers.
+ *
+ * This involves;
+ * - Ensuring the edge version is available in the OpenNext node_modules.
+ * - Changing node imports for the library to edge imports.
+ * - Changing font fetches in the library to use .bin imports.
+ *
+ * @param buildOpts Build options.
+ */
 export function patchVercelOgLibrary(buildOpts: BuildOptions) {
   const { appBuildOutputPath, outputDir } = buildOpts;
 

--- a/packages/cloudflare/src/cli/build/patches/investigated/patch-vercel-og-library.ts
+++ b/packages/cloudflare/src/cli/build/patches/investigated/patch-vercel-og-library.ts
@@ -1,0 +1,50 @@
+import { copyFileSync, existsSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+import type { BuildOptions } from "@opennextjs/aws/build/helper.js";
+import { getPackagePath } from "@opennextjs/aws/build/helper.js";
+import { globSync } from "glob";
+
+import { parseFile } from "../ast/util.js";
+import { patchVercelOgFallbackFont, patchVercelOgImport } from "../ast/vercel-og.js";
+
+type TraceInfo = { version: number; files: string[] };
+
+export function patchVercelOgLibrary(buildOpts: BuildOptions) {
+  const { appBuildOutputPath, outputDir } = buildOpts;
+
+  const packagePath = path.join(outputDir, "server-functions/default", getPackagePath(buildOpts));
+
+  for (const traceInfoPath of globSync(path.join(appBuildOutputPath, ".next/server/**/*.nft.json"))) {
+    const traceInfo: TraceInfo = JSON.parse(readFileSync(traceInfoPath, { encoding: "utf8" }));
+    const tracedNodePath = traceInfo.files.find((p) => p.endsWith("@vercel/og/index.node.js"));
+
+    if (!tracedNodePath) continue;
+
+    const outputDir = path.join(packagePath, "node_modules/next/dist/compiled/@vercel/og");
+    const outputEdgePath = path.join(outputDir, "index.edge.js");
+
+    if (!existsSync(outputEdgePath)) {
+      const tracedEdgePath = path.join(
+        path.dirname(traceInfoPath),
+        tracedNodePath.replace("index.node.js", "index.edge.js")
+      );
+
+      copyFileSync(tracedEdgePath, outputEdgePath);
+      rmSync(outputEdgePath.replace("index.edge.js", "index.node.js"));
+
+      const node = parseFile(outputEdgePath);
+      const { edits, matches } = patchVercelOgFallbackFont(node);
+      writeFileSync(outputEdgePath, node.commitEdits(edits));
+
+      const fontFileName = matches[0]!.getMatch("PATH")!.text();
+      renameSync(path.join(outputDir, fontFileName), path.join(outputDir, `${fontFileName}.bin`));
+    }
+
+    const routeFilePath = traceInfoPath.replace(appBuildOutputPath, packagePath).replace(".nft.json", "");
+
+    const node = parseFile(routeFilePath);
+    const { edits } = patchVercelOgImport(node);
+    writeFileSync(routeFilePath, node.commitEdits(edits));
+  }
+}


### PR DESCRIPTION
PR is based off of #282 and should not be merged before that one.

This PR does the following:
- Changes the function for getting rule edits to also enable returning matches.
- Patches the import of `index.node.js` to `index.edge.js`.
- Patches the fallback font fetch to use an import.
- Renames the fallback font to be suffixed with `.bin`.
- Copies the edge version to the OpenNext `node_modules`.
- Unit tests + e2e test.

Might be worth noting that the edge runtime version is only available in the node_modules location referenced by the traced files in .next/server, and not .next/standalone. So we need to use that output to get the edge file and work our way back up to node_modules, and bring that over the right place for the standalone build in our output.

Not sure if this approach is entirely what you had in mind.
