### PR TITLE
chore: unskip more isr e2es

### DIFF
--- a/examples/e2e/app-pages-router/e2e/isr.test.ts
+++ b/examples/e2e/app-pages-router/e2e/isr.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 // ISR is currently not supported: https://github.com/opennextjs/opennextjs-cloudflare/issues/105
-test.skip("Incremental Static Regeneration", async ({ page }) => {
+test("Incremental Static Regeneration", async ({ page }) => {
   test.setTimeout(60000);
   await page.goto("/");
   await page.locator('[href="/isr"]').click();

--- a/examples/e2e/app-pages-router/e2e/pages_isr.test.ts
+++ b/examples/e2e/app-pages-router/e2e/pages_isr.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 // ISR is currently not supported: https://github.com/opennextjs/opennextjs-cloudflare/issues/105
-test.skip("Incremental Static Regeneration", async ({ page }) => {
+test("Incremental Static Regeneration", async ({ page }) => {
   test.setTimeout(60000);
   await page.goto("/");
   await page.locator('[href="/pages_isr"]').click();

--- a/examples/e2e/app-pages-router/open-next.config.ts
+++ b/examples/e2e/app-pages-router/open-next.config.ts
@@ -1,14 +1,16 @@
 import type { OpenNextConfig } from "@opennextjs/aws/types/open-next.js";
+import kvCache from "@opennextjs/cloudflare/kv-cache";
+import memoryQueue from "@opennextjs/cloudflare/memory-queue";
 
 const config: OpenNextConfig = {
   default: {
     override: {
       wrapper: "cloudflare-node",
       converter: "edge",
+      incrementalCache: () => kvCache,
+      queue: () => memoryQueue,
       // Unused implementation
-      incrementalCache: "dummy",
       tagCache: "dummy",
-      queue: "dummy",
     },
   },
 

--- a/examples/e2e/app-pages-router/wrangler.json
+++ b/examples/e2e/app-pages-router/wrangler.json
@@ -7,5 +7,11 @@
   "assets": {
     "directory": ".open-next/assets",
     "binding": "ASSETS"
-  }
+  },
+  "kv_namespaces": [
+    {
+      "binding": "NEXT_CACHE_WORKERS_KV",
+      "id": "<BINDING_ID>"
+    }
+  ]
 }

--- a/examples/e2e/pages-router/e2e/isr.test.ts
+++ b/examples/e2e/pages-router/e2e/isr.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 // ISR is currently not supported: https://github.com/opennextjs/opennextjs-cloudflare/issues/105
-test.skip("Incremental Static Regeneration", async ({ page }) => {
+test("Incremental Static Regeneration", async ({ page }) => {
   test.setTimeout(45000);
   await page.goto("/");
   await page.locator("[href='/isr/']").click();

--- a/examples/e2e/pages-router/open-next.config.ts
+++ b/examples/e2e/pages-router/open-next.config.ts
@@ -1,14 +1,16 @@
 import type { OpenNextConfig } from "@opennextjs/aws/types/open-next.js";
+import kvCache from "@opennextjs/cloudflare/kv-cache";
+import memoryQueue from "@opennextjs/cloudflare/memory-queue";
 
 const config: OpenNextConfig = {
   default: {
     override: {
       wrapper: "cloudflare-node",
       converter: "edge",
+      incrementalCache: () => kvCache,
+      queue: () => memoryQueue,
       // Unused implementation
-      incrementalCache: "dummy",
       tagCache: "dummy",
-      queue: "dummy",
     },
   },
 

--- a/examples/e2e/pages-router/wrangler.json
+++ b/examples/e2e/pages-router/wrangler.json
@@ -7,5 +7,11 @@
   "assets": {
     "directory": ".open-next/assets",
     "binding": "ASSETS"
-  }
+  },
+  "kv_namespaces": [
+    {
+      "binding": "NEXT_CACHE_WORKERS_KV",
+      "id": "<BINDING_ID>"
+    }
+  ]
 }


### PR DESCRIPTION
enable cache/queue and un`skip` passing tests