### PR TITLE
enable `e2e/app-router` tests to run in CI

### DIFF
--- a/examples/e2e/app-router/e2e/after.test.ts
+++ b/examples/e2e/app-router/e2e/after.test.ts
@@ -1,6 +1,8 @@
 import { expect, test } from "@playwright/test";
 
-test("Next after", async ({ request }) => {
+// Cache is currently not supported: https://github.com/opennextjs/opennextjs-cloudflare/issues/105
+// (Note: specifically this test relied on `unstable_cache`: https://github.com/opennextjs/opennextjs-cloudflare/issues/105#issuecomment-2627074820)
+test.skip("Next after", async ({ request }) => {
   const initialSSG = await request.get("/api/after/ssg");
   expect(initialSSG.status()).toEqual(200);
   const initialSSGJson = await initialSSG.json();

--- a/examples/e2e/app-router/e2e/host.test.ts
+++ b/examples/e2e/app-router/e2e/host.test.ts
@@ -2,8 +2,11 @@ import { expect, test } from "@playwright/test";
 
 /**
  * Tests that the request.url is the deployed host and not localhost
+ *
+ * This test is skipped since e2e tests for the cloudflare adapter
+ * run only locally to the baseURL doesn't match
  */
-test("Request.url is host", async ({ baseURL, page }) => {
+test.skip("Request.url is host", async ({ baseURL, page }) => {
   await page.goto("/api/host");
 
   const el = page.getByText(`{"url":"${baseURL}/api/host"}`);

--- a/examples/e2e/app-router/e2e/image-optimization.test.ts
+++ b/examples/e2e/app-router/e2e/image-optimization.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 
-test("Image Optimization", async ({ page }) => {
+// Image Optimization is currently not supported: https://github.com/opennextjs/opennextjs-cloudflare/issues/106
+test.skip("Image Optimization", async ({ page }) => {
   await page.goto("/");
 
   const imageResponsePromise = page.waitForResponse(/https%3A%2F%2Fopennext.js.org%2Farchitecture.png/);

--- a/examples/e2e/app-router/e2e/isr.revalidate.test.ts
+++ b/examples/e2e/app-router/e2e/isr.revalidate.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 
-test("Test revalidate", async ({ request }) => {
+// Cache (and revalidation) is currently not supported: https://github.com/opennextjs/opennextjs-cloudflare/issues/105
+test.skip("Test revalidate", async ({ request }) => {
   const result = await request.get("/api/isr");
 
   expect(result.status()).toEqual(200);

--- a/examples/e2e/app-router/e2e/isr.test.ts
+++ b/examples/e2e/app-router/e2e/isr.test.ts
@@ -41,7 +41,8 @@ test.skip("Incremental Static Regeneration", async ({ page }) => {
   expect(newTime).not.toEqual(finalTime);
 });
 
-test("headers", async ({ page }) => {
+// ISR is currently not supported: https://github.com/opennextjs/opennextjs-cloudflare/issues/105
+test.skip("headers", async ({ page }) => {
   let responsePromise = page.waitForResponse((response) => {
     return response.status() === 200;
   });

--- a/examples/e2e/app-router/e2e/isr.test.ts
+++ b/examples/e2e/app-router/e2e/isr.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 
-test("Incremental Static Regeneration", async ({ page }) => {
+// ISR is currently not supported: https://github.com/opennextjs/opennextjs-cloudflare/issues/105
+test.skip("Incremental Static Regeneration", async ({ page }) => {
   test.setTimeout(45000);
   await page.goto("/");
   await page.locator("[href='/isr']").click();

--- a/examples/e2e/app-router/e2e/revalidateTag.test.ts
+++ b/examples/e2e/app-router/e2e/revalidateTag.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 
-test("Revalidate tag", async ({ page, request }) => {
+// Cache (and revalidateTag) is currently not supported: https://github.com/opennextjs/opennextjs-cloudflare/issues/105
+test.skip("Revalidate tag", async ({ page, request }) => {
   test.setTimeout(45000);
   // We need to hit the page twice to make sure it's properly cached
   // Turbo might cache next build result, resulting in the tag being newer than the page
@@ -68,7 +69,8 @@ test("Revalidate tag", async ({ page, request }) => {
   expect(nextCacheHeaderNested).toEqual("HIT");
 });
 
-test("Revalidate path", async ({ page, request }) => {
+// Cache (and revalidatePath) is currently not supported: https://github.com/opennextjs/opennextjs-cloudflare/issues/105
+test.skip("Revalidate path", async ({ page, request }) => {
   await page.goto("/revalidate-path");
 
   let elLayout = page.getByText("RequestID:");

--- a/examples/e2e/app-router/e2e/ssr.test.ts
+++ b/examples/e2e/app-router/e2e/ssr.test.ts
@@ -28,8 +28,7 @@ test.skip("Server Side Render and loading.tsx", async ({ page }) => {
   }
 });
 
-// Fetch caching doesn't currently work: https://github.com/opennextjs/opennextjs-cloudflare/issues/311
-test.skip("Fetch cache properly cached", async ({ page }) => {
+test("Fetch cache properly cached", async ({ page }) => {
   await page.goto("/ssr");
   const originalDate = await page.getByText("Cached fetch:").textContent();
   await page.waitForTimeout(2000);

--- a/examples/e2e/app-router/e2e/ssr.test.ts
+++ b/examples/e2e/app-router/e2e/ssr.test.ts
@@ -4,7 +4,8 @@
 import { expect, test } from "@playwright/test";
 
 // NOTE: We don't await page load b/c we want to see the Loading page
-test("Server Side Render and loading.tsx", async ({ page }) => {
+// loading.tsx doesn't currently work: https://github.com/opennextjs/opennextjs-cloudflare/issues/313
+test.skip("Server Side Render and loading.tsx", async ({ page }) => {
   test.setTimeout(600000);
   await page.goto("/");
   await page.getByRole("link", { name: "SSR" }).click();
@@ -27,7 +28,8 @@ test("Server Side Render and loading.tsx", async ({ page }) => {
   }
 });
 
-test("Fetch cache properly cached", async ({ page }) => {
+// Fetch caching doesn't currently work: https://github.com/opennextjs/opennextjs-cloudflare/issues/311
+test.skip("Fetch cache properly cached", async ({ page }) => {
   await page.goto("/ssr");
   const originalDate = await page.getByText("Cached fetch:").textContent();
   await page.waitForTimeout(2000);

--- a/examples/e2e/app-router/e2e/trailing.test.ts
+++ b/examples/e2e/app-router/e2e/trailing.test.ts
@@ -1,13 +1,15 @@
 import { expect, test } from "@playwright/test";
 
-test("trailingSlash redirect", async ({ page }) => {
+// trailingSlash redirecting doesn't work: https://github.com/opennextjs/opennextjs-cloudflare/issues/312
+test.skip("trailingSlash redirect", async ({ page }) => {
   const response = await page.goto("/ssr/");
 
   expect(response?.request().redirectedFrom()?.url()).toMatch(/\/ssr\/$/);
   expect(response?.request().url()).toMatch(/\/ssr$/);
 });
 
-test("trailingSlash redirect with search parameters", async ({ page }) => {
+// trailingSlash redirecting doesn't work: https://github.com/opennextjs/opennextjs-cloudflare/issues/312
+test.skip("trailingSlash redirect with search parameters", async ({ page }) => {
   const response = await page.goto("/ssr/?happy=true");
 
   expect(response?.request().redirectedFrom()?.url()).toMatch(/\/ssr\/\?happy=true$/);

--- a/examples/e2e/app-router/open-next.config.ts
+++ b/examples/e2e/app-router/open-next.config.ts
@@ -1,12 +1,12 @@
 import type { OpenNextConfig } from "@opennextjs/aws/types/open-next.js";
+import cache from "@opennextjs/cloudflare/kvCache";
 
 const config: OpenNextConfig = {
   default: {
     override: {
       wrapper: "cloudflare-node",
       converter: "edge",
-      // Unused implementation
-      incrementalCache: "dummy",
+      incrementalCache: async () => cache,
       tagCache: "dummy",
       queue: "dummy",
     },

--- a/examples/e2e/app-router/package.json
+++ b/examples/e2e/app-router/package.json
@@ -12,7 +12,7 @@
     "build:worker": "pnpm opennextjs-cloudflare",
     "dev:worker": "wrangler dev --port 8790 --inspector-port 9350",
     "preview": "pnpm build:worker && pnpm dev:worker",
-    "e2e-fix": "playwright test -c e2e/playwright.config.ts"
+    "e2e": "playwright test -c e2e/playwright.config.ts"
   },
   "dependencies": {
     "@opennextjs/cloudflare": "workspace:*",

--- a/examples/e2e/app-router/wrangler.json
+++ b/examples/e2e/app-router/wrangler.json
@@ -7,5 +7,11 @@
   "assets": {
     "directory": ".open-next/assets",
     "binding": "ASSETS"
-  }
+  },
+  "kv_namespaces": [
+    {
+      "binding": "NEXT_CACHE_WORKERS_KV",
+      "id": "<BINDING_ID>"
+    }
+  ]
 }


### PR DESCRIPTION
this change renames the `e2e-fix` script of the `e2e/app-router` app to just `e2e` so that it is included as part of our CI checks, in order for it not to fail some tests have been skipped (with appropriate comments explain why)

__

Part of #291 