### PR TITLE
chore: disable typescript + eslint during next.js builds

### DIFF
--- a/examples/bugs/gh-119/next.config.ts
+++ b/examples/bugs/gh-119/next.config.ts
@@ -1,7 +1,8 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  typescript: { ignoreBuildErrors: true },
+  eslint: { ignoreDuringBuilds: true },
 };
 
 export default nextConfig;

--- a/examples/bugs/gh-219/next.config.ts
+++ b/examples/bugs/gh-219/next.config.ts
@@ -1,11 +1,8 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  eslint: {
-    // Warning: This allows production builds to successfully complete even if
-    // your project has ESLint errors.
-    ignoreDuringBuilds: true,
-  },
+  typescript: { ignoreBuildErrors: true },
+  eslint: { ignoreDuringBuilds: true },
 };
 
 export default nextConfig;

--- a/examples/bugs/gh-223/next.config.mjs
+++ b/examples/bugs/gh-223/next.config.mjs
@@ -1,8 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  typescript: {
-    ignoreBuildErrors: true,
-  },
+  typescript: { ignoreBuildErrors: true },
+  eslint: { ignoreDuringBuilds: true },
 };
 
 export default nextConfig;

--- a/examples/create-next-app/next.config.mjs
+++ b/examples/create-next-app/next.config.mjs
@@ -3,6 +3,9 @@ import { initOpenNextCloudflareForDev } from "@opennextjs/cloudflare";
 initOpenNextCloudflareForDev();
 
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  typescript: { ignoreBuildErrors: true },
+  eslint: { ignoreDuringBuilds: true },
+};
 
 export default nextConfig;

--- a/examples/middleware/next.config.mjs
+++ b/examples/middleware/next.config.mjs
@@ -3,6 +3,9 @@ import { initOpenNextCloudflareForDev } from "@opennextjs/cloudflare";
 initOpenNextCloudflareForDev();
 
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  typescript: { ignoreBuildErrors: true },
+  eslint: { ignoreDuringBuilds: true },
+};
 
 export default nextConfig;

--- a/examples/next-partial-prerendering/next.config.js
+++ b/examples/next-partial-prerendering/next.config.js
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   typescript: { ignoreBuildErrors: true },
+  eslint: { ignoreDuringBuilds: true },
   experimental: {
     ppr: true,
   },

--- a/examples/playground14/next.config.mjs
+++ b/examples/playground14/next.config.mjs
@@ -4,6 +4,8 @@ initOpenNextCloudflareForDev();
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  typescript: { ignoreBuildErrors: true },
+  eslint: { ignoreDuringBuilds: true },
   experimental: {
     // Generate source map to validate the fix for opennextjs/opennextjs-cloudflare#341
     serverSourceMaps: true,

--- a/examples/playground15/next.config.mjs
+++ b/examples/playground15/next.config.mjs
@@ -4,6 +4,8 @@ initOpenNextCloudflareForDev();
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  typescript: { ignoreBuildErrors: true },
+  eslint: { ignoreDuringBuilds: true },
   experimental: {
     // Generate source map to validate the fix for opennextjs/opennextjs-cloudflare#341
     serverSourceMaps: true,

--- a/examples/ssg-app/next.config.ts
+++ b/examples/ssg-app/next.config.ts
@@ -4,7 +4,8 @@ import { initOpenNextCloudflareForDev } from "@opennextjs/cloudflare";
 initOpenNextCloudflareForDev();
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  typescript: { ignoreBuildErrors: true },
+  eslint: { ignoreDuringBuilds: true },
 };
 
 export default nextConfig;

--- a/examples/vercel-blog-starter/next.config.mjs
+++ b/examples/vercel-blog-starter/next.config.mjs
@@ -1,4 +1,7 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  typescript: { ignoreBuildErrors: true },
+  eslint: { ignoreDuringBuilds: true },
+};
 
 export default nextConfig;

--- a/examples/vercel-commerce/next.config.js
+++ b/examples/vercel-commerce/next.config.js
@@ -1,5 +1,7 @@
 /** @type {import('next').NextConfig} */
 module.exports = {
+  typescript: { ignoreBuildErrors: true },
+  eslint: { ignoreDuringBuilds: true },
   images: {
     formats: ['image/avif', 'image/webp'],
     remotePatterns: [


### PR DESCRIPTION
The typescript and eslint checks slow down our e2e builds while providing zero value. I would like to propose disabling them completely. The e2es we copied from aws already do this.

It's not a significant gain, but it cuts off about 15-20 seconds from time spent building apps.