### PR TITLE
refactor: Next env loading

### DIFF
--- a/packages/cloudflare/env.d.ts
+++ b/packages/cloudflare/env.d.ts
@@ -7,8 +7,6 @@ declare global {
       NEXT_PRIVATE_DEBUG_CACHE?: string;
       OPEN_NEXT_ORIGIN: string;
       NODE_ENV?: string;
-      // Whether process.env has been populated (on first request).
-      __PROCESS_ENV_POPULATED?: string;
     }
   }
 }

--- a/packages/cloudflare/src/cli/build/open-next/compile-env-files.ts
+++ b/packages/cloudflare/src/cli/build/open-next/compile-env-files.ts
@@ -9,9 +9,11 @@ import { extractProjectEnvVars } from "../utils/index.js";
  * Compiles the values extracted from the project's env files to the output directory for use in the worker.
  */
 export function compileEnvFiles(buildOpts: BuildOptions) {
+  const envDir = path.join(buildOpts.outputDir, "env");
+  fs.mkdirSync(envDir, { recursive: true });
   ["production", "development", "test"].forEach((mode) =>
     fs.appendFileSync(
-      path.join(buildOpts.outputDir, `.env.mjs`),
+      path.join(envDir, `next-env.mjs`),
       `export const ${mode} = ${JSON.stringify(extractProjectEnvVars(mode, buildOpts))};\n`
     )
   );


### PR DESCRIPTION
- move the generated file to an env folder
- use a local variable to load once (vs a key of process.env)