### PR TITLE
fix:path to file template in open-next.config.ts

### DIFF
--- a/.changeset/selfish-bananas-nail.md
+++ b/.changeset/selfish-bananas-nail.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+fix path to file template in `open-next.config.ts`.

--- a/packages/cloudflare/src/utils/get-package-templates-dir-path.ts
+++ b/packages/cloudflare/src/utils/get-package-templates-dir-path.ts
@@ -1,7 +1,9 @@
-import * as path from "node:path";
+import path from "node:path";
+import url from "node:url";
 
-const __dirname = path.dirname(new URL(import.meta.url).pathname);
-const templatesDirPath = path.resolve(`${__dirname}/../../templates`);
+const __filename = url.fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const templatesDirPath = path.join(__dirname, "/../../templates");
 
 /**
  * Utility for getting the resolved path to the package's templates directory

--- a/packages/cloudflare/src/utils/get-package-templates-dir-path.ts
+++ b/packages/cloudflare/src/utils/get-package-templates-dir-path.ts
@@ -1,6 +1,7 @@
 import * as path from "node:path";
 
-const templatesDirPath = path.resolve(`${import.meta.dirname}/../../templates`);
+const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const templatesDirPath = path.resolve(`${__dirname}/../../templates`);
 
 /**
  * Utility for getting the resolved path to the package's templates directory


### PR DESCRIPTION
fix: #358

Make references to the template `open-next.config.ts` correct.