### PR TITLE
enable e2e/pages-router tests to run in CI

### DIFF
--- a/examples/e2e/pages-router/e2e/isr.test.ts
+++ b/examples/e2e/pages-router/e2e/isr.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 
-test("Incremental Static Regeneration", async ({ page }) => {
+// ISR is currently not supported: https://github.com/opennextjs/opennextjs-cloudflare/issues/105
+test.skip("Incremental Static Regeneration", async ({ page }) => {
   test.setTimeout(45000);
   await page.goto("/");
   await page.locator("[href='/isr/']").click();

--- a/examples/e2e/pages-router/next.config.ts
+++ b/examples/e2e/pages-router/next.config.ts
@@ -43,7 +43,7 @@ const nextConfig: NextConfig = {
     },
     {
       source: "/external-on-image",
-      destination: "https://opennext.js.org/share.png",
+      destination: "https://raw.githubusercontent.com/opennextjs/docs/refs/heads/main/public/share.png",
     },
   ],
   redirects: async () => [

--- a/examples/e2e/pages-router/package.json
+++ b/examples/e2e/pages-router/package.json
@@ -12,7 +12,7 @@
     "build:worker": "pnpm opennextjs-cloudflare",
     "dev:worker": "wrangler dev --port 8791 --inspector-port 9351",
     "preview": "pnpm build:worker && pnpm dev:worker",
-    "e2e-fix": "playwright test -c e2e/playwright.config.ts"
+    "e2e": "playwright test -c e2e/playwright.config.ts"
   },
   "dependencies": {
     "@opennextjs/cloudflare": "workspace:*",


### PR DESCRIPTION
this change renames the `e2e` script of the `e2e/pages-router` app to just `e2e` so that it is included as part of our CI checks, in order for it not to fail one test has been skipped (with an appropriate comment explain why)

___

related to https://github.com/opennextjs/opennextjs-cloudflare/issues/291