### PR TITLE
fix: deployed worker unable to invoke itself in memory queue

### DIFF
--- a/.changeset/spicy-seas-appear.md
+++ b/.changeset/spicy-seas-appear.md
@@ -3,3 +3,18 @@
 ---
 
 fix: deployed worker unable to invoke itself in memory queue
+
+In deployments, Cloudflare Workers are unable to invoke workers on the same account via fetch, and the recommended way to call a worker is to use a service binding. This change switches to use service bindings for the memory queue to avoid issues with worker-to-worker subrequests.
+
+To continue using the memory queue, add a service binding to your wrangler config for the binding `NEXT_CACHE_REVALIDATION_WORKER`.
+
+```json
+{
+  "services": [
+    {
+      "binding": "NEXT_CACHE_REVALIDATION_WORKER",
+      "service": "<WORKER_NAME>"
+    }
+  ]
+}
+```

--- a/.changeset/spicy-seas-appear.md
+++ b/.changeset/spicy-seas-appear.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+fix: deployed worker unable to invoke itself in memory queue

--- a/examples/e2e/app-pages-router/wrangler.json
+++ b/examples/e2e/app-pages-router/wrangler.json
@@ -13,5 +13,11 @@
       "binding": "NEXT_CACHE_WORKERS_KV",
       "id": "<BINDING_ID>"
     }
+  ],
+  "services": [
+    {
+      "binding": "NEXT_CACHE_REVALIDATION_WORKER",
+      "service": "app-pages-router"
+    }
   ]
 }

--- a/examples/e2e/app-router/wrangler.json
+++ b/examples/e2e/app-router/wrangler.json
@@ -20,5 +20,11 @@
       "database_id": "NEXT_CACHE_D1",
       "database_name": "NEXT_CACHE_D1"
     }
+  ],
+  "services": [
+    {
+      "binding": "NEXT_CACHE_REVALIDATION_WORKER",
+      "service": "app-router"
+    }
   ]
 }

--- a/examples/e2e/pages-router/wrangler.json
+++ b/examples/e2e/pages-router/wrangler.json
@@ -13,5 +13,11 @@
       "binding": "NEXT_CACHE_WORKERS_KV",
       "id": "<BINDING_ID>"
     }
+  ],
+  "services": [
+    {
+      "binding": "NEXT_CACHE_REVALIDATION_WORKER",
+      "service": "pages-router"
+    }
   ]
 }

--- a/packages/cloudflare/src/api/cloudflare-context.ts
+++ b/packages/cloudflare/src/api/cloudflare-context.ts
@@ -6,6 +6,7 @@ declare global {
     NEXT_CACHE_D1?: D1Database;
     NEXT_CACHE_D1_TAGS_TABLE?: string;
     NEXT_CACHE_D1_REVALIDATIONS_TABLE?: string;
+    NEXT_CACHE_REVALIDATION_WORKER?: Service;
     ASSETS?: Fetcher;
   }
 }


### PR DESCRIPTION
Service bindings are required for fetching the same worker in production.

A bit of a shame that our local e2es were unable to catch this as wrangler doesn't fail when doing fetches in local mode.

Docs PR - https://github.com/opennextjs/docs/pull/89