### PR TITLE
enable e2e/app-pages-router tests to run in CI

### DIFF
--- a/examples/e2e/app-pages-router/e2e/host.test.ts
+++ b/examples/e2e/app-pages-router/e2e/host.test.ts
@@ -2,8 +2,11 @@ import { expect, test } from "@playwright/test";
 
 /**
  * Tests that the request.url is the deployed host and not localhost
+ *
+ * This test is skipped since e2e tests for the cloudflare adapter
+ * run only locally to the baseURL doesn't match
  */
-test("Request.url is host", async ({ baseURL, page }) => {
+test.skip("Request.url is host", async ({ baseURL, page }) => {
   await page.goto("/api/host");
 
   const el = page.getByText(`{"url":"${baseURL}/api/host"}`);

--- a/examples/e2e/app-pages-router/e2e/image-optimization.test.ts
+++ b/examples/e2e/app-pages-router/e2e/image-optimization.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 
-test("Image Optimization", async ({ page }) => {
+// Image Optimization is currently not supported: https://github.com/opennextjs/opennextjs-cloudflare/issues/106
+test.skip("Image Optimization", async ({ page }) => {
   await page.goto("/");
 
   const imageResponsePromise = page.waitForResponse(/corporate_holiday_card.jpg/);

--- a/examples/e2e/app-pages-router/e2e/isr.test.ts
+++ b/examples/e2e/app-pages-router/e2e/isr.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 
-test("Incremental Static Regeneration", async ({ page }) => {
+// ISR is currently not supported: https://github.com/opennextjs/opennextjs-cloudflare/issues/105
+test.skip("Incremental Static Regeneration", async ({ page }) => {
   test.setTimeout(60000);
   await page.goto("/");
   await page.locator('[href="/isr"]').click();

--- a/examples/e2e/app-pages-router/e2e/pages_isr.test.ts
+++ b/examples/e2e/app-pages-router/e2e/pages_isr.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 
-test("Incremental Static Regeneration", async ({ page }) => {
+// ISR is currently not supported: https://github.com/opennextjs/opennextjs-cloudflare/issues/105
+test.skip("Incremental Static Regeneration", async ({ page }) => {
   test.setTimeout(60000);
   await page.goto("/");
   await page.locator('[href="/pages_isr"]').click();

--- a/examples/e2e/app-pages-router/package.json
+++ b/examples/e2e/app-pages-router/package.json
@@ -12,7 +12,7 @@
     "build:worker": "pnpm opennextjs-cloudflare",
     "dev:worker": "wrangler dev --port 8792 --inspector-port 9352",
     "preview": "pnpm build:worker && pnpm dev:worker",
-    "e2e-fix": "playwright test -c e2e/playwright.config.ts"
+    "e2e": "playwright test -c e2e/playwright.config.ts"
   },
   "dependencies": {
     "@opennextjs/cloudflare": "workspace:*",


### PR DESCRIPTION
this change renames the `e2e-fix` script of the `e2e/app-pages-router` app to just `e2e` so that it is included as part of our CI checks, in order for it not to fail some tests have been skipped (with appropriate comments explain why)

____


Part of #291 