### PR TITLE
fix:Crypto works under node18

### DIFF
--- a/.changeset/fifty-parrots-retire.md
+++ b/.changeset/fifty-parrots-retire.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+Crypto does not generate errors even when node version is less than 18.

--- a/.changeset/fifty-parrots-retire.md
+++ b/.changeset/fifty-parrots-retire.md
@@ -2,4 +2,4 @@
 "@opennextjs/cloudflare": patch
 ---
 
-Crypto does not generate errors even when node version is less than 18.
+import `randomUUID` from `node:crypto` to support NodeJS 18

--- a/packages/cloudflare/src/cli/utils/ask-confirmation.ts
+++ b/packages/cloudflare/src/cli/utils/ask-confirmation.ts
@@ -1,4 +1,3 @@
-// TODO: Drop this file when Node.js 18 is deprecated
 import { randomUUID } from "node:crypto";
 
 import Enquirer from "enquirer";

--- a/packages/cloudflare/src/cli/utils/ask-confirmation.ts
+++ b/packages/cloudflare/src/cli/utils/ask-confirmation.ts
@@ -1,7 +1,10 @@
+// TODO: Drop this file when Node.js 18 is deprecated
+import { randomUUID } from "node:crypto";
+
 import Enquirer from "enquirer";
 
 export async function askConfirmation(message: string): Promise<boolean> {
-  const questionName = crypto.randomUUID();
+  const questionName = randomUUID();
 
   const enquirerAnswersObject = await Enquirer.prompt<Record<string, boolean>>({
     name: questionName,


### PR DESCRIPTION
When using opennextjs-cloudflare under node18, I get the following error in “crypto”.
```
file:///home/nojiri/yourself-score/node_modules/@opennextjs/cloudflare/dist/cli/utils/ask-confirmation.js:3
    const questionName = crypto.randomUUUID();

ReferenceError: crypto is not defined
```
Until node@v18 is deprecated, we think it's ok to import.