### PR TITLE
un-skip the ssr loading e2e test in the `app-router` app

### DIFF
--- a/examples/e2e/app-router/e2e/sse.test.ts
+++ b/examples/e2e/app-router/e2e/sse.test.ts
@@ -1,6 +1,3 @@
-// NOTE: loading.tsx is currently broken on open - next
-//  This works locally but not on deployed apps
-
 import { expect, test } from "@playwright/test";
 
 // NOTE: We don't await page load b/c we want to see the Loading page

--- a/examples/e2e/app-router/e2e/ssr.test.ts
+++ b/examples/e2e/app-router/e2e/ssr.test.ts
@@ -1,6 +1,3 @@
-// NOTE: loading.tsx is currently broken on open - next
-//  This works locally but not on deployed apps
-
 import { expect, test } from "@playwright/test";
 
 // NOTE: We don't await page load b/c we want to see the Loading page

--- a/examples/e2e/app-router/e2e/ssr.test.ts
+++ b/examples/e2e/app-router/e2e/ssr.test.ts
@@ -4,8 +4,7 @@
 import { expect, test } from "@playwright/test";
 
 // NOTE: We don't await page load b/c we want to see the Loading page
-// loading.tsx doesn't currently work: https://github.com/opennextjs/opennextjs-cloudflare/issues/313
-test.skip("Server Side Render and loading.tsx", async ({ page }) => {
+test("Server Side Render and loading.tsx", async ({ page }) => {
   test.setTimeout(600000);
   await page.goto("/");
   await page.getByRole("link", { name: "SSR" }).click();


### PR DESCRIPTION
I'm pretty sure I was getting this test failing both locally and in CI, but now everything seems to be working just fine... 🤔

_____

fixes #313 
