### PR TITLE
feat: auto-populating d1 cache data

### DIFF
--- a/.changeset/tame-icons-shave.md
+++ b/.changeset/tame-icons-shave.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+feat: auto-populating d1 cache data

--- a/examples/e2e/app-router/package.json
+++ b/examples/e2e/app-router/package.json
@@ -10,8 +10,7 @@
     "lint": "next lint",
     "clean": "rm -rf .turbo node_modules .next .open-next",
     "d1:clean": "wrangler d1 execute NEXT_CACHE_D1 --command \"DROP TABLE IF EXISTS tags; DROP TABLE IF EXISTS revalidations\"",
-    "d1:setup": "wrangler d1 execute NEXT_CACHE_D1 --file .open-next/cloudflare/cache-assets-manifest.sql",
-    "build:worker": "pnpm opennextjs-cloudflare && pnpm d1:clean && pnpm d1:setup",
+    "build:worker": "pnpm d1:clean && pnpm opennextjs-cloudflare --populateCache=local",
     "preview": "pnpm build:worker && pnpm wrangler dev",
     "e2e": "playwright test -c e2e/playwright.config.ts"
   },

--- a/packages/cloudflare/src/cli/args.ts
+++ b/packages/cloudflare/src/cli/args.ts
@@ -10,7 +10,7 @@ export function getArgs(): {
   skipWranglerConfigCheck: boolean;
   outputDir?: string;
   minify: boolean;
-  populateCache?: { mode: CacheBindingMode; onlyPopulate: boolean };
+  populateCache?: { mode: CacheBindingMode; onlyPopulateWithoutBuilding: boolean };
 } {
   const { skipBuild, skipWranglerConfigCheck, output, noMinify, populateCache, onlyPopulateCache } =
     parseArgs({
@@ -63,7 +63,9 @@ export function getArgs(): {
       skipWranglerConfigCheck ||
       ["1", "true", "yes"].includes(String(process.env.SKIP_WRANGLER_CONFIG_CHECK)),
     minify: !noMinify,
-    populateCache: populateCache ? { mode: populateCache, onlyPopulate: !!onlyPopulateCache } : undefined,
+    populateCache: populateCache
+      ? { mode: populateCache, onlyPopulateWithoutBuilding: !!onlyPopulateCache }
+      : undefined,
   };
 }
 

--- a/packages/cloudflare/src/cli/args.ts
+++ b/packages/cloudflare/src/cli/args.ts
@@ -2,14 +2,15 @@ import { mkdirSync, type Stats, statSync } from "node:fs";
 import { resolve } from "node:path";
 import { parseArgs } from "node:util";
 
-import { CacheBindingMode } from "./build/utils/index.js";
+import type { CacheBindingMode } from "./build/utils/index.js";
+import { isCacheBindingMode } from "./build/utils/index.js";
 
 export function getArgs(): {
   skipNextBuild: boolean;
   skipWranglerConfigCheck: boolean;
   outputDir?: string;
   minify: boolean;
-  populateCache?: { mode: "local" | "remote"; onlyPopulate: boolean };
+  populateCache?: { mode: CacheBindingMode; onlyPopulate: boolean };
 } {
   const { skipBuild, skipWranglerConfigCheck, output, noMinify, populateCache, onlyPopulateCache } =
     parseArgs({
@@ -50,7 +51,7 @@ export function getArgs(): {
 
   if (
     (populateCache !== undefined || onlyPopulateCache) &&
-    (!populateCache?.length || !["local", "remote"].includes(populateCache))
+    (!populateCache?.length || !isCacheBindingMode(populateCache))
   ) {
     throw new Error(`Error: missing mode for populate cache flag, expected 'local' | 'remote'`);
   }
@@ -62,9 +63,7 @@ export function getArgs(): {
       skipWranglerConfigCheck ||
       ["1", "true", "yes"].includes(String(process.env.SKIP_WRANGLER_CONFIG_CHECK)),
     minify: !noMinify,
-    populateCache: populateCache
-      ? { mode: populateCache as CacheBindingMode, onlyPopulate: !!onlyPopulateCache }
-      : undefined,
+    populateCache: populateCache ? { mode: populateCache, onlyPopulate: !!onlyPopulateCache } : undefined,
   };
 }
 

--- a/packages/cloudflare/src/cli/build/build.ts
+++ b/packages/cloudflare/src/cli/build/build.ts
@@ -20,6 +20,7 @@ import {
   createOpenNextConfigIfNotExistent,
   createWranglerConfigIfNotExistent,
   ensureCloudflareConfig,
+  populateCache,
 } from "./utils/index.js";
 import { getVersion } from "./utils/version.js";
 
@@ -62,6 +63,11 @@ export async function build(projectOpts: ProjectOptions): Promise<void> {
   logger.info(`@opennextjs/cloudflare version: ${cloudflare}`);
   logger.info(`@opennextjs/aws version: ${aws}`);
 
+  if (projectOpts.populateCache?.onlyPopulate) {
+    populateCache(options, config, projectOpts.populateCache.mode);
+    return;
+  }
+
   if (projectOpts.skipNextBuild) {
     logger.warn("Skipping Next.js build");
   } else {
@@ -101,6 +107,10 @@ export async function build(projectOpts: ProjectOptions): Promise<void> {
 
   if (!projectOpts.skipWranglerConfigCheck) {
     await createWranglerConfigIfNotExistent(projectOpts);
+  }
+
+  if (projectOpts.populateCache) {
+    populateCache(options, config, projectOpts.populateCache.mode);
   }
 
   logger.info("OpenNext build complete.");

--- a/packages/cloudflare/src/cli/build/build.ts
+++ b/packages/cloudflare/src/cli/build/build.ts
@@ -63,7 +63,7 @@ export async function build(projectOpts: ProjectOptions): Promise<void> {
   logger.info(`@opennextjs/cloudflare version: ${cloudflare}`);
   logger.info(`@opennextjs/aws version: ${aws}`);
 
-  if (projectOpts.populateCache?.onlyPopulate) {
+  if (projectOpts.populateCache?.onlyPopulateWithoutBuilding) {
     populateCache(options, config, projectOpts.populateCache.mode);
     return;
   }

--- a/packages/cloudflare/src/cli/build/utils/index.ts
+++ b/packages/cloudflare/src/cli/build/utils/index.ts
@@ -4,3 +4,4 @@ export * from "./ensure-cf-config.js";
 export * from "./extract-project-env-vars.js";
 export * from "./needs-experimental-react.js";
 export * from "./normalize-path.js";
+export * from "./populate-cache.js";

--- a/packages/cloudflare/src/cli/build/utils/populate-cache.ts
+++ b/packages/cloudflare/src/cli/build/utils/populate-cache.ts
@@ -54,7 +54,7 @@ export async function populateCache(opts: BuildOptions, config: OpenNextConfig, 
     logger.info("Incremental cache does not need populating");
   }
 
-  if (!config.dangerous?.disableTagCache && tagCache) {
+  if (!config.dangerous?.disableTagCache && !config.dangerous?.disableIncrementalCache && tagCache) {
     const name = await resolveCacheName(tagCache);
     switch (name) {
       case "d1-tag-cache": {

--- a/packages/cloudflare/src/cli/build/utils/populate-cache.ts
+++ b/packages/cloudflare/src/cli/build/utils/populate-cache.ts
@@ -72,3 +72,7 @@ export async function populateCache(opts: BuildOptions, config: OpenNextConfig, 
     }
   }
 }
+
+export function isCacheBindingMode(v: string | undefined): v is CacheBindingMode {
+  return !!v && ["local", "remote"].includes(v);
+}

--- a/packages/cloudflare/src/cli/build/utils/populate-cache.ts
+++ b/packages/cloudflare/src/cli/build/utils/populate-cache.ts
@@ -1,0 +1,61 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+
+import type { BuildOptions } from "@opennextjs/aws/build/helper.js";
+import logger from "@opennextjs/aws/logger.js";
+import type {
+  IncludedIncrementalCache,
+  IncludedTagCache,
+  LazyLoadedOverride,
+  OpenNextConfig,
+} from "@opennextjs/aws/types/open-next.js";
+import type { IncrementalCache, TagCache } from "@opennextjs/aws/types/overrides.js";
+
+export type CacheBindingMode = "local" | "remote";
+
+async function resolveCacheName(
+  value:
+    | IncludedIncrementalCache
+    | IncludedTagCache
+    | LazyLoadedOverride<IncrementalCache>
+    | LazyLoadedOverride<TagCache>
+) {
+  return typeof value === "function" ? (await value()).name : value;
+}
+
+function runWrangler(opts: BuildOptions, mode: CacheBindingMode, args: string[]) {
+  const result = spawnSync(
+    opts.packager,
+    ["exec", "wrangler", ...args, mode === "remote" && "--remote"].filter((v): v is string => !!v),
+    {
+      shell: true,
+      stdio: ["ignore", "ignore", "inherit"],
+    }
+  );
+
+  if (result.status !== 0) {
+    logger.error("Failed to populate cache");
+  } else {
+    logger.info("Successfully populated cache");
+  }
+}
+
+export async function populateCache(opts: BuildOptions, config: OpenNextConfig, mode: CacheBindingMode) {
+  const { tagCache } = config.default.override ?? {};
+
+  if (tagCache) {
+    const name = await resolveCacheName(tagCache);
+    switch (name) {
+      case "d1-tag-cache": {
+        logger.info("\nPopulating D1 tag cache...");
+
+        runWrangler(opts, mode, [
+          "d1 execute",
+          "NEXT_CACHE_D1",
+          `--file ${JSON.stringify(path.join(opts.outputDir, "cloudflare/cache-assets-manifest.sql"))}`,
+        ]);
+        break;
+      }
+    }
+  }
+}

--- a/packages/cloudflare/src/cli/index.ts
+++ b/packages/cloudflare/src/cli/index.ts
@@ -6,7 +6,7 @@ import { build } from "./build/build.js";
 
 const nextAppDir = process.cwd();
 
-const { skipNextBuild, skipWranglerConfigCheck, outputDir, minify } = getArgs();
+const { skipNextBuild, skipWranglerConfigCheck, outputDir, minify, populateCache } = getArgs();
 
 await build({
   sourceDir: nextAppDir,
@@ -14,4 +14,5 @@ await build({
   skipNextBuild,
   skipWranglerConfigCheck,
   minify,
+  populateCache,
 });

--- a/packages/cloudflare/src/cli/project-options.ts
+++ b/packages/cloudflare/src/cli/project-options.ts
@@ -1,3 +1,5 @@
+import type { CacheBindingMode } from "./build/utils/index.js";
+
 export type ProjectOptions = {
   // Next app root folder
   sourceDir: string;
@@ -9,4 +11,5 @@ export type ProjectOptions = {
   skipWranglerConfigCheck: boolean;
   // Whether minification of the worker should be enabled
   minify: boolean;
+  populateCache?: { mode: CacheBindingMode; onlyPopulate: boolean };
 };

--- a/packages/cloudflare/src/cli/project-options.ts
+++ b/packages/cloudflare/src/cli/project-options.ts
@@ -11,5 +11,5 @@ export type ProjectOptions = {
   skipWranglerConfigCheck: boolean;
   // Whether minification of the worker should be enabled
   minify: boolean;
-  populateCache?: { mode: CacheBindingMode; onlyPopulate: boolean };
+  populateCache?: { mode: CacheBindingMode; onlyPopulateWithoutBuilding: boolean };
 };


### PR DESCRIPTION
- Adds a CLI flag to enable auto-population of cache data for either local or remote.
- Adds a CLI flag to only populate cache (i.e. skip build completely).
- Populates D1 tag cache data when the adapter is used.

Docs PR and KV change to use auto-population will follow if we agree on this being the way forward

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #479 
- <kbd>&nbsp;2&nbsp;</kbd> #443 
- <kbd>&nbsp;1&nbsp;</kbd> #436 👈 
<!-- GitButler Footer Boundary Bottom -->

