### PR TITLE
shim `next/dist/compiled/node-fetch`

### DIFF
--- a/packages/cloudflare/src/cli/build/bundle-server.ts
+++ b/packages/cloudflare/src/cli/build/bundle-server.ts
@@ -104,6 +104,11 @@ export async function bundleServer(buildOpts: BuildOptions): Promise<void> {
     ],
     external: ["./middleware/handler.mjs"],
     alias: {
+      // Note: it looks like node-fetch is actually not necessary for us, so we could replace it with an empty shim
+      //       but just to be safe we replace it with a module that re-exports the native fetch
+      //       we do this to both save on bundle size (there isn't really any benefit in us shipping the node-fetch code)
+      //       and also get rid of a warning in the terminal caused by the package (because it performs an === comparison with -0)
+      "next/dist/compiled/node-fetch": path.join(buildOpts.outputDir, "cloudflare-templates/shims/fetch.js"),
       // Note: we apply an empty shim to next/dist/compiled/ws because it generates two `eval`s:
       //   eval("require")("bufferutil");
       //   eval("require")("utf-8-validate");

--- a/packages/cloudflare/src/cli/templates/shims/fetch.ts
+++ b/packages/cloudflare/src/cli/templates/shims/fetch.ts
@@ -1,0 +1,1 @@
+export default fetch;


### PR DESCRIPTION
currently in our bundle we include the `next/dist/compiled/node-fetch` package, this doesn't seem actually necessary and it introduces a good amount of unnecessary code in our bundle, moreover it also causes a warning in the terminal (because of an === -0 comparison), the changes here replace the node-fetch code with a simply shim that re-exports the native fetch

___

Notes:
 - by looking at the Next.js source code I wouldn't really tell why node-fetch is used, I can only imagine that it's there for either backward compatibility or brought in as part of some dependencies
 - all the Next.js source code that would import from node-fetch that I've found always only imports just the default export
 - I couldn't find a way to trigger a Next.js app to call node-fetch (as far as I can tell it's generally unused)
 - I think this change if beneficial for the two reasons I mentioned above (less code in our bundle + removed warning) but it introduces a small risk (assuming that node-fetch would actually work in workerd), I think the risk is very tolerable especially since all the e2es pass

If someone disagree with this PR I'm ok changing course and just patch the `=== -0` check (although I do think it is pretty nice to reduce the bundle size here as an added bonus)
___

resolves #321 