### PR TITLE
fix: manifest glob on windows

### DIFF
--- a/.changeset/warm-dragons-search.md
+++ b/.changeset/warm-dragons-search.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+improve windows support

--- a/packages/cloudflare/src/cli/build/patches/ast/patch-vercel-og-library.ts
+++ b/packages/cloudflare/src/cli/build/patches/ast/patch-vercel-og-library.ts
@@ -21,7 +21,9 @@ export function patchVercelOgLibrary(buildOpts: BuildOptions) {
   const functionsPath = path.join(outputDir, "server-functions/default");
   const packagePath = path.join(functionsPath, getPackagePath(buildOpts));
 
-  for (const traceInfoPath of globSync(path.join(appBuildOutputPath, ".next/server/**/*.nft.json"))) {
+  for (const traceInfoPath of globSync(path.join(appBuildOutputPath, ".next/server/**/*.nft.json"), {
+    windowsPathsNoEscape: true,
+  })) {
     const traceInfo: TraceInfo = JSON.parse(readFileSync(traceInfoPath, { encoding: "utf8" }));
     const tracedNodePath = traceInfo.files.find((p) => p.endsWith("@vercel/og/index.node.js"));
 

--- a/packages/cloudflare/src/cli/build/patches/plugins/eval-manifest.ts
+++ b/packages/cloudflare/src/cli/build/patches/plugins/eval-manifest.ts
@@ -29,7 +29,7 @@ async function getRule(buildOpts: BuildOptions) {
 
   const baseDir = join(outputDir, "server-functions/default", getPackagePath(buildOpts), ".next");
   const appDir = join(baseDir, "server/app");
-  const manifests = await glob(join(baseDir, "**/*_client-reference-manifest.js"));
+  const manifests = await glob(join(baseDir, "**/*_client-reference-manifest.js"), { windowsPathsNoEscape: true });
 
   const returnManifests = manifests
     .map((manifest) => {

--- a/packages/cloudflare/src/cli/build/patches/plugins/eval-manifest.ts
+++ b/packages/cloudflare/src/cli/build/patches/plugins/eval-manifest.ts
@@ -29,7 +29,9 @@ async function getRule(buildOpts: BuildOptions) {
 
   const baseDir = join(outputDir, "server-functions/default", getPackagePath(buildOpts), ".next");
   const appDir = join(baseDir, "server/app");
-  const manifests = await glob(join(baseDir, "**/*_client-reference-manifest.js"), { windowsPathsNoEscape: true });
+  const manifests = await glob(join(baseDir, "**/*_client-reference-manifest.js"), {
+    windowsPathsNoEscape: true,
+  });
 
   const returnManifests = manifests
     .map((manifest) => {

--- a/packages/cloudflare/src/cli/build/patches/plugins/load-manifest.ts
+++ b/packages/cloudflare/src/cli/build/patches/plugins/load-manifest.ts
@@ -30,7 +30,7 @@ async function getRule(buildOpts: BuildOptions) {
   const baseDir = join(outputDir, "server-functions/default", getPackagePath(buildOpts));
   const dotNextDir = join(baseDir, ".next");
 
-  const manifests = await glob(join(dotNextDir, "**/*-manifest.json"));
+  const manifests = await glob(join(dotNextDir, "**/*-manifest.json"), { windowsPathsNoEscape: true });
 
   const returnManifests = (
     await Promise.all(


### PR DESCRIPTION
relates to #321 

node:path's join on windows uses `\\` separator but node-glob by default accepts only `/`
