### PR TITLE
Fix for next 15.2 and renderHTML should not be called in minimal mode

### DIFF
--- a/.changeset/famous-deers-attack.md
+++ b/.changeset/famous-deers-attack.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+Fix for `Invariant: renderHTML should not be called in minimal mode`

--- a/packages/cloudflare/src/cli/build/bundle-server.ts
+++ b/packages/cloudflare/src/cli/build/bundle-server.ts
@@ -17,6 +17,7 @@ import { patchFetchCacheSetMissingWaitUntil } from "./patches/plugins/fetch-cach
 import { inlineFindDir } from "./patches/plugins/find-dir.js";
 import { patchInstrumentation } from "./patches/plugins/instrumentation.js";
 import { inlineLoadManifest } from "./patches/plugins/load-manifest.js";
+import { patchNextMinimal } from "./patches/plugins/next-minimal.js";
 import { handleOptionalDependencies } from "./patches/plugins/optional-deps.js";
 import { patchDepdDeprecations } from "./patches/plugins/patch-depd-deprecations.js";
 import { fixRequire } from "./patches/plugins/require.js";
@@ -99,6 +100,7 @@ export async function bundleServer(buildOpts: BuildOptions): Promise<void> {
       inlineLoadManifest(updater, buildOpts),
       inlineBuildId(updater),
       patchDepdDeprecations(updater),
+      patchNextMinimal(updater),
       // Apply updater updaters, must be the last plugin
       updater.plugin,
     ],
@@ -136,7 +138,8 @@ export async function bundleServer(buildOpts: BuildOptions): Promise<void> {
       // We make sure that environment variables that Next.js expects are properly defined
       "process.env.NEXT_RUNTIME": '"nodejs"',
       "process.env.NODE_ENV": '"production"',
-      "process.env.NEXT_MINIMAL": "true",
+      "process.env.TURBOPACK": "false",
+      // Ideally here we should define the `process.env.__NEXT_EXPERIMENTAL_REACT`, but this would require that function splitting is enabled for the case where both versions are needed (i.e. page and app router routes)
     },
     platform: "node",
     banner: {

--- a/packages/cloudflare/src/cli/build/bundle-server.ts
+++ b/packages/cloudflare/src/cli/build/bundle-server.ts
@@ -138,8 +138,11 @@ export async function bundleServer(buildOpts: BuildOptions): Promise<void> {
       // We make sure that environment variables that Next.js expects are properly defined
       "process.env.NEXT_RUNTIME": '"nodejs"',
       "process.env.NODE_ENV": '"production"',
+      // The 2 following defines are used to reduce the bundle size by removing unnecessary code
+      // Next uses different precompiled renderers (i.e. `app-page.runtime.prod.js`) based on if you use `TURBOPACK` or some experimental React features
+      // Turbopack is not supported for build at the moment, so we disable it
       "process.env.TURBOPACK": "false",
-      // This define should be safe to use for Next 14.2+
+      // This define should be safe to use for Next 14.2+, earlier versions (13.5 and less) will cause trouble
       "process.env.__NEXT_EXPERIMENTAL_REACT": `${needsExperimentalReact(nextConfig)}`,
     },
     platform: "node",

--- a/packages/cloudflare/src/cli/build/bundle-server.ts
+++ b/packages/cloudflare/src/cli/build/bundle-server.ts
@@ -23,7 +23,7 @@ import { patchDepdDeprecations } from "./patches/plugins/patch-depd-deprecations
 import { fixRequire } from "./patches/plugins/require.js";
 import { shimRequireHook } from "./patches/plugins/require-hook.js";
 import { setWranglerExternal } from "./patches/plugins/wrangler-external.js";
-import { normalizePath, patchCodeWithValidations } from "./utils/index.js";
+import { needsExperimentalReact, normalizePath, patchCodeWithValidations } from "./utils/index.js";
 
 /** The dist directory of the Cloudflare adapter package */
 const packageDistDir = path.join(path.dirname(fileURLToPath(import.meta.url)), "../..");
@@ -139,7 +139,8 @@ export async function bundleServer(buildOpts: BuildOptions): Promise<void> {
       "process.env.NEXT_RUNTIME": '"nodejs"',
       "process.env.NODE_ENV": '"production"',
       "process.env.TURBOPACK": "false",
-      // Ideally here we should define the `process.env.__NEXT_EXPERIMENTAL_REACT`, but this would require that function splitting is enabled for the case where both versions are needed (i.e. page and app router routes)
+      // This define should be safe to use for Next 14.2+
+      "process.env.__NEXT_EXPERIMENTAL_REACT": `${needsExperimentalReact(nextConfig)}`,
     },
     platform: "node",
     banner: {

--- a/packages/cloudflare/src/cli/build/patches/plugins/next-minimal.spec.ts
+++ b/packages/cloudflare/src/cli/build/patches/plugins/next-minimal.spec.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "vitest";
+
+import { patchCode } from "../ast/util";
+import { abortControllerRule } from "./next-minimal";
+
+const appPageRuntimeProdJs = `let p = new AbortController;
+async function h(e3, t3) {
+  let { flightRouterState: r3, nextUrl: a2, prefetchKind: i2 } = t3, u2 = { [n2.hY]: "1", [n2.B]: encodeURIComponent(JSON.stringify(r3)) };
+  i2 === o.ob.AUTO && (u2[n2._V] = "1"), a2 && (u2[n2.kO] = a2);
+  try {
+    var c2;
+    let t4 = i2 ? i2 === o.ob.TEMPORARY ? "high" : "low" : "auto";
+    "export" === process.env.__NEXT_CONFIG_OUTPUT && ((e3 = new URL(e3)).pathname.endsWith("/") ? e3.pathname += "index.txt" : e3.pathname += ".txt");
+    let r4 = await m(e3, u2, t4, p.signal), a3 = d(r4.url), h2 = r4.redirected ? a3 : void 0, g = r4.headers.get("content-type") || "", v = !!(null == (c2 = r4.headers.get("vary")) ? void 0 : c2.includes(n2.kO)), b = !!r4.headers.get(n2.jc), S = r4.headers.get(n2.UK), _ = null !== S ? parseInt(S, 10) : -1, w = g.startsWith(n2.al);
+    if ("export" !== process.env.__NEXT_CONFIG_OUTPUT || w || (w = g.startsWith("text/plain")), !w || !r4.ok || !r4.body)
+      return e3.hash && (a3.hash = e3.hash), f(a3.toString());
+    let k = b ? function(e4) {
+      let t5 = e4.getReader();
+      return new ReadableStream({ async pull(e5) {
+        for (; ; ) {
+          let { done: r5, value: n3 } = await t5.read();
+          if (!r5) {
+            e5.enqueue(n3);
+            continue;
+          }
+          return;
+        }
+      } });
+    }(r4.body) : r4.body, E = await y(k);
+    if ((0, l.X)() !== E.b)
+      return f(r4.url);
+    return { flightData: (0, s.aj)(E.f), canonicalUrl: h2, couldBeIntercepted: v, prerendered: E.S, postponed: b, staleTime: _ };
+  } catch (t4) {
+    return p.signal.aborted || console.error("Failed to fetch RSC payload for " + e3 + ". Falling back to browser navigation.", t4), { flightData: e3.toString(), canonicalUrl: void 0, couldBeIntercepted: false, prerendered: false, postponed: false, staleTime: -1 };
+  }
+}
+`;
+
+describe("Abort controller", () => {
+  test("minimal", () => {
+    expect(patchCode(appPageRuntimeProdJs,abortControllerRule )).toBe(
+`let p = {signal:{aborted: false}};
+async function h(e3, t3) {
+  let { flightRouterState: r3, nextUrl: a2, prefetchKind: i2 } = t3, u2 = { [n2.hY]: "1", [n2.B]: encodeURIComponent(JSON.stringify(r3)) };
+  i2 === o.ob.AUTO && (u2[n2._V] = "1"), a2 && (u2[n2.kO] = a2);
+  try {
+    var c2;
+    let t4 = i2 ? i2 === o.ob.TEMPORARY ? "high" : "low" : "auto";
+    "export" === process.env.__NEXT_CONFIG_OUTPUT && ((e3 = new URL(e3)).pathname.endsWith("/") ? e3.pathname += "index.txt" : e3.pathname += ".txt");
+    let r4 = await m(e3, u2, t4, p.signal), a3 = d(r4.url), h2 = r4.redirected ? a3 : void 0, g = r4.headers.get("content-type") || "", v = !!(null == (c2 = r4.headers.get("vary")) ? void 0 : c2.includes(n2.kO)), b = !!r4.headers.get(n2.jc), S = r4.headers.get(n2.UK), _ = null !== S ? parseInt(S, 10) : -1, w = g.startsWith(n2.al);
+    if ("export" !== process.env.__NEXT_CONFIG_OUTPUT || w || (w = g.startsWith("text/plain")), !w || !r4.ok || !r4.body)
+      return e3.hash && (a3.hash = e3.hash), f(a3.toString());
+    let k = b ? function(e4) {
+      let t5 = e4.getReader();
+      return new ReadableStream({ async pull(e5) {
+        for (; ; ) {
+          let { done: r5, value: n3 } = await t5.read();
+          if (!r5) {
+            e5.enqueue(n3);
+            continue;
+          }
+          return;
+        }
+      } });
+    }(r4.body) : r4.body, E = await y(k);
+    if ((0, l.X)() !== E.b)
+      return f(r4.url);
+    return { flightData: (0, s.aj)(E.f), canonicalUrl: h2, couldBeIntercepted: v, prerendered: E.S, postponed: b, staleTime: _ };
+  } catch (t4) {
+    return p.signal.aborted || console.error("Failed to fetch RSC payload for " + e3 + ". Falling back to browser navigation.", t4), { flightData: e3.toString(), canonicalUrl: void 0, couldBeIntercepted: false, prerendered: false, postponed: false, staleTime: -1 };
+  }
+}
+`);
+  });
+})

--- a/packages/cloudflare/src/cli/build/patches/plugins/next-minimal.spec.ts
+++ b/packages/cloudflare/src/cli/build/patches/plugins/next-minimal.spec.ts
@@ -38,8 +38,8 @@ async function h(e3, t3) {
 
 describe("Abort controller", () => {
   test("minimal", () => {
-    expect(patchCode(appPageRuntimeProdJs,abortControllerRule )).toBe(
-`let p = {signal:{aborted: false}};
+    expect(patchCode(appPageRuntimeProdJs, abortControllerRule)).toBe(
+      `let p = {signal:{aborted: false}};
 async function h(e3, t3) {
   let { flightRouterState: r3, nextUrl: a2, prefetchKind: i2 } = t3, u2 = { [n2.hY]: "1", [n2.B]: encodeURIComponent(JSON.stringify(r3)) };
   i2 === o.ob.AUTO && (u2[n2._V] = "1"), a2 && (u2[n2.kO] = a2);
@@ -70,6 +70,7 @@ async function h(e3, t3) {
     return p.signal.aborted || console.error("Failed to fetch RSC payload for " + e3 + ". Falling back to browser navigation.", t4), { flightData: e3.toString(), canonicalUrl: void 0, couldBeIntercepted: false, prerendered: false, postponed: false, staleTime: -1 };
   }
 }
-`);
+`
+    );
   });
-})
+});

--- a/packages/cloudflare/src/cli/build/patches/plugins/next-minimal.ts
+++ b/packages/cloudflare/src/cli/build/patches/plugins/next-minimal.ts
@@ -1,0 +1,84 @@
+import { patchCode } from "../ast/util.js";
+import { ContentUpdater } from "./content-updater.js";
+
+// We try to be as specific as possible to avoid patching the wrong thing here
+// It seems that there is a bug in the worker runtime. When the AbortController is created outside of the request context it throws an error (not sure if it's expected or not) except in this case.
+// It fails while requiring the `app-page.runtime.prod.js` file, but instead of throwing an error, it just return an empty object for the `require('app-page.runtime.prod.js')` call which makes every request to an app router page fail.
+// If it's a bug in workerd and it's not expected to throw an error, we can remove this patch.
+export const abortControllerRule = `
+rule:
+  all: 
+    - kind: lexical_declaration
+      pattern: let $VAR = new AbortController
+    - precedes:
+        kind: function_declaration
+        stopBy: end
+        has:
+          kind: statement_block
+          has:
+            kind: try_statement
+            has:
+              kind: catch_clause
+              has:
+                kind: statement_block
+                has: 
+                  kind: return_statement
+                  all: 
+                    - has: 
+                        stopBy: end
+                        kind: member_expression
+                        pattern: $VAR.signal.aborted
+                    - has:
+                        stopBy: end
+                        kind: call_expression
+                        regex: console.error\\("Failed to fetch RSC payload for
+                    
+fix:
+  'let $VAR = {signal:{aborted: false}};'
+`
+
+// This rule is used instead of defining `process.env.NEXT_MINIMAL` in the `esbuild config.
+// Do we want to entirely replace these functions to reduce the bundle size?
+// In next `renderHTML` is used as a fallback in case of errors, but in minimal mode it just throws the error and the responsability of handling it is on the infra.
+export const nextMinimalRule = `
+rule:
+  kind: member_expression
+  pattern: process.env.NEXT_MINIMAL
+  any: 
+    - inside:
+        kind: parenthesized_expression
+        stopBy: end
+        inside:
+          kind: if_statement
+          any:
+            - inside:
+                kind: statement_block
+                inside:
+                  kind: method_definition
+                  any:
+                    - has: {kind: property_identifier, field: name, regex: runEdgeFunction}
+                    - has: {kind: property_identifier, field: name, regex: runMiddleware}
+                    - has: {kind: property_identifier, field: name, regex: imageOptimizer}
+            - has:
+                kind: statement_block
+                has:
+                  kind: expression_statement
+                  pattern: res.statusCode = 400;
+fix:
+  'true'                
+`
+
+export function patchNextMinimal(updater: ContentUpdater) {
+    updater.updateContent("patch-abortController-next15.2", { filter: /app-page\.runtime\.prod\.(js)$/, contentFilter: /new AbortController/ }, async ({ contents }) => {
+      return patchCode(contents, abortControllerRule)
+    });
+
+    updater.updateContent("patch-next-minimal", { filter: /next-server\.(js)$/, contentFilter: /.*/ }, async ({ contents }) => {
+      return patchCode(contents, nextMinimalRule)
+    });
+    
+    return {
+        name: "patch-abortController",
+        setup() { },
+    };
+}

--- a/packages/cloudflare/src/cli/build/patches/plugins/next-minimal.ts
+++ b/packages/cloudflare/src/cli/build/patches/plugins/next-minimal.ts
@@ -2,7 +2,7 @@ import { patchCode } from "../ast/util.js";
 import { ContentUpdater } from "./content-updater.js";
 
 // We try to be as specific as possible to avoid patching the wrong thing here
-// It seems that there is a bug in the worker runtime. When the AbortController is created outside of the request context it throws an error (not sure if it's expected or not) except in this case.
+// It seems that there is a bug in the worker runtime. When the AbortController is created outside of the request context it throws an error (not sure if it's expected or not) except in this case. https://github.com/cloudflare/workerd/issues/3657
 // It fails while requiring the `app-page.runtime.prod.js` file, but instead of throwing an error, it just return an empty object for the `require('app-page.runtime.prod.js')` call which makes every request to an app router page fail.
 // If it's a bug in workerd and it's not expected to throw an error, we can remove this patch.
 export const abortControllerRule = `
@@ -71,7 +71,7 @@ fix:
 export function patchNextMinimal(updater: ContentUpdater) {
   updater.updateContent(
     "patch-abortController-next15.2",
-    { filter: /app-page(-experimental)?\.runtime\.prod\.(js)$/, contentFilter: /new AbortController/ },
+    { filter: /app-page(-experimental)?\.runtime\.prod\.js$/, contentFilter: /new AbortController/ },
     async ({ contents }) => {
       return patchCode(contents, abortControllerRule);
     }

--- a/packages/cloudflare/src/cli/build/patches/plugins/next-minimal.ts
+++ b/packages/cloudflare/src/cli/build/patches/plugins/next-minimal.ts
@@ -71,7 +71,7 @@ fix:
 export function patchNextMinimal(updater: ContentUpdater) {
   updater.updateContent(
     "patch-abortController-next15.2",
-    { filter: /app-page\.runtime\.prod\.(js)$/, contentFilter: /new AbortController/ },
+    { filter: /app-page(-experimental)?\.runtime\.prod\.(js)$/, contentFilter: /new AbortController/ },
     async ({ contents }) => {
       return patchCode(contents, abortControllerRule);
     }

--- a/packages/cloudflare/src/cli/build/patches/plugins/next-minimal.ts
+++ b/packages/cloudflare/src/cli/build/patches/plugins/next-minimal.ts
@@ -35,7 +35,7 @@ rule:
                     
 fix:
   'let $VAR = {signal:{aborted: false}};'
-`
+`;
 
 // This rule is used instead of defining `process.env.NEXT_MINIMAL` in the `esbuild config.
 // Do we want to entirely replace these functions to reduce the bundle size?
@@ -66,19 +66,27 @@ rule:
                   pattern: res.statusCode = 400;
 fix:
   'true'                
-`
+`;
 
 export function patchNextMinimal(updater: ContentUpdater) {
-    updater.updateContent("patch-abortController-next15.2", { filter: /app-page\.runtime\.prod\.(js)$/, contentFilter: /new AbortController/ }, async ({ contents }) => {
-      return patchCode(contents, abortControllerRule)
-    });
+  updater.updateContent(
+    "patch-abortController-next15.2",
+    { filter: /app-page\.runtime\.prod\.(js)$/, contentFilter: /new AbortController/ },
+    async ({ contents }) => {
+      return patchCode(contents, abortControllerRule);
+    }
+  );
 
-    updater.updateContent("patch-next-minimal", { filter: /next-server\.(js)$/, contentFilter: /.*/ }, async ({ contents }) => {
-      return patchCode(contents, nextMinimalRule)
-    });
-    
-    return {
-        name: "patch-abortController",
-        setup() { },
-    };
+  updater.updateContent(
+    "patch-next-minimal",
+    { filter: /next-server\.(js)$/, contentFilter: /.*/ },
+    async ({ contents }) => {
+      return patchCode(contents, nextMinimalRule);
+    }
+  );
+
+  return {
+    name: "patch-abortController",
+    setup() {},
+  };
 }

--- a/packages/cloudflare/src/cli/build/utils/index.ts
+++ b/packages/cloudflare/src/cli/build/utils/index.ts
@@ -2,4 +2,5 @@ export * from "./apply-patches.js";
 export * from "./create-config-files.js";
 export * from "./ensure-cf-config.js";
 export * from "./extract-project-env-vars.js";
+export * from "./needs-experimental-react.js";
 export * from "./normalize-path.js";

--- a/packages/cloudflare/src/cli/build/utils/needs-experimental-react.ts
+++ b/packages/cloudflare/src/cli/build/utils/needs-experimental-react.ts
@@ -1,0 +1,19 @@
+import type { NextConfig } from "@opennextjs/aws/types/next-types";
+
+// Not sure if this should be upstreamed to aws
+// Adding more stuff there make typing incorrect actually, these properties are never undefined as long as it is the right version of next
+// Ideally we'd have different `NextConfig` types for different versions of next
+interface ExtendedNextConfig extends NextConfig {
+  experimental: {
+    ppr?: boolean;
+    taint?: boolean;
+    viewTransition?: boolean;
+    serverActions?: boolean;
+  };
+}
+
+// Copied from https://github.com/vercel/next.js/blob/4518bc91641a0fd938664b781e12ae7c145f3396/packages/next/src/lib/needs-experimental-react.ts#L3-L6
+export function needsExperimentalReact(nextConfig: ExtendedNextConfig) {
+  const { ppr, taint, viewTransition } = nextConfig.experimental || {};
+  return Boolean(ppr || taint || viewTransition);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,8 +98,8 @@ catalogs:
       specifier: 10.4.15
       version: 10.4.15
     next:
-      specifier: 15.1.0
-      version: 15.1.0
+      specifier: 15.2.0
+      version: 15.2.0
     postcss:
       specifier: 8.4.27
       version: 8.4.27
@@ -435,7 +435,7 @@ importers:
         version: link:../../../packages/cloudflare
       next:
         specifier: catalog:e2e
-        version: 15.1.0(@opentelemetry/api@1.9.0)(@playwright/test@1.47.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 15.2.0(@opentelemetry/api@1.9.0)(@playwright/test@1.47.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react:
         specifier: catalog:e2e
         version: 19.0.0
@@ -481,7 +481,7 @@ importers:
         version: link:../../../packages/cloudflare
       next:
         specifier: catalog:e2e
-        version: 15.1.0(@opentelemetry/api@1.9.0)(@playwright/test@1.47.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 15.2.0(@opentelemetry/api@1.9.0)(@playwright/test@1.47.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react:
         specifier: catalog:e2e
         version: 19.0.0
@@ -527,7 +527,7 @@ importers:
         version: link:../../../packages/cloudflare
       next:
         specifier: catalog:e2e
-        version: 15.1.0(@opentelemetry/api@1.9.0)(@playwright/test@1.47.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 15.2.0(@opentelemetry/api@1.9.0)(@playwright/test@1.47.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react:
         specifier: catalog:e2e
         version: 19.0.0
@@ -567,7 +567,7 @@ importers:
     dependencies:
       next:
         specifier: catalog:e2e
-        version: 15.1.0(@opentelemetry/api@1.9.0)(@playwright/test@1.47.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 15.2.0(@opentelemetry/api@1.9.0)(@playwright/test@1.47.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react:
         specifier: catalog:e2e
         version: 19.0.0
@@ -3279,6 +3279,9 @@ packages:
   '@next/env@15.1.7':
     resolution: {integrity: sha512-d9jnRrkuOH7Mhi+LHav2XW91HOgTAWHxjMPkXMGBc9B2b7614P7kjt8tAplRvJpbSt4nbO1lugcT/kAaWzjlLQ==}
 
+  '@next/env@15.2.0':
+    resolution: {integrity: sha512-eMgJu1RBXxxqqnuRJQh5RozhskoNUDHBFybvi+Z+yK9qzKeG7dadhv/Vp1YooSZmCnegf7JxWuapV77necLZNA==}
+
   '@next/eslint-plugin-next@14.2.14':
     resolution: {integrity: sha512-kV+OsZ56xhj0rnTn6HegyTGkoa16Mxjrpk7pjWumyB2P8JVQb8S9qtkjy/ye0GnTr4JWtWG4x/2qN40lKZ3iVQ==}
 
@@ -3333,6 +3336,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@next/swc-darwin-arm64@15.2.0':
+    resolution: {integrity: sha512-rlp22GZwNJjFCyL7h5wz9vtpBVuCt3ZYjFWpEPBGzG712/uL1bbSkS675rVAUCRZ4hjoTJ26Q7IKhr5DfJrHDA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@next/swc-darwin-x64@14.2.11':
     resolution: {integrity: sha512-lnB0zYCld4yE0IX3ANrVMmtAbziBb7MYekcmR6iE9bujmgERl6+FK+b0MBq0pl304lYe7zO4yxJus9H/Af8jbg==}
     engines: {node: '>= 10'}
@@ -3371,6 +3380,12 @@ packages:
 
   '@next/swc-darwin-x64@15.1.7':
     resolution: {integrity: sha512-2qoas+fO3OQKkU0PBUfwTiw/EYpN+kdAx62cePRyY1LqKtP09Vp5UcUntfZYajop5fDFTjSxCHfZVRxzi+9FYQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@next/swc-darwin-x64@15.2.0':
+    resolution: {integrity: sha512-DiU85EqSHogCz80+sgsx90/ecygfCSGl5P3b4XDRVZpgujBm5lp4ts7YaHru7eVTyZMjHInzKr+w0/7+qDrvMA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
@@ -3417,6 +3432,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@next/swc-linux-arm64-gnu@15.2.0':
+    resolution: {integrity: sha512-VnpoMaGukiNWVxeqKHwi8MN47yKGyki5q+7ql/7p/3ifuU2341i/gDwGK1rivk0pVYbdv5D8z63uu9yMw0QhpQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
   '@next/swc-linux-arm64-musl@14.2.11':
     resolution: {integrity: sha512-fH377DnKGyUnkWlmUpFF1T90m0dADBfK11dF8sOQkiELF9M+YwDRCGe8ZyDzvQcUd20Rr5U7vpZRrAxKwd3Rzg==}
     engines: {node: '>= 10'}
@@ -3455,6 +3476,12 @@ packages:
 
   '@next/swc-linux-arm64-musl@15.1.7':
     resolution: {integrity: sha512-zblK1OQbQWdC8fxdX4fpsHDw+VSpBPGEUX4PhSE9hkaWPrWoeIJn+baX53vbsbDRaDKd7bBNcXRovY1hEhFd7w==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@next/swc-linux-arm64-musl@15.2.0':
+    resolution: {integrity: sha512-ka97/ssYE5nPH4Qs+8bd8RlYeNeUVBhcnsNUmFM6VWEob4jfN9FTr0NBhXVi1XEJpj3cMfgSRW+LdE3SUZbPrw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -3501,6 +3528,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@next/swc-linux-x64-gnu@15.2.0':
+    resolution: {integrity: sha512-zY1JduE4B3q0k2ZCE+DAF/1efjTXUsKP+VXRtrt/rJCTgDlUyyryx7aOgYXNc1d8gobys/Lof9P9ze8IyRDn7Q==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
   '@next/swc-linux-x64-musl@14.2.11':
     resolution: {integrity: sha512-DYYZcO4Uir2gZxA4D2JcOAKVs8ZxbOFYPpXSVIgeoQbREbeEHxysVsg3nY4FrQy51e5opxt5mOHl/LzIyZBoKA==}
     engines: {node: '>= 10'}
@@ -3543,6 +3576,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@next/swc-linux-x64-musl@15.2.0':
+    resolution: {integrity: sha512-QqvLZpurBD46RhaVaVBepkVQzh8xtlUN00RlG4Iq1sBheNugamUNPuZEH1r9X1YGQo1KqAe1iiShF0acva3jHQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
   '@next/swc-win32-arm64-msvc@14.2.11':
     resolution: {integrity: sha512-PwqHeKG3/kKfPpM6of1B9UJ+Er6ySUy59PeFu0Un0LBzJTRKKAg2V6J60Yqzp99m55mLa+YTbU6xj61ImTv9mg==}
     engines: {node: '>= 10'}
@@ -3581,6 +3620,12 @@ packages:
 
   '@next/swc-win32-arm64-msvc@15.1.7':
     resolution: {integrity: sha512-LDnj1f3OVbou1BqvvXVqouJZKcwq++mV2F+oFHptToZtScIEnhNRJAhJzqAtTE2dB31qDYL45xJwrc+bLeKM2Q==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@next/swc-win32-arm64-msvc@15.2.0':
+    resolution: {integrity: sha512-ODZ0r9WMyylTHAN6pLtvUtQlGXBL9voljv6ujSlcsjOxhtXPI1Ag6AhZK0SE8hEpR1374WZZ5w33ChpJd5fsjw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
@@ -3641,6 +3686,12 @@ packages:
 
   '@next/swc-win32-x64-msvc@15.1.7':
     resolution: {integrity: sha512-dC01f1quuf97viOfW05/K8XYv2iuBgAxJZl7mbCKEjMgdQl5JjAKJ0D2qMKZCgPWDeFbFT0Q0nYWwytEW0DWTQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@next/swc-win32-x64-msvc@15.2.0':
+    resolution: {integrity: sha512-8+4Z3Z7xa13NdUuUAcpVNA6o76lNPniBd9Xbo02bwXQXnZgFvEopwY2at5+z7yHl47X9qbZpvwatZ2BRo3EdZw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -7668,6 +7719,27 @@ packages:
 
   next@15.1.7:
     resolution: {integrity: sha512-GNeINPGS9c6OZKCvKypbL8GTsT5GhWPp4DM0fzkXJuXMilOO2EeFxuAY6JZbtk6XIl6Ws10ag3xRINDjSO5+wg==}
+    engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.41.2
+      babel-plugin-react-compiler: '*'
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+      sass:
+        optional: true
+
+  next@15.2.0:
+    resolution: {integrity: sha512-VaiM7sZYX8KIAHBrRGSFytKknkrexNfGb8GlG6e93JqueCspuGte8i4ybn8z4ww1x3f2uzY4YpTaBEW4/hvsoQ==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
     hasBin: true
     peerDependencies:
@@ -12593,6 +12665,8 @@ snapshots:
 
   '@next/env@15.1.7': {}
 
+  '@next/env@15.2.0': {}
+
   '@next/eslint-plugin-next@14.2.14':
     dependencies:
       glob: 10.3.10
@@ -12630,6 +12704,9 @@ snapshots:
   '@next/swc-darwin-arm64@15.1.7':
     optional: true
 
+  '@next/swc-darwin-arm64@15.2.0':
+    optional: true
+
   '@next/swc-darwin-x64@14.2.11':
     optional: true
 
@@ -12649,6 +12726,9 @@ snapshots:
     optional: true
 
   '@next/swc-darwin-x64@15.1.7':
+    optional: true
+
+  '@next/swc-darwin-x64@15.2.0':
     optional: true
 
   '@next/swc-linux-arm64-gnu@14.2.11':
@@ -12672,6 +12752,9 @@ snapshots:
   '@next/swc-linux-arm64-gnu@15.1.7':
     optional: true
 
+  '@next/swc-linux-arm64-gnu@15.2.0':
+    optional: true
+
   '@next/swc-linux-arm64-musl@14.2.11':
     optional: true
 
@@ -12691,6 +12774,9 @@ snapshots:
     optional: true
 
   '@next/swc-linux-arm64-musl@15.1.7':
+    optional: true
+
+  '@next/swc-linux-arm64-musl@15.2.0':
     optional: true
 
   '@next/swc-linux-x64-gnu@14.2.11':
@@ -12714,6 +12800,9 @@ snapshots:
   '@next/swc-linux-x64-gnu@15.1.7':
     optional: true
 
+  '@next/swc-linux-x64-gnu@15.2.0':
+    optional: true
+
   '@next/swc-linux-x64-musl@14.2.11':
     optional: true
 
@@ -12735,6 +12824,9 @@ snapshots:
   '@next/swc-linux-x64-musl@15.1.7':
     optional: true
 
+  '@next/swc-linux-x64-musl@15.2.0':
+    optional: true
+
   '@next/swc-win32-arm64-msvc@14.2.11':
     optional: true
 
@@ -12754,6 +12846,9 @@ snapshots:
     optional: true
 
   '@next/swc-win32-arm64-msvc@15.1.7':
+    optional: true
+
+  '@next/swc-win32-arm64-msvc@15.2.0':
     optional: true
 
   '@next/swc-win32-ia32-msvc@14.2.11':
@@ -12784,6 +12879,9 @@ snapshots:
     optional: true
 
   '@next/swc-win32-x64-msvc@15.1.7':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@15.2.0':
     optional: true
 
   '@noble/ciphers@1.1.3': {}
@@ -12979,7 +13077,7 @@ snapshots:
       '@react-aria/interactions': 3.22.2(react@19.0.0-rc-3208e73e-20240730)
       '@react-aria/utils': 3.25.2(react@19.0.0-rc-3208e73e-20240730)
       '@react-types/shared': 3.24.1(react@19.0.0-rc-3208e73e-20240730)
-      '@swc/helpers': 0.5.12
+      '@swc/helpers': 0.5.15
       clsx: 2.1.1
       react: 19.0.0-rc-3208e73e-20240730
 
@@ -12988,7 +13086,7 @@ snapshots:
       '@react-aria/ssr': 3.9.5(react@19.0.0-rc-3208e73e-20240730)
       '@react-aria/utils': 3.25.2(react@19.0.0-rc-3208e73e-20240730)
       '@react-types/shared': 3.24.1(react@19.0.0-rc-3208e73e-20240730)
-      '@swc/helpers': 0.5.12
+      '@swc/helpers': 0.5.15
       react: 19.0.0-rc-3208e73e-20240730
 
   '@react-aria/ssr@3.9.5(react@19.0.0-rc-3208e73e-20240730)':
@@ -16021,7 +16119,7 @@ snapshots:
       debug: 4.3.6
       enhanced-resolve: 5.17.1
       eslint: 8.57.1
-      eslint-module-utils: 2.11.0(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
+      eslint-module-utils: 2.11.0(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0)(eslint@8.57.1))(eslint@8.57.1)
       fast-glob: 3.3.2
       get-tsconfig: 4.8.0
       is-bun-module: 1.2.1
@@ -16040,7 +16138,7 @@ snapshots:
       debug: 4.3.6
       enhanced-resolve: 5.17.1
       eslint: 8.57.1
-      eslint-module-utils: 2.11.0(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
+      eslint-module-utils: 2.11.0(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1)
       fast-glob: 3.3.2
       get-tsconfig: 4.8.0
       is-bun-module: 1.2.1
@@ -16059,7 +16157,7 @@ snapshots:
       debug: 4.3.6
       enhanced-resolve: 5.17.1
       eslint: 9.11.1(jiti@1.21.6)
-      eslint-module-utils: 2.11.0(@typescript-eslint/parser@8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.11.1(jiti@1.21.6))
+      eslint-module-utils: 2.11.0(@typescript-eslint/parser@8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.11.1(jiti@1.21.6)))(eslint@9.11.1(jiti@1.21.6))
       fast-glob: 3.3.2
       get-tsconfig: 4.8.0
       is-bun-module: 1.2.1
@@ -16078,7 +16176,7 @@ snapshots:
       debug: 4.3.6
       enhanced-resolve: 5.17.1
       eslint: 9.19.0(jiti@1.21.6)
-      eslint-module-utils: 2.11.0(@typescript-eslint/parser@8.7.0(eslint@9.19.0(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.19.0(jiti@1.21.6))
+      eslint-module-utils: 2.11.0(@typescript-eslint/parser@8.7.0(eslint@9.19.0(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.7.0(eslint@9.19.0(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.19.0(jiti@1.21.6)))(eslint@9.19.0(jiti@1.21.6))
       fast-glob: 3.3.2
       get-tsconfig: 4.8.0
       is-bun-module: 1.2.1
@@ -16091,7 +16189,18 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.11.0(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1):
+  eslint-module-utils@2.11.0(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0)(eslint@8.57.1))(eslint@8.57.1):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.7.0(eslint@8.57.1)(typescript@5.7.3)
+      eslint: 8.57.1
+      eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0)(eslint@8.57.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.11.0(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -16102,7 +16211,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.11.0(@typescript-eslint/parser@8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.11.1(jiti@1.21.6)):
+  eslint-module-utils@2.11.0(@typescript-eslint/parser@8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.11.1(jiti@1.21.6)))(eslint@9.11.1(jiti@1.21.6)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -16113,7 +16222,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.11.0(@typescript-eslint/parser@8.7.0(eslint@9.19.0(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.19.0(jiti@1.21.6)):
+  eslint-module-utils@2.11.0(@typescript-eslint/parser@8.7.0(eslint@9.19.0(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.7.0(eslint@9.19.0(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.19.0(jiti@1.21.6)))(eslint@9.19.0(jiti@1.21.6)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -16124,7 +16233,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -16135,7 +16244,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.11.1(jiti@1.21.6)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.11.1(jiti@1.21.6)))(eslint@9.11.1(jiti@1.21.6)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -16146,7 +16255,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.7.0(eslint@9.19.0(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.19.0(jiti@1.21.6)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.7.0(eslint@9.19.0(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.7.0(eslint@9.19.0(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.19.0(jiti@1.21.6)))(eslint@9.19.0(jiti@1.21.6)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -16168,7 +16277,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.11.0(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
+      eslint-module-utils: 2.11.0(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0)(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -16196,7 +16305,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -16225,7 +16334,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.11.1(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.11.1(jiti@1.21.6))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.7.0(eslint@9.11.1(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.11.1(jiti@1.21.6)))(eslint@9.11.1(jiti@1.21.6))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -16254,7 +16363,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.19.0(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.7.0(eslint@9.19.0(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.19.0(jiti@1.21.6))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.7.0(eslint@9.19.0(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.7.0(eslint@9.19.0(jiti@1.21.6))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.19.0(jiti@1.21.6)))(eslint@9.19.0(jiti@1.21.6))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -18407,6 +18516,33 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.1.7
       '@next/swc-win32-arm64-msvc': 15.1.7
       '@next/swc-win32-x64-msvc': 15.1.7
+      '@opentelemetry/api': 1.9.0
+      '@playwright/test': 1.47.0
+      sharp: 0.33.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
+  next@15.2.0(@opentelemetry/api@1.9.0)(@playwright/test@1.47.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+    dependencies:
+      '@next/env': 15.2.0
+      '@swc/counter': 0.1.3
+      '@swc/helpers': 0.5.15
+      busboy: 1.6.0
+      caniuse-lite: 1.0.30001664
+      postcss: 8.4.31
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+      styled-jsx: 5.1.6(react@19.0.0)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 15.2.0
+      '@next/swc-darwin-x64': 15.2.0
+      '@next/swc-linux-arm64-gnu': 15.2.0
+      '@next/swc-linux-arm64-musl': 15.2.0
+      '@next/swc-linux-x64-gnu': 15.2.0
+      '@next/swc-linux-x64-musl': 15.2.0
+      '@next/swc-win32-arm64-msvc': 15.2.0
+      '@next/swc-win32-x64-msvc': 15.2.0
       '@opentelemetry/api': 1.9.0
       '@playwright/test': 1.47.0
       sharp: 0.33.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -42,7 +42,7 @@ catalogs:
     "@types/react-dom": 19.0.0
     "@types/react": 19.0.0
     autoprefixer: 10.4.15
-    next: 15.1.0
+    next: 15.2.0
     postcss: 8.4.27
     react-dom: 19.0.0
     react: 19.0.0


### PR DESCRIPTION
Should fix #432 #373 and #333

Next 15.2 introduced a change that create an `AbortController` https://github.com/vercel/next.js/pull/73975/files as a const outside of the request context.
This `AbortController` cause an issue while requiring app router pages that makes all these require return `{}` instead of the actual module in workerd. (see the comment for more detail)

It also replace the define of `process.env.NEXT_MINIMAL` inside of esbuild by a custom plugin that keep the `renderHTML` that can be used as a fallback by Next in case of error.

It also bump next version to 15.2.0 for the e2e examples

It's a draft for now, if workerd is not expected to throw for this case we could remove almost everything in this PR and just bump wrangler once fixed and merged