### PR TITLE
fix: vercel og patch not moving to right node_modules directory

### DIFF
--- a/.changeset/modern-dancers-rescue.md
+++ b/.changeset/modern-dancers-rescue.md
@@ -1,0 +1,7 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+fix: vercel og patch not moving to right node_modules directory
+
+There are two separate places where the node_modules could be. One is a package-scoped node_modules which does not always exist - if it doesn't exist, the server functions-scoped node_modules is used.

--- a/examples/next-partial-prerendering/next.config.js
+++ b/examples/next-partial-prerendering/next.config.js
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  typescript: { ignoreBuildErrors: true },
   experimental: {
     ppr: true,
   },

--- a/packages/cloudflare/src/cli/build/patches/ast/patch-vercel-og-library.ts
+++ b/packages/cloudflare/src/cli/build/patches/ast/patch-vercel-og-library.ts
@@ -10,6 +10,8 @@ import { patchVercelOgFallbackFont, patchVercelOgImport } from "./vercel-og.js";
 
 type TraceInfo = { version: number; files: string[] };
 
+const vercelOgNodeModulePath = "node_modules/next/dist/compiled/@vercel/og";
+
 /**
  * Patches the usage of @vercel/og to be compatible with Cloudflare Workers.
  *
@@ -18,7 +20,8 @@ type TraceInfo = { version: number; files: string[] };
 export function patchVercelOgLibrary(buildOpts: BuildOptions) {
   const { appBuildOutputPath, outputDir } = buildOpts;
 
-  const packagePath = path.join(outputDir, "server-functions/default", getPackagePath(buildOpts));
+  const functionsPath = path.join(outputDir, "server-functions/default");
+  const packagePath = path.join(functionsPath, getPackagePath(buildOpts));
 
   for (const traceInfoPath of globSync(path.join(appBuildOutputPath, ".next/server/**/*.nft.json"))) {
     const traceInfo: TraceInfo = JSON.parse(readFileSync(traceInfoPath, { encoding: "utf8" }));
@@ -26,7 +29,7 @@ export function patchVercelOgLibrary(buildOpts: BuildOptions) {
 
     if (!tracedNodePath) continue;
 
-    const outputDir = path.join(packagePath, "node_modules/next/dist/compiled/@vercel/og");
+    const outputDir = getOutputDir({ functionsPath, packagePath });
     const outputEdgePath = path.join(outputDir, "index.edge.js");
 
     // Ensure the edge version is available in the OpenNext node_modules.
@@ -54,4 +57,13 @@ export function patchVercelOgLibrary(buildOpts: BuildOptions) {
     const { edits } = patchVercelOgImport(node);
     writeFileSync(routeFilePath, node.commitEdits(edits));
   }
+}
+
+function getOutputDir(opts: { functionsPath: string; packagePath: string }) {
+  const packageOutputPath = path.join(opts.packagePath, vercelOgNodeModulePath);
+  if (existsSync(packageOutputPath)) {
+    return packageOutputPath;
+  }
+
+  return path.join(opts.functionsPath, vercelOgNodeModulePath);
 }

--- a/packages/cloudflare/src/cli/build/patches/ast/patch-vercel-og-library.ts
+++ b/packages/cloudflare/src/cli/build/patches/ast/patch-vercel-og-library.ts
@@ -10,8 +10,6 @@ import { patchVercelOgFallbackFont, patchVercelOgImport } from "./vercel-og.js";
 
 type TraceInfo = { version: number; files: string[] };
 
-const vercelOgNodeModulePath = "node_modules/next/dist/compiled/@vercel/og";
-
 /**
  * Patches the usage of @vercel/og to be compatible with Cloudflare Workers.
  *
@@ -60,6 +58,8 @@ export function patchVercelOgLibrary(buildOpts: BuildOptions) {
 }
 
 function getOutputDir(opts: { functionsPath: string; packagePath: string }) {
+  const vercelOgNodeModulePath = "node_modules/next/dist/compiled/@vercel/og";
+
   const packageOutputPath = path.join(opts.packagePath, vercelOgNodeModulePath);
   if (existsSync(packageOutputPath)) {
     return packageOutputPath;


### PR DESCRIPTION
fixes #376 

In some monorepo projects when running build there is a node_modules inside `server-functions` but not inside `server-functions/{projectPath}`.

This change to check for the existence of the package-scoped node_modules before choosing it over the non-package-scoped one.

Not quite sure how simple it would be to add an e2e for this because it's dependent on the monorepo structure and I believe it would be hit for us due to having multiple apps