### PR TITLE
fix: use intended asset cache dir

### DIFF
--- a/.changeset/curly-mice-agree.md
+++ b/.changeset/curly-mice-agree.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+Fix asset cache path

--- a/packages/cloudflare/src/api/kvCache.ts
+++ b/packages/cloudflare/src/api/kvCache.ts
@@ -3,7 +3,7 @@ import { IgnorableError, RecoverableError } from "@opennextjs/aws/utils/error.js
 
 import { getCloudflareContext } from "./cloudflare-context.js";
 
-export const CACHE_ASSET_DIR = "cnd-cgi/_next_cache";
+export const CACHE_ASSET_DIR = "cdn-cgi/_next_cache";
 
 export const STATUS_DELETED = 1;
 


### PR DESCRIPTION
Hi :wave:,

I noticed the typo during a build output, and I think this wanted to be the `cdn-cgi` special cf path.