### PR TITLE
add `defineCloudflareConfig` utility

### DIFF
--- a/.changeset/cold-numbers-bow.md
+++ b/.changeset/cold-numbers-bow.md
@@ -1,0 +1,20 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+add `defineConfig` utility
+
+this change adds a new `defineConfig` utility that developers can use in their `open-next.config.ts`
+file to easily generate a configuration compatible with the adapter
+
+Example usage:
+
+```ts
+// open-next.config.ts
+import cache from "@opennextjs/cloudflare/kv-cache";
+import { defineConfig } from "@opennextjs/cloudflare/config";
+
+export default defineConfig({
+  incrementalCache: cache,
+});
+```

--- a/.changeset/cold-numbers-bow.md
+++ b/.changeset/cold-numbers-bow.md
@@ -2,9 +2,9 @@
 "@opennextjs/cloudflare": patch
 ---
 
-add `defineConfig` utility
+add `defineCloudflareConfig` utility
 
-this change adds a new `defineConfig` utility that developers can use in their `open-next.config.ts`
+this change adds a new `defineCloudflareConfig` utility that developers can use in their `open-next.config.ts`
 file to easily generate a configuration compatible with the adapter
 
 Example usage:
@@ -12,9 +12,9 @@ Example usage:
 ```ts
 // open-next.config.ts
 import cache from "@opennextjs/cloudflare/kv-cache";
-import { defineConfig } from "@opennextjs/cloudflare/config";
+import { defineCloudflareConfig } from "@opennextjs/cloudflare/config";
 
-export default defineConfig({
+export default defineCloudflareConfig({
   incrementalCache: cache,
 });
 ```

--- a/.changeset/cold-numbers-bow.md
+++ b/.changeset/cold-numbers-bow.md
@@ -11,8 +11,8 @@ Example usage:
 
 ```ts
 // open-next.config.ts
-import cache from "@opennextjs/cloudflare/kv-cache";
 import { defineCloudflareConfig } from "@opennextjs/cloudflare";
+import cache from "@opennextjs/cloudflare/kv-cache";
 
 export default defineCloudflareConfig({
   incrementalCache: cache,

--- a/.changeset/cold-numbers-bow.md
+++ b/.changeset/cold-numbers-bow.md
@@ -12,7 +12,7 @@ Example usage:
 ```ts
 // open-next.config.ts
 import cache from "@opennextjs/cloudflare/kv-cache";
-import { defineCloudflareConfig } from "@opennextjs/cloudflare/config";
+import { defineCloudflareConfig } from "@opennextjs/cloudflare";
 
 export default defineCloudflareConfig({
   incrementalCache: cache,

--- a/.changeset/cold-numbers-bow.md
+++ b/.changeset/cold-numbers-bow.md
@@ -12,9 +12,9 @@ Example usage:
 ```ts
 // open-next.config.ts
 import { defineCloudflareConfig } from "@opennextjs/cloudflare";
-import cache from "@opennextjs/cloudflare/kv-cache";
+import kvIncrementalCache from "@opennextjs/cloudflare/kv-cache";
 
 export default defineCloudflareConfig({
-  incrementalCache: cache,
+  incrementalCache: kvIncrementalCache,
 });
 ```

--- a/.changeset/lovely-bugs-flow.md
+++ b/.changeset/lovely-bugs-flow.md
@@ -1,5 +1,0 @@
----
-"@opennextjs/cloudflare": patch
----
-
-bump `@opennextjs/aws` dependency to `https://pkg.pr.new/@opennextjs/aws@755`

--- a/.changeset/lovely-bugs-flow.md
+++ b/.changeset/lovely-bugs-flow.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+bump `@opennextjs/aws` dependency to `https://pkg.pr.new/@opennextjs/aws@755`

--- a/examples/bugs/gh-119/open-next.config.ts
+++ b/examples/bugs/gh-119/open-next.config.ts
@@ -1,25 +1,3 @@
-import type { OpenNextConfig } from "@opennextjs/aws/types/open-next.js";
+import { defineConfig } from "@opennextjs/cloudflare/config";
 
-const config: OpenNextConfig = {
-  default: {
-    override: {
-      wrapper: "cloudflare-node",
-      converter: "edge",
-      // Unused implementation
-      incrementalCache: "dummy",
-      tagCache: "dummy",
-      queue: "dummy",
-    },
-  },
-
-  middleware: {
-    external: true,
-    override: {
-      wrapper: "cloudflare-edge",
-      converter: "edge",
-      proxyExternalRequest: "fetch",
-    },
-  },
-};
-
-export default config;
+export default defineConfig();

--- a/examples/bugs/gh-119/open-next.config.ts
+++ b/examples/bugs/gh-119/open-next.config.ts
@@ -1,3 +1,3 @@
-import { defineConfig } from "@opennextjs/cloudflare/config";
+import { defineCloudflareConfig } from "@opennextjs/cloudflare/config";
 
-export default defineConfig();
+export default defineCloudflareConfig();

--- a/examples/bugs/gh-119/open-next.config.ts
+++ b/examples/bugs/gh-119/open-next.config.ts
@@ -1,3 +1,3 @@
-import { defineCloudflareConfig } from "@opennextjs/cloudflare/config";
+import { defineCloudflareConfig } from "@opennextjs/cloudflare";
 
 export default defineCloudflareConfig();

--- a/examples/bugs/gh-219/open-next.config.ts
+++ b/examples/bugs/gh-219/open-next.config.ts
@@ -1,25 +1,3 @@
-import type { OpenNextConfig } from "@opennextjs/aws/types/open-next.js";
+import { defineConfig } from "@opennextjs/cloudflare/config";
 
-const config: OpenNextConfig = {
-  default: {
-    override: {
-      wrapper: "cloudflare-node",
-      converter: "edge",
-      // Unused implementation
-      incrementalCache: "dummy",
-      tagCache: "dummy",
-      queue: "dummy",
-    },
-  },
-
-  middleware: {
-    external: true,
-    override: {
-      wrapper: "cloudflare-edge",
-      converter: "edge",
-      proxyExternalRequest: "fetch",
-    },
-  },
-};
-
-export default config;
+export default defineConfig();

--- a/examples/bugs/gh-219/open-next.config.ts
+++ b/examples/bugs/gh-219/open-next.config.ts
@@ -1,3 +1,3 @@
-import { defineConfig } from "@opennextjs/cloudflare/config";
+import { defineCloudflareConfig } from "@opennextjs/cloudflare/config";
 
-export default defineConfig();
+export default defineCloudflareConfig();

--- a/examples/bugs/gh-219/open-next.config.ts
+++ b/examples/bugs/gh-219/open-next.config.ts
@@ -1,3 +1,3 @@
-import { defineCloudflareConfig } from "@opennextjs/cloudflare/config";
+import { defineCloudflareConfig } from "@opennextjs/cloudflare";
 
 export default defineCloudflareConfig();

--- a/examples/bugs/gh-223/open-next.config.ts
+++ b/examples/bugs/gh-223/open-next.config.ts
@@ -1,3 +1,3 @@
-import { defineConfig } from "@opennextjs/cloudflare/config";
+import { defineCloudflareConfig } from "@opennextjs/cloudflare/config";
 
-export default defineConfig();
+export default defineCloudflareConfig();

--- a/examples/bugs/gh-223/open-next.config.ts
+++ b/examples/bugs/gh-223/open-next.config.ts
@@ -1,24 +1,3 @@
-import type { OpenNextConfig } from "@opennextjs/aws/types/open-next";
+import { defineConfig } from "@opennextjs/cloudflare/config";
 
-const config: OpenNextConfig = {
-  default: {
-    override: {
-      wrapper: "cloudflare-node",
-      converter: "edge",
-      incrementalCache: "dummy",
-      tagCache: "dummy",
-      queue: "dummy",
-    },
-  },
-
-  middleware: {
-    external: true,
-    override: {
-      wrapper: "cloudflare-edge",
-      converter: "edge",
-      proxyExternalRequest: "fetch",
-    },
-  },
-};
-
-export default config;
+export default defineConfig();

--- a/examples/bugs/gh-223/open-next.config.ts
+++ b/examples/bugs/gh-223/open-next.config.ts
@@ -1,3 +1,3 @@
-import { defineCloudflareConfig } from "@opennextjs/cloudflare/config";
+import { defineCloudflareConfig } from "@opennextjs/cloudflare";
 
 export default defineCloudflareConfig();

--- a/examples/create-next-app/open-next.config.ts
+++ b/examples/create-next-app/open-next.config.ts
@@ -1,3 +1,3 @@
-import { defineConfig } from "@opennextjs/cloudflare/config";
+import { defineCloudflareConfig } from "@opennextjs/cloudflare/config";
 
-export default defineConfig({});
+export default defineCloudflareConfig({});

--- a/examples/create-next-app/open-next.config.ts
+++ b/examples/create-next-app/open-next.config.ts
@@ -1,3 +1,3 @@
 import { defineCloudflareConfig } from "@opennextjs/cloudflare/config";
 
-export default defineCloudflareConfig({});
+export default defineCloudflareConfig();

--- a/examples/create-next-app/open-next.config.ts
+++ b/examples/create-next-app/open-next.config.ts
@@ -1,25 +1,3 @@
-import type { OpenNextConfig } from "@opennextjs/aws/types/open-next.js";
+import { defineConfig } from "@opennextjs/cloudflare/config";
 
-const config: OpenNextConfig = {
-  default: {
-    override: {
-      wrapper: "cloudflare-node",
-      converter: "edge",
-      // Unused implementation
-      incrementalCache: "dummy",
-      tagCache: "dummy",
-      queue: "dummy",
-    },
-  },
-
-  middleware: {
-    external: true,
-    override: {
-      wrapper: "cloudflare-edge",
-      converter: "edge",
-      proxyExternalRequest: "fetch",
-    },
-  },
-};
-
-export default config;
+export default defineConfig({});

--- a/examples/create-next-app/open-next.config.ts
+++ b/examples/create-next-app/open-next.config.ts
@@ -1,3 +1,3 @@
-import { defineCloudflareConfig } from "@opennextjs/cloudflare/config";
+import { defineCloudflareConfig } from "@opennextjs/cloudflare";
 
 export default defineCloudflareConfig();

--- a/examples/e2e/app-pages-router/open-next.config.ts
+++ b/examples/e2e/app-pages-router/open-next.config.ts
@@ -1,6 +1,6 @@
+import { defineCloudflareConfig } from "@opennextjs/cloudflare";
 import kvCache from "@opennextjs/cloudflare/kv-cache";
 import memoryQueue from "@opennextjs/cloudflare/memory-queue";
-import { defineCloudflareConfig } from "@opennextjs/cloudflare";
 
 export default defineCloudflareConfig({
   incrementalCache: kvCache,

--- a/examples/e2e/app-pages-router/open-next.config.ts
+++ b/examples/e2e/app-pages-router/open-next.config.ts
@@ -1,6 +1,6 @@
 import kvCache from "@opennextjs/cloudflare/kv-cache";
 import memoryQueue from "@opennextjs/cloudflare/memory-queue";
-import { defineCloudflareConfig } from "@opennextjs/cloudflare/config";
+import { defineCloudflareConfig } from "@opennextjs/cloudflare";
 
 export default defineCloudflareConfig({
   incrementalCache: kvCache,

--- a/examples/e2e/app-pages-router/open-next.config.ts
+++ b/examples/e2e/app-pages-router/open-next.config.ts
@@ -1,8 +1,8 @@
 import kvCache from "@opennextjs/cloudflare/kv-cache";
 import memoryQueue from "@opennextjs/cloudflare/memory-queue";
-import { defineConfig } from "@opennextjs/cloudflare/config";
+import { defineCloudflareConfig } from "@opennextjs/cloudflare/config";
 
-export default defineConfig({
+export default defineCloudflareConfig({
   incrementalCache: kvCache,
   queue: memoryQueue,
 });

--- a/examples/e2e/app-pages-router/open-next.config.ts
+++ b/examples/e2e/app-pages-router/open-next.config.ts
@@ -1,27 +1,8 @@
-import type { OpenNextConfig } from "@opennextjs/aws/types/open-next.js";
 import kvCache from "@opennextjs/cloudflare/kv-cache";
 import memoryQueue from "@opennextjs/cloudflare/memory-queue";
+import { defineConfig } from "@opennextjs/cloudflare/config";
 
-const config: OpenNextConfig = {
-  default: {
-    override: {
-      wrapper: "cloudflare-node",
-      converter: "edge",
-      incrementalCache: () => kvCache,
-      queue: () => memoryQueue,
-      // Unused implementation
-      tagCache: "dummy",
-    },
-  },
-
-  middleware: {
-    external: true,
-    override: {
-      wrapper: "cloudflare-edge",
-      converter: "edge",
-      proxyExternalRequest: "fetch",
-    },
-  },
-};
-
-export default config;
+export default defineConfig({
+  incrementalCache: kvCache,
+  queue: memoryQueue,
+});

--- a/examples/e2e/app-pages-router/open-next.config.ts
+++ b/examples/e2e/app-pages-router/open-next.config.ts
@@ -1,8 +1,8 @@
 import { defineCloudflareConfig } from "@opennextjs/cloudflare";
-import kvCache from "@opennextjs/cloudflare/kv-cache";
+import kvIncrementalCache from "@opennextjs/cloudflare/kv-cache";
 import memoryQueue from "@opennextjs/cloudflare/memory-queue";
 
 export default defineCloudflareConfig({
-  incrementalCache: kvCache,
+  incrementalCache: kvIncrementalCache,
   queue: memoryQueue,
 });

--- a/examples/e2e/app-router/open-next.config.ts
+++ b/examples/e2e/app-router/open-next.config.ts
@@ -1,27 +1,10 @@
-import type { OpenNextConfig } from "@opennextjs/aws/types/open-next.js";
+import { defineCloudflareConfig } from "@opennextjs/cloudflare/config";
 import tagCache from "@opennextjs/cloudflare/d1-tag-cache";
 import incrementalCache from "@opennextjs/cloudflare/kv-cache";
 import memoryQueue from "@opennextjs/cloudflare/memory-queue";
 
-const config: OpenNextConfig = {
-  default: {
-    override: {
-      wrapper: "cloudflare-node",
-      converter: "edge",
-      incrementalCache: async () => incrementalCache,
-      tagCache: () => tagCache,
-      queue: () => memoryQueue,
-    },
-  },
-
-  middleware: {
-    external: true,
-    override: {
-      wrapper: "cloudflare-edge",
-      converter: "edge",
-      proxyExternalRequest: "fetch",
-    },
-  },
-};
-
-export default config;
+export default defineCloudflareConfig({
+  incrementalCache,
+  tagCache,
+  queue: memoryQueue,
+});

--- a/examples/e2e/app-router/open-next.config.ts
+++ b/examples/e2e/app-router/open-next.config.ts
@@ -1,10 +1,10 @@
 import { defineCloudflareConfig } from "@opennextjs/cloudflare";
-import tagCache from "@opennextjs/cloudflare/d1-tag-cache";
-import incrementalCache from "@opennextjs/cloudflare/kv-cache";
+import d1TagCache from "@opennextjs/cloudflare/d1-tag-cache";
+import kvIncrementalCache from "@opennextjs/cloudflare/kv-cache";
 import memoryQueue from "@opennextjs/cloudflare/memory-queue";
 
 export default defineCloudflareConfig({
-  incrementalCache,
-  tagCache,
+  incrementalCache: kvIncrementalCache,
+  tagCache: d1TagCache,
   queue: memoryQueue,
 });

--- a/examples/e2e/app-router/open-next.config.ts
+++ b/examples/e2e/app-router/open-next.config.ts
@@ -1,4 +1,4 @@
-import { defineCloudflareConfig } from "@opennextjs/cloudflare/config";
+import { defineCloudflareConfig } from "@opennextjs/cloudflare";
 import tagCache from "@opennextjs/cloudflare/d1-tag-cache";
 import incrementalCache from "@opennextjs/cloudflare/kv-cache";
 import memoryQueue from "@opennextjs/cloudflare/memory-queue";

--- a/examples/e2e/pages-router/open-next.config.ts
+++ b/examples/e2e/pages-router/open-next.config.ts
@@ -1,6 +1,6 @@
 import memoryQueue from "@opennextjs/cloudflare/memory-queue";
 import cache from "@opennextjs/cloudflare/kv-cache";
-import { defineCloudflareConfig } from "@opennextjs/cloudflare/config";
+import { defineCloudflareConfig } from "@opennextjs/cloudflare";
 
 export default defineCloudflareConfig({
   incrementalCache: cache,

--- a/examples/e2e/pages-router/open-next.config.ts
+++ b/examples/e2e/pages-router/open-next.config.ts
@@ -1,27 +1,8 @@
-import type { OpenNextConfig } from "@opennextjs/aws/types/open-next.js";
-import kvCache from "@opennextjs/cloudflare/kv-cache";
 import memoryQueue from "@opennextjs/cloudflare/memory-queue";
+import cache from "@opennextjs/cloudflare/kv-cache";
+import { defineConfig } from "@opennextjs/cloudflare/config";
 
-const config: OpenNextConfig = {
-  default: {
-    override: {
-      wrapper: "cloudflare-node",
-      converter: "edge",
-      incrementalCache: () => kvCache,
-      queue: () => memoryQueue,
-      // Unused implementation
-      tagCache: "dummy",
-    },
-  },
-
-  middleware: {
-    external: true,
-    override: {
-      wrapper: "cloudflare-edge",
-      converter: "edge",
-      proxyExternalRequest: "fetch",
-    },
-  },
-};
-
-export default config;
+export default defineConfig({
+  incrementalCache: cache,
+  queue: memoryQueue,
+});

--- a/examples/e2e/pages-router/open-next.config.ts
+++ b/examples/e2e/pages-router/open-next.config.ts
@@ -1,8 +1,8 @@
 import memoryQueue from "@opennextjs/cloudflare/memory-queue";
 import cache from "@opennextjs/cloudflare/kv-cache";
-import { defineConfig } from "@opennextjs/cloudflare/config";
+import { defineCloudflareConfig } from "@opennextjs/cloudflare/config";
 
-export default defineConfig({
+export default defineCloudflareConfig({
   incrementalCache: cache,
   queue: memoryQueue,
 });

--- a/examples/e2e/pages-router/open-next.config.ts
+++ b/examples/e2e/pages-router/open-next.config.ts
@@ -1,6 +1,6 @@
+import { defineCloudflareConfig } from "@opennextjs/cloudflare";
 import memoryQueue from "@opennextjs/cloudflare/memory-queue";
 import cache from "@opennextjs/cloudflare/kv-cache";
-import { defineCloudflareConfig } from "@opennextjs/cloudflare";
 
 export default defineCloudflareConfig({
   incrementalCache: cache,

--- a/examples/e2e/pages-router/open-next.config.ts
+++ b/examples/e2e/pages-router/open-next.config.ts
@@ -1,8 +1,8 @@
 import { defineCloudflareConfig } from "@opennextjs/cloudflare";
+import kvIncrementalCache from "@opennextjs/cloudflare/kv-cache";
 import memoryQueue from "@opennextjs/cloudflare/memory-queue";
-import cache from "@opennextjs/cloudflare/kv-cache";
 
 export default defineCloudflareConfig({
-  incrementalCache: cache,
+  incrementalCache: kvIncrementalCache,
   queue: memoryQueue,
 });

--- a/examples/middleware/open-next.config.ts
+++ b/examples/middleware/open-next.config.ts
@@ -1,25 +1,3 @@
-import type { OpenNextConfig } from "@opennextjs/aws/types/open-next.js";
+import { defineConfig } from "@opennextjs/cloudflare/config";
 
-const config: OpenNextConfig = {
-  default: {
-    override: {
-      wrapper: "cloudflare-node",
-      converter: "edge",
-      // Unused implementation
-      incrementalCache: "dummy",
-      tagCache: "dummy",
-      queue: "dummy",
-    },
-  },
-
-  middleware: {
-    external: true,
-    override: {
-      wrapper: "cloudflare-edge",
-      converter: "edge",
-      proxyExternalRequest: "fetch",
-    },
-  },
-};
-
-export default config;
+export default defineConfig();

--- a/examples/middleware/open-next.config.ts
+++ b/examples/middleware/open-next.config.ts
@@ -1,3 +1,3 @@
-import { defineConfig } from "@opennextjs/cloudflare/config";
+import { defineCloudflareConfig } from "@opennextjs/cloudflare/config";
 
-export default defineConfig();
+export default defineCloudflareConfig();

--- a/examples/middleware/open-next.config.ts
+++ b/examples/middleware/open-next.config.ts
@@ -1,3 +1,3 @@
-import { defineCloudflareConfig } from "@opennextjs/cloudflare/config";
+import { defineCloudflareConfig } from "@opennextjs/cloudflare";
 
 export default defineCloudflareConfig();

--- a/examples/next-partial-prerendering/open-next.config.ts
+++ b/examples/next-partial-prerendering/open-next.config.ts
@@ -1,25 +1,3 @@
-import type { OpenNextConfig } from '@opennextjs/aws/types/open-next.js';
+import { defineCloudflareConfig } from '@opennextjs/cloudflare/config';
 
-const config: OpenNextConfig = {
-  default: {
-    override: {
-      wrapper: 'cloudflare-node',
-      converter: 'edge',
-      // Unused implementation
-      incrementalCache: 'dummy',
-      tagCache: 'dummy',
-      queue: 'dummy',
-    },
-  },
-
-  middleware: {
-    external: true,
-    override: {
-      wrapper: 'cloudflare-edge',
-      converter: 'edge',
-      proxyExternalRequest: 'fetch',
-    },
-  },
-};
-
-export default config;
+export default defineCloudflareConfig();

--- a/examples/playground14/open-next.config.ts
+++ b/examples/playground14/open-next.config.ts
@@ -1,5 +1,5 @@
-import cache from "@opennextjs/cloudflare/kv-cache";
 import { defineCloudflareConfig } from "@opennextjs/cloudflare";
+import cache from "@opennextjs/cloudflare/kv-cache";
 
 export default defineCloudflareConfig({
   incrementalCache: cache,

--- a/examples/playground14/open-next.config.ts
+++ b/examples/playground14/open-next.config.ts
@@ -1,26 +1,6 @@
-import type { OpenNextConfig } from "@opennextjs/aws/types/open-next.js";
 import cache from "@opennextjs/cloudflare/kv-cache";
+import { defineConfig } from "@opennextjs/cloudflare/config";
 
-const config: OpenNextConfig = {
-  default: {
-    override: {
-      wrapper: "cloudflare-node",
-      converter: "edge",
-      incrementalCache: async () => cache,
-      queue: "direct",
-      // Unused implementation
-      tagCache: "dummy",
-    },
-  },
-
-  middleware: {
-    external: true,
-    override: {
-      wrapper: "cloudflare-edge",
-      converter: "edge",
-      proxyExternalRequest: "fetch",
-    },
-  },
-};
-
-export default config;
+export default defineConfig({
+  incrementalCache: cache,
+});

--- a/examples/playground14/open-next.config.ts
+++ b/examples/playground14/open-next.config.ts
@@ -1,6 +1,6 @@
 import { defineCloudflareConfig } from "@opennextjs/cloudflare";
-import cache from "@opennextjs/cloudflare/kv-cache";
+import kvIncrementalCache from "@opennextjs/cloudflare/kv-cache";
 
 export default defineCloudflareConfig({
-  incrementalCache: cache,
+  incrementalCache: kvIncrementalCache,
 });

--- a/examples/playground14/open-next.config.ts
+++ b/examples/playground14/open-next.config.ts
@@ -1,5 +1,5 @@
 import cache from "@opennextjs/cloudflare/kv-cache";
-import { defineCloudflareConfig } from "@opennextjs/cloudflare/config";
+import { defineCloudflareConfig } from "@opennextjs/cloudflare";
 
 export default defineCloudflareConfig({
   incrementalCache: cache,

--- a/examples/playground14/open-next.config.ts
+++ b/examples/playground14/open-next.config.ts
@@ -1,6 +1,6 @@
 import cache from "@opennextjs/cloudflare/kv-cache";
-import { defineConfig } from "@opennextjs/cloudflare/config";
+import { defineCloudflareConfig } from "@opennextjs/cloudflare/config";
 
-export default defineConfig({
+export default defineCloudflareConfig({
   incrementalCache: cache,
 });

--- a/examples/playground15/open-next.config.ts
+++ b/examples/playground15/open-next.config.ts
@@ -1,5 +1,5 @@
-import cache from "@opennextjs/cloudflare/kv-cache";
 import { defineCloudflareConfig } from "@opennextjs/cloudflare";
+import cache from "@opennextjs/cloudflare/kv-cache";
 
 export default defineCloudflareConfig({
   incrementalCache: cache,

--- a/examples/playground15/open-next.config.ts
+++ b/examples/playground15/open-next.config.ts
@@ -1,26 +1,6 @@
-import type { OpenNextConfig } from "@opennextjs/aws/types/open-next.js";
 import cache from "@opennextjs/cloudflare/kv-cache";
+import { defineConfig } from "@opennextjs/cloudflare/config";
 
-const config: OpenNextConfig = {
-  default: {
-    override: {
-      wrapper: "cloudflare-node",
-      converter: "edge",
-      incrementalCache: async () => cache,
-      queue: "direct",
-      // Unused implementation
-      tagCache: "dummy",
-    },
-  },
-
-  middleware: {
-    external: true,
-    override: {
-      wrapper: "cloudflare-edge",
-      converter: "edge",
-      proxyExternalRequest: "fetch",
-    },
-  },
-};
-
-export default config;
+export default defineConfig({
+  incrementalCache: cache,
+});

--- a/examples/playground15/open-next.config.ts
+++ b/examples/playground15/open-next.config.ts
@@ -1,6 +1,6 @@
 import { defineCloudflareConfig } from "@opennextjs/cloudflare";
-import cache from "@opennextjs/cloudflare/kv-cache";
+import kvIncrementalCache from "@opennextjs/cloudflare/kv-cache";
 
 export default defineCloudflareConfig({
-  incrementalCache: cache,
+  incrementalCache: kvIncrementalCache,
 });

--- a/examples/playground15/open-next.config.ts
+++ b/examples/playground15/open-next.config.ts
@@ -1,5 +1,5 @@
 import cache from "@opennextjs/cloudflare/kv-cache";
-import { defineCloudflareConfig } from "@opennextjs/cloudflare/config";
+import { defineCloudflareConfig } from "@opennextjs/cloudflare";
 
 export default defineCloudflareConfig({
   incrementalCache: cache,

--- a/examples/playground15/open-next.config.ts
+++ b/examples/playground15/open-next.config.ts
@@ -1,6 +1,6 @@
 import cache from "@opennextjs/cloudflare/kv-cache";
-import { defineConfig } from "@opennextjs/cloudflare/config";
+import { defineCloudflareConfig } from "@opennextjs/cloudflare/config";
 
-export default defineConfig({
+export default defineCloudflareConfig({
   incrementalCache: cache,
 });

--- a/examples/ssg-app/open-next.config.ts
+++ b/examples/ssg-app/open-next.config.ts
@@ -1,5 +1,5 @@
-import cache from "@opennextjs/cloudflare/kv-cache";
 import { defineCloudflareConfig } from "@opennextjs/cloudflare";
+import cache from "@opennextjs/cloudflare/kv-cache";
 
 export default defineCloudflareConfig({
   incrementalCache: cache,

--- a/examples/ssg-app/open-next.config.ts
+++ b/examples/ssg-app/open-next.config.ts
@@ -1,26 +1,6 @@
-// default open-next.config.ts file created by @opennextjs/cloudflare
-
 import cache from "@opennextjs/cloudflare/kv-cache";
+import { defineConfig } from "@opennextjs/cloudflare/config";
 
-const config = {
-  default: {
-    override: {
-      wrapper: "cloudflare-node",
-      converter: "edge",
-      incrementalCache: async () => cache,
-      tagCache: "dummy",
-      queue: "dummy",
-    },
-  },
-
-  middleware: {
-    external: true,
-    override: {
-      wrapper: "cloudflare-edge",
-      converter: "edge",
-      proxyExternalRequest: "fetch",
-    },
-  },
-};
-
-export default config;
+export default defineConfig({
+  incrementalCache: cache,
+});

--- a/examples/ssg-app/open-next.config.ts
+++ b/examples/ssg-app/open-next.config.ts
@@ -1,6 +1,6 @@
 import { defineCloudflareConfig } from "@opennextjs/cloudflare";
-import cache from "@opennextjs/cloudflare/kv-cache";
+import kvIncrementalCache from "@opennextjs/cloudflare/kv-cache";
 
 export default defineCloudflareConfig({
-  incrementalCache: cache,
+  incrementalCache: kvIncrementalCache,
 });

--- a/examples/ssg-app/open-next.config.ts
+++ b/examples/ssg-app/open-next.config.ts
@@ -1,5 +1,5 @@
 import cache from "@opennextjs/cloudflare/kv-cache";
-import { defineCloudflareConfig } from "@opennextjs/cloudflare/config";
+import { defineCloudflareConfig } from "@opennextjs/cloudflare";
 
 export default defineCloudflareConfig({
   incrementalCache: cache,

--- a/examples/ssg-app/open-next.config.ts
+++ b/examples/ssg-app/open-next.config.ts
@@ -1,6 +1,6 @@
 import cache from "@opennextjs/cloudflare/kv-cache";
-import { defineConfig } from "@opennextjs/cloudflare/config";
+import { defineCloudflareConfig } from "@opennextjs/cloudflare/config";
 
-export default defineConfig({
+export default defineCloudflareConfig({
   incrementalCache: cache,
 });

--- a/examples/vercel-blog-starter/open-next.config.ts
+++ b/examples/vercel-blog-starter/open-next.config.ts
@@ -1,5 +1,5 @@
-import cache from "@opennextjs/cloudflare/kv-cache";
 import { defineCloudflareConfig } from "@opennextjs/cloudflare";
+import cache from "@opennextjs/cloudflare/kv-cache";
 
 export default defineCloudflareConfig({
   incrementalCache: cache,

--- a/examples/vercel-blog-starter/open-next.config.ts
+++ b/examples/vercel-blog-starter/open-next.config.ts
@@ -1,6 +1,6 @@
 import { defineCloudflareConfig } from "@opennextjs/cloudflare";
-import cache from "@opennextjs/cloudflare/kv-cache";
+import kvIncrementalCache from "@opennextjs/cloudflare/kv-cache";
 
 export default defineCloudflareConfig({
-  incrementalCache: cache,
+  incrementalCache: kvIncrementalCache,
 });

--- a/examples/vercel-blog-starter/open-next.config.ts
+++ b/examples/vercel-blog-starter/open-next.config.ts
@@ -1,5 +1,5 @@
 import cache from "@opennextjs/cloudflare/kv-cache";
-import { defineCloudflareConfig } from "@opennextjs/cloudflare/config";
+import { defineCloudflareConfig } from "@opennextjs/cloudflare";
 
 export default defineCloudflareConfig({
   incrementalCache: cache,

--- a/examples/vercel-blog-starter/open-next.config.ts
+++ b/examples/vercel-blog-starter/open-next.config.ts
@@ -1,26 +1,6 @@
-import type { OpenNextConfig } from "@opennextjs/aws/types/open-next.js";
 import cache from "@opennextjs/cloudflare/kv-cache";
+import { defineConfig } from "@opennextjs/cloudflare/config";
 
-const config: OpenNextConfig = {
-  default: {
-    override: {
-      wrapper: "cloudflare-node",
-      converter: "edge",
-      incrementalCache: async () => cache,
-      // Unused implementations
-      tagCache: "dummy",
-      queue: "dummy",
-    },
-  },
-
-  middleware: {
-    external: true,
-    override: {
-      wrapper: "cloudflare-edge",
-      converter: "edge",
-      proxyExternalRequest: "fetch",
-    },
-  },
-};
-
-export default config;
+export default defineConfig({
+  incrementalCache: cache,
+});

--- a/examples/vercel-blog-starter/open-next.config.ts
+++ b/examples/vercel-blog-starter/open-next.config.ts
@@ -1,6 +1,6 @@
 import cache from "@opennextjs/cloudflare/kv-cache";
-import { defineConfig } from "@opennextjs/cloudflare/config";
+import { defineCloudflareConfig } from "@opennextjs/cloudflare/config";
 
-export default defineConfig({
+export default defineCloudflareConfig({
   incrementalCache: cache,
 });

--- a/examples/vercel-commerce/open-next.config.ts
+++ b/examples/vercel-commerce/open-next.config.ts
@@ -1,25 +1,3 @@
-import type { OpenNextConfig } from '@opennextjs/aws/types/open-next';
+import { defineCloudflareConfig } from '@opennextjs/cloudflare/config';
 
-const config: OpenNextConfig = {
-  default: {
-    override: {
-      wrapper: 'cloudflare-node',
-      converter: 'edge',
-      // Unused implementation
-      incrementalCache: 'dummy',
-      tagCache: 'dummy',
-      queue: 'dummy'
-    }
-  },
-
-  middleware: {
-    external: true,
-    override: {
-      wrapper: 'cloudflare-edge',
-      converter: 'edge',
-      proxyExternalRequest: 'fetch'
-    }
-  }
-};
-
-export default config;
+export default defineCloudflareConfig();

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -24,6 +24,11 @@
       "types": "./dist/api/index.d.ts",
       "default": "./dist/api/index.js"
     },
+    "./config": {
+      "import": "./dist/api/config.js",
+      "types": "./dist/api/config.d.ts",
+      "default": "./dist/api/config.js"
+    },
     "./*": {
       "import": "./dist/api/*.js",
       "types": "./dist/api/*.d.ts",

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -24,11 +24,6 @@
       "types": "./dist/api/index.d.ts",
       "default": "./dist/api/index.js"
     },
-    "./config": {
-      "import": "./dist/api/config.js",
-      "types": "./dist/api/config.d.ts",
-      "default": "./dist/api/config.js"
-    },
     "./*": {
       "import": "./dist/api/*.js",
       "types": "./dist/api/*.d.ts",

--- a/packages/cloudflare/src/api/config.ts
+++ b/packages/cloudflare/src/api/config.ts
@@ -16,7 +16,7 @@ export type CloudflareConfigOptions = {
    *     incrementalCache: cache,
    *   });
    */
-  incrementalCache?: IncrementalCache | (() => IncrementalCache | Promise<IncrementalCache>);
+  incrementalCache?: "dummy" | IncrementalCache | (() => IncrementalCache | Promise<IncrementalCache>);
 
   /**
    * The tag cache implementation to use, for more details see the [Caching documentation](https://opennext.js.org/cloudflare/caching))
@@ -32,7 +32,7 @@ export type CloudflareConfigOptions = {
    *     tagCache: cache,
    *   });
    */
-  tagCache?: TagCache | (() => TagCache | Promise<TagCache>);
+  tagCache?: "dummy" | TagCache | (() => TagCache | Promise<TagCache>);
 
   /**
    * The revalidation queue implementation to use, for more details see the [Caching documentation](https://opennext.js.org/cloudflare/caching))
@@ -48,7 +48,7 @@ export type CloudflareConfigOptions = {
    *     queue: memoryQueue,
    *   });
    */
-  queue?: Queue | (() => Queue | Promise<Queue>);
+  queue?: "dummy" | "direct" | Queue | (() => Queue | Promise<Queue>);
 };
 
 /**
@@ -88,9 +88,5 @@ function resolveOverride<T extends IncrementalCache | TagCache | Queue>(
     return "dummy";
   }
 
-  if (typeof value === "function") {
-    return () => value();
-  }
-
-  return async () => value;
+  return typeof value === "function" ? value : () => value;
 }

--- a/packages/cloudflare/src/api/config.ts
+++ b/packages/cloudflare/src/api/config.ts
@@ -50,10 +50,6 @@ export function defineCloudflareConfig(options: CloudflareConfigOptions = {}): O
         proxyExternalRequest: "fetch",
       },
     },
-
-    dangerous: {
-      enableCacheInterception: false,
-    },
   };
 }
 

--- a/packages/cloudflare/src/api/config.ts
+++ b/packages/cloudflare/src/api/config.ts
@@ -9,7 +9,7 @@ export type CloudflareConfigOptions = {
    * to use which can be imported from `"@opennextjs/cloudflare/kv-cache"`
    *
    * @example
-   *   import { defineCloudflareConfig } from "@opennextjs/cloudflare/config";
+   *   import { defineCloudflareConfig } from "@opennextjs/cloudflare";
    *   import cache from "@opennextjs/cloudflare/kv-cache";
    *
    *   export default defineCloudflareConfig({
@@ -25,7 +25,7 @@ export type CloudflareConfigOptions = {
    * to use which can be imported from `"@opennextjs/cloudflare/d1-tag-cache"`
    *
    * @example
-   *   import { defineCloudflareConfig } from "@opennextjs/cloudflare/config";
+   *   import { defineCloudflareConfig } from "@opennextjs/cloudflare";
    *   import cache from "@opennextjs/cloudflare/d1-tag-cache";
    *
    *   export default defineCloudflareConfig({
@@ -41,7 +41,7 @@ export type CloudflareConfigOptions = {
    * to use which can be imported from `"@opennextjs/cloudflare/memory-queue"`
    *
    * @example
-   *   import { defineCloudflareConfig } from "@opennextjs/cloudflare/config";
+   *   import { defineCloudflareConfig } from "@opennextjs/cloudflare";
    *   import memoryQueue from "@opennextjs/cloudflare/memory-queue";
    *
    *   export default defineCloudflareConfig({

--- a/packages/cloudflare/src/api/config.ts
+++ b/packages/cloudflare/src/api/config.ts
@@ -83,13 +83,13 @@ export function defineCloudflareConfig(options: CloudflareConfigOptions = {}): O
 
 function resolveOverride<T extends IncrementalCache | TagCache | Queue>(
   value: T | (() => T | Promise<T>) | undefined
-): (() => T | Promise<T>) | "dummy" {
+): (() => Promise<T>) | "dummy" {
   if (!value) {
     return "dummy";
   }
 
   if (typeof value === "function") {
-    return () => value();
+    return async () => value();
   }
 
   return async () => value;

--- a/packages/cloudflare/src/api/config.ts
+++ b/packages/cloudflare/src/api/config.ts
@@ -89,7 +89,7 @@ function resolveOverride<T extends IncrementalCache | TagCache | Queue>(
   }
 
   if (typeof value === "function") {
-    return async () => value();
+    return async () => await value();
   }
 
   return async () => value;

--- a/packages/cloudflare/src/api/config.ts
+++ b/packages/cloudflare/src/api/config.ts
@@ -3,8 +3,6 @@ import type { IncrementalCache, Queue, TagCache } from "@opennextjs/aws/types/ov
 
 export type CloudflareConfigOptions = {
   /**
-   *
-   *
    * The incremental cache implementation to use, for more details see the [Caching documentation](https://opennext.js.org/cloudflare/caching))
    *
    * `@opennextjs/cloudflare` offers a kv incremental cache implementation ready

--- a/packages/cloudflare/src/api/config.ts
+++ b/packages/cloudflare/src/api/config.ts
@@ -3,22 +3,50 @@ import type { IncrementalCache, Queue, TagCache } from "@opennextjs/aws/types/ov
 
 export type CloudflareConfigOptions = {
   /**
-   * The incremental cache implementation to use
+   * The incremental cache implementation to use (for more details see the [Incremental Cache documentation](https://opennext.js.org/aws/config/overrides/incremental_cache))
    *
-   * see: https://opennext.js.org/aws/config/overrides/incremental_cache
+   * `@opennextjs/cloudflare` offers a kv incremental cache implementation ready
+   * to use which can be imported from `"@opennextjs/cloudflare/kv-cache"`
+   *
+   * @example
+   *   import { defineCloudflareConfig } from "@opennextjs/cloudflare/config";
+   *   import cache from "@opennextjs/cloudflare/kv-cache";
+   *
+   *   export default defineCloudflareConfig({
+   *     incrementalCache: cache,
+   *   });
    */
   incrementalCache?: IncrementalCache | (() => IncrementalCache | Promise<IncrementalCache>);
+
   /**
-   * The tag cache implementation to use
+   * The tag cache implementation to use (for more details see the [Tag Cache documentation](https://opennext.js.org/aws/config/overrides/tag_cache))
    *
-   * see: https://opennext.js.org/aws/config/overrides/tag_cache
+   * `@opennextjs/cloudflare` offers a d1 tag cache implementation ready
+   * to use which can be imported from `"@opennextjs/cloudflare/d1-tag-cache"`
+   *
+   * @example
+   *   import { defineCloudflareConfig } from "@opennextjs/cloudflare/config";
+   *   import cache from "@opennextjs/cloudflare/d1-tag-cache";
+   *
+   *   export default defineCloudflareConfig({
+   *     tagCache: cache,
+   *   });
    */
   tagCache?: TagCache | (() => TagCache | Promise<TagCache>);
 
   /**
-   * The revalidation queue implementation to use
+   * The revalidation queue implementation to use (for more details see the [Queue documentation](https://opennext.js.org/aws/config/overrides/queue))
    *
-   * see: https://opennext.js.org/aws/config/overrides/queue
+   * `@opennextjs/cloudflare` offers an in memory queue implementation ready
+   * to use which can be imported from `"@opennextjs/cloudflare/memory-queue"`
+   *
+   * @example
+   *   import { defineCloudflareConfig } from "@opennextjs/cloudflare/config";
+   *   import memoryQueue from "@opennextjs/cloudflare/memory-queue";
+   *
+   *   export default defineCloudflareConfig({
+   *     queue: memoryQueue,
+   *   });
    */
   queue?: Queue | (() => Queue | Promise<Queue>);
 };

--- a/packages/cloudflare/src/api/config.ts
+++ b/packages/cloudflare/src/api/config.ts
@@ -29,7 +29,7 @@ export type CloudflareConfigOptions = {
  * @param options options that enabled you to configure the application's behavior
  * @returns the OpenNext configuration object
  */
-export function defineConfig(options: CloudflareConfigOptions = {}): OpenNextConfig {
+export function defineCloudflareConfig(options: CloudflareConfigOptions = {}): OpenNextConfig {
   const { incrementalCache, tagCache, queue } = options;
   return {
     default: {

--- a/packages/cloudflare/src/api/config.ts
+++ b/packages/cloudflare/src/api/config.ts
@@ -83,13 +83,13 @@ export function defineCloudflareConfig(options: CloudflareConfigOptions = {}): O
 
 function resolveOverride<T extends IncrementalCache | TagCache | Queue>(
   value: T | (() => T | Promise<T>) | undefined
-): (() => Promise<T>) | "dummy" {
+): (() => T | Promise<T>) | "dummy" {
   if (!value) {
     return "dummy";
   }
 
   if (typeof value === "function") {
-    return async () => await value();
+    return () => value();
   }
 
   return async () => value;

--- a/packages/cloudflare/src/api/config.ts
+++ b/packages/cloudflare/src/api/config.ts
@@ -3,7 +3,9 @@ import type { IncrementalCache, Queue, TagCache } from "@opennextjs/aws/types/ov
 
 export type CloudflareConfigOptions = {
   /**
-   * The incremental cache implementation to use (for more details see the [Incremental Cache documentation](https://opennext.js.org/aws/config/overrides/incremental_cache))
+   *
+   *
+   * The incremental cache implementation to use, for more details see the [Caching documentation](https://opennext.js.org/cloudflare/caching))
    *
    * `@opennextjs/cloudflare` offers a kv incremental cache implementation ready
    * to use which can be imported from `"@opennextjs/cloudflare/kv-cache"`
@@ -19,7 +21,7 @@ export type CloudflareConfigOptions = {
   incrementalCache?: IncrementalCache | (() => IncrementalCache | Promise<IncrementalCache>);
 
   /**
-   * The tag cache implementation to use (for more details see the [Tag Cache documentation](https://opennext.js.org/aws/config/overrides/tag_cache))
+   * The tag cache implementation to use, for more details see the [Caching documentation](https://opennext.js.org/cloudflare/caching))
    *
    * `@opennextjs/cloudflare` offers a d1 tag cache implementation ready
    * to use which can be imported from `"@opennextjs/cloudflare/d1-tag-cache"`
@@ -35,7 +37,7 @@ export type CloudflareConfigOptions = {
   tagCache?: TagCache | (() => TagCache | Promise<TagCache>);
 
   /**
-   * The revalidation queue implementation to use (for more details see the [Queue documentation](https://opennext.js.org/aws/config/overrides/queue))
+   * The revalidation queue implementation to use, for more details see the [Caching documentation](https://opennext.js.org/cloudflare/caching))
    *
    * `@opennextjs/cloudflare` offers an in memory queue implementation ready
    * to use which can be imported from `"@opennextjs/cloudflare/memory-queue"`

--- a/packages/cloudflare/src/api/config.ts
+++ b/packages/cloudflare/src/api/config.ts
@@ -1,0 +1,72 @@
+import { OpenNextConfig } from "@opennextjs/aws/types/open-next";
+import type { IncrementalCache, Queue, TagCache } from "@opennextjs/aws/types/overrides";
+
+export type CloudflareConfigOptions = {
+  /**
+   * The incremental cache implementation to use
+   *
+   * see: https://opennext.js.org/aws/config/overrides/incremental_cache
+   */
+  incrementalCache?: IncrementalCache | (() => IncrementalCache | Promise<IncrementalCache>);
+  /**
+   * The tag cache implementation to use
+   *
+   * see: https://opennext.js.org/aws/config/overrides/tag_cache
+   */
+  tagCache?: TagCache | (() => TagCache | Promise<TagCache>);
+
+  /**
+   * The revalidation queue implementation to use
+   *
+   * see: https://opennext.js.org/aws/config/overrides/queue
+   */
+  queue?: Queue | (() => Queue | Promise<Queue>);
+};
+
+/**
+ * Defines the OpenNext configuration that targets the Cloudflare adapter
+ *
+ * @param options options that enabled you to configure the application's behavior
+ * @returns the OpenNext configuration object
+ */
+export function defineConfig(options: CloudflareConfigOptions = {}): OpenNextConfig {
+  const { incrementalCache, tagCache, queue } = options;
+  return {
+    default: {
+      override: {
+        wrapper: "cloudflare-node",
+        converter: "edge",
+        incrementalCache: resolveOverride(incrementalCache),
+        tagCache: resolveOverride(tagCache),
+        queue: resolveOverride(queue),
+      },
+    },
+
+    middleware: {
+      external: true,
+      override: {
+        wrapper: "cloudflare-edge",
+        converter: "edge",
+        proxyExternalRequest: "fetch",
+      },
+    },
+
+    dangerous: {
+      enableCacheInterception: false,
+    },
+  };
+}
+
+function resolveOverride<T extends IncrementalCache | TagCache | Queue>(
+  value: T | (() => T | Promise<T>) | undefined
+): (() => Promise<T>) | "dummy" {
+  if (!value) {
+    return "dummy";
+  }
+
+  if (typeof value === "function") {
+    return async () => value();
+  }
+
+  return async () => value;
+}

--- a/packages/cloudflare/src/api/config.ts
+++ b/packages/cloudflare/src/api/config.ts
@@ -10,10 +10,10 @@ export type CloudflareConfigOptions = {
    *
    * @example
    *   import { defineCloudflareConfig } from "@opennextjs/cloudflare";
-   *   import cache from "@opennextjs/cloudflare/kv-cache";
+   *   import kvIncrementalCache from "@opennextjs/cloudflare/kv-cache";
    *
    *   export default defineCloudflareConfig({
-   *     incrementalCache: cache,
+   *     incrementalCache: kvIncrementalCache,
    *   });
    */
   incrementalCache?: "dummy" | IncrementalCache | (() => IncrementalCache | Promise<IncrementalCache>);
@@ -26,10 +26,10 @@ export type CloudflareConfigOptions = {
    *
    * @example
    *   import { defineCloudflareConfig } from "@opennextjs/cloudflare";
-   *   import cache from "@opennextjs/cloudflare/d1-tag-cache";
+   *   import d1TagCache from "@opennextjs/cloudflare/d1-tag-cache";
    *
    *   export default defineCloudflareConfig({
-   *     tagCache: cache,
+   *     tagCache: d1TagCache,
    *   });
    */
   tagCache?: "dummy" | TagCache | (() => TagCache | Promise<TagCache>);

--- a/packages/cloudflare/src/api/index.ts
+++ b/packages/cloudflare/src/api/index.ts
@@ -1,1 +1,2 @@
 export * from "./cloudflare-context.js";
+export { defineCloudflareConfig } from "./config.js";

--- a/packages/cloudflare/src/api/kvCache.ts
+++ b/packages/cloudflare/src/api/kvCache.ts
@@ -1,6 +1,6 @@
-import cache from "./kv-cache.js";
+import kvIncrementalCache from "./kv-cache.js";
 
 /**
  * @deprecated Please import from `kv-cache` instead of `kvCache`.
  */
-export default cache;
+export default kvIncrementalCache;

--- a/packages/cloudflare/templates/defaults/open-next.config.ts
+++ b/packages/cloudflare/templates/defaults/open-next.config.ts
@@ -1,7 +1,7 @@
 // default open-next.config.ts file created by @opennextjs/cloudflare
-import { defineConfig } from "@opennextjs/cloudflare/dist/api/config";
+import { defineCloudflareConfig } from "@opennextjs/cloudflare/dist/api/config";
 import cache from "@opennextjs/cloudflare/dist/api/kv-cache";
 
-export default defineConfig({
+export default defineCloudflareConfig({
   incrementalCache: cache,
 });

--- a/packages/cloudflare/templates/defaults/open-next.config.ts
+++ b/packages/cloudflare/templates/defaults/open-next.config.ts
@@ -1,26 +1,7 @@
 // default open-next.config.ts file created by @opennextjs/cloudflare
+import { defineConfig } from "@opennextjs/cloudflare/dist/api/config";
+import cache from "@opennextjs/cloudflare/dist/api/kv-cache";
 
-import cache from "@opennextjs/cloudflare/kv-cache";
-
-const config = {
-  default: {
-    override: {
-      wrapper: "cloudflare-node",
-      converter: "edge",
-      incrementalCache: async () => cache,
-      tagCache: "dummy",
-      queue: "dummy",
-    },
-  },
-
-  middleware: {
-    external: true,
-    override: {
-      wrapper: "cloudflare-edge",
-      converter: "edge",
-      proxyExternalRequest: "fetch",
-    },
-  },
-};
-
-export default config;
+export default defineConfig({
+  incrementalCache: cache,
+});

--- a/packages/cloudflare/templates/defaults/open-next.config.ts
+++ b/packages/cloudflare/templates/defaults/open-next.config.ts
@@ -1,7 +1,7 @@
 // default open-next.config.ts file created by @opennextjs/cloudflare
 import { defineCloudflareConfig } from "@opennextjs/cloudflare/dist/api/config";
-import cache from "@opennextjs/cloudflare/dist/api/kv-cache";
+import kvIncrementalCache from "@opennextjs/cloudflare/dist/api/kv-cache";
 
 export default defineCloudflareConfig({
-  incrementalCache: cache,
+  incrementalCache: kvIncrementalCache,
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16000,7 +16000,7 @@ snapshots:
       debug: 4.3.6
       enhanced-resolve: 5.17.1
       eslint: 8.57.1
-      eslint-module-utils: 2.11.0(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.11.0(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
       fast-glob: 3.3.2
       get-tsconfig: 4.8.0
       is-bun-module: 1.2.1
@@ -16019,7 +16019,7 @@ snapshots:
       debug: 4.3.6
       enhanced-resolve: 5.17.1
       eslint: 8.57.1
-      eslint-module-utils: 2.11.0(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.11.0(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
       fast-glob: 3.3.2
       get-tsconfig: 4.8.0
       is-bun-module: 1.2.1
@@ -16038,7 +16038,7 @@ snapshots:
       debug: 4.3.6
       enhanced-resolve: 5.17.1
       eslint: 9.11.1(jiti@1.21.6)
-      eslint-module-utils: 2.11.0(@typescript-eslint/parser@8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.11.1(jiti@1.21.6)))(eslint@9.11.1(jiti@1.21.6))
+      eslint-module-utils: 2.11.0(@typescript-eslint/parser@8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.11.1(jiti@1.21.6))
       fast-glob: 3.3.2
       get-tsconfig: 4.8.0
       is-bun-module: 1.2.1
@@ -16057,7 +16057,7 @@ snapshots:
       debug: 4.3.6
       enhanced-resolve: 5.17.1
       eslint: 9.19.0(jiti@1.21.6)
-      eslint-module-utils: 2.11.0(@typescript-eslint/parser@8.7.0(eslint@9.19.0(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.7.0(eslint@9.19.0(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.19.0(jiti@1.21.6)))(eslint@9.19.0(jiti@1.21.6))
+      eslint-module-utils: 2.11.0(@typescript-eslint/parser@8.7.0(eslint@9.19.0(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.19.0(jiti@1.21.6))
       fast-glob: 3.3.2
       get-tsconfig: 4.8.0
       is-bun-module: 1.2.1
@@ -16070,18 +16070,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.11.0(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0)(eslint@8.57.1))(eslint@8.57.1):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.7.0(eslint@8.57.1)(typescript@5.7.3)
-      eslint: 8.57.1
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0)(eslint@8.57.1)
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.11.0(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.11.0(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -16092,7 +16081,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.11.0(@typescript-eslint/parser@8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.11.1(jiti@1.21.6)))(eslint@9.11.1(jiti@1.21.6)):
+  eslint-module-utils@2.11.0(@typescript-eslint/parser@8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.11.1(jiti@1.21.6)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -16103,7 +16092,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.11.0(@typescript-eslint/parser@8.7.0(eslint@9.19.0(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.7.0(eslint@9.19.0(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.19.0(jiti@1.21.6)))(eslint@9.19.0(jiti@1.21.6)):
+  eslint-module-utils@2.11.0(@typescript-eslint/parser@8.7.0(eslint@9.19.0(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.19.0(jiti@1.21.6)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -16114,7 +16103,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -16125,7 +16114,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.11.1(jiti@1.21.6)))(eslint@9.11.1(jiti@1.21.6)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.11.1(jiti@1.21.6)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -16136,7 +16125,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.7.0(eslint@9.19.0(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.7.0(eslint@9.19.0(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.19.0(jiti@1.21.6)))(eslint@9.19.0(jiti@1.21.6)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.7.0(eslint@9.19.0(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.19.0(jiti@1.21.6)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -16158,7 +16147,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.11.0(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.11.0(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -16186,7 +16175,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -16215,7 +16204,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.11.1(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.11.1(jiti@1.21.6)))(eslint@9.11.1(jiti@1.21.6))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.11.1(jiti@1.21.6))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -16244,7 +16233,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.19.0(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.7.0(eslint@9.19.0(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.7.0(eslint@9.19.0(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.19.0(jiti@1.21.6)))(eslint@9.19.0(jiti@1.21.6))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.7.0(eslint@9.19.0(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.19.0(jiti@1.21.6))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3


### PR DESCRIPTION
this change adds a new `defineCloudflareConfig` utility that developers can use in their `open-next.config.ts` file to easily generate a configuration compatible with the adapter

___

Docs PR: https://github.com/opennextjs/docs/pull/84

___

resolves #114 