### PR TITLE
Durable Queue Storage

### DIFF
--- a/.changeset/smart-bugs-play.md
+++ b/.changeset/smart-bugs-play.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+feat: durable object de-duping revalidation queue

--- a/examples/e2e/app-router/wrangler.jsonc
+++ b/examples/e2e/app-router/wrangler.jsonc
@@ -19,7 +19,7 @@
   "migrations": [
     {
       "tag": "v1",
-      "new_classes": ["DurableObjectQueueHandler"]
+      "new_sqlite_classes": ["DurableObjectQueueHandler"]
     }
   ],
   "kv_namespaces": [

--- a/packages/cloudflare/src/api/cloudflare-context.ts
+++ b/packages/cloudflare/src/api/cloudflare-context.ts
@@ -18,6 +18,17 @@ declare global {
     NEXT_CACHE_REVALIDATION_DURABLE_OBJECT?: DurableObjectNamespace<DurableObjectQueueHandler>;
     // Asset binding
     ASSETS?: Fetcher;
+
+    // Below are the potential environment variables that can be set by the user to configure the durable object queue handler
+    // The max number of revalidations that can be processed by the durable worker at the same time
+    MAX_REVALIDATION_BY_DURABLE_OBJECT?: string;
+    // The max time in milliseconds that a revalidation can take before being considered as failed
+    REVALIDATION_TIMEOUT_MS?: string;
+    // The amount of time after which a revalidation will be attempted again if it failed
+    // If it fails again it will exponentially back off until it reaches the max retry interval
+    REVALIDATION_RETRY_INTERVAL_MS?: string;
+    // The maximum number of attempts that can be made to revalidate a path
+    MAX_REVALIDATION_ATTEMPTS?: string;
   }
 }
 

--- a/packages/cloudflare/src/api/durable-objects/queue.spec.ts
+++ b/packages/cloudflare/src/api/durable-objects/queue.spec.ts
@@ -208,10 +208,10 @@ describe("DurableObjectQueue", () => {
 
     it("should add an alarm if there are failed states", async () => {
       const queue = createDurableObjectQueue({ fetchDuration: 10 });
-      const nextAlarm = Date.now() + 1000;
-      queue.routeInFailedState.set("id", { msg: createMessage("id"), retryCount: 0, nextAlarmMs: nextAlarm });
+      const nextAlarmMs = Date.now() + 1000;
+      queue.routeInFailedState.set("id", { msg: createMessage("id"), retryCount: 0, nextAlarmMs });
       await queue.addAlarm();
-      expect(getStorage(queue).setAlarm).toHaveBeenCalledWith(nextAlarm);
+      expect(getStorage(queue).setAlarm).toHaveBeenCalledWith(nextAlarmMs);
     });
 
     it("should not add an alarm if there is already an alarm set", async () => {
@@ -225,9 +225,9 @@ describe("DurableObjectQueue", () => {
 
     it("should set the alarm to the lowest nextAlarm", async () => {
       const queue = createDurableObjectQueue({ fetchDuration: 10 });
-      const nextAlarm = Date.now() + 1000;
+      const nextAlarmMs = Date.now() + 1000;
       const firstAlarm = Date.now() + 500;
-      queue.routeInFailedState.set("id", { msg: createMessage("id"), retryCount: 0, nextAlarmMs: nextAlarm });
+      queue.routeInFailedState.set("id", { msg: createMessage("id"), retryCount: 0, nextAlarmMs });
       queue.routeInFailedState.set("id2", {
         msg: createMessage("id2"),
         retryCount: 0,

--- a/packages/cloudflare/src/api/durable-objects/queue.spec.ts
+++ b/packages/cloudflare/src/api/durable-objects/queue.spec.ts
@@ -26,6 +26,9 @@ const createDurableObjectQueue = ({
     storage: {
       setAlarm: vi.fn(),
       getAlarm: vi.fn(),
+      sql: {
+        exec: vi.fn(),
+      },
     },
   };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -102,8 +105,9 @@ describe("DurableObjectQueue", () => {
       expect(queue.ongoingRevalidations.has("id6")).toBe(false);
       expect(Array.from(queue.ongoingRevalidations.keys())).toEqual(["id", "id2", "id3", "id4", "id5"]);
 
+      // BlockConcurrencyWhile is called twice here, first time during creation of the object and second time when we try to revalidate
       // @ts-expect-error
-      expect(queue.ctx.blockConcurrencyWhile).toHaveBeenCalledTimes(1);
+      expect(queue.ctx.blockConcurrencyWhile).toHaveBeenCalledTimes(2);
 
       // Here we await the blocked request to ensure it's resolved
       await blockedReq;
@@ -201,9 +205,10 @@ describe("DurableObjectQueue", () => {
 
     it("should add an alarm if there are failed states", async () => {
       const queue = createDurableObjectQueue({ fetchDuration: 10 });
-      queue.routeInFailedState.set("id", { msg: createMessage("id"), retryCount: 0, nextAlarmMs: 1000 });
+      const nextAlarm = Date.now() + 1000;
+      queue.routeInFailedState.set("id", { msg: createMessage("id"), retryCount: 0, nextAlarmMs: nextAlarm });
       await queue.addAlarm();
-      expect(getStorage(queue).setAlarm).toHaveBeenCalledWith(1000);
+      expect(getStorage(queue).setAlarm).toHaveBeenCalledWith(nextAlarm);
     });
 
     it("should not add an alarm if there is already an alarm set", async () => {
@@ -217,10 +222,16 @@ describe("DurableObjectQueue", () => {
 
     it("should set the alarm to the lowest nextAlarm", async () => {
       const queue = createDurableObjectQueue({ fetchDuration: 10 });
-      queue.routeInFailedState.set("id", { msg: createMessage("id"), retryCount: 0, nextAlarmMs: 1000 });
-      queue.routeInFailedState.set("id2", { msg: createMessage("id2"), retryCount: 0, nextAlarmMs: 500 });
+      const nextAlarm = Date.now() + 1000;
+      const firstAlarm = Date.now() + 500;
+      queue.routeInFailedState.set("id", { msg: createMessage("id"), retryCount: 0, nextAlarmMs: nextAlarm });
+      queue.routeInFailedState.set("id2", {
+        msg: createMessage("id2"),
+        retryCount: 0,
+        nextAlarmMs: firstAlarm,
+      });
       await queue.addAlarm();
-      expect(getStorage(queue).setAlarm).toHaveBeenCalledWith(500);
+      expect(getStorage(queue).setAlarm).toHaveBeenCalledWith(firstAlarm);
     });
   });
 

--- a/packages/cloudflare/src/api/durable-objects/queue.spec.ts
+++ b/packages/cloudflare/src/api/durable-objects/queue.spec.ts
@@ -28,7 +28,7 @@ const createDurableObjectQueue = ({
       getAlarm: vi.fn(),
       sql: {
         exec: vi.fn().mockImplementation(() => ({
-          one: vi.fn()
+          one: vi.fn(),
         })),
       },
     },
@@ -65,6 +65,7 @@ const createMessage = (dedupId: string, lastModified = Date.now()) => ({
 describe("DurableObjectQueue", () => {
   describe("successful revalidation", () => {
     it("should process a single revalidation", async () => {
+      process.env.__NEXT_PREVIEW_MODE_ID = "test";
       const queue = createDurableObjectQueue({ fetchDuration: 10 });
       const firstRequest = await queue.revalidate(createMessage("id"));
       expect(firstRequest).toBeUndefined();

--- a/packages/cloudflare/src/api/durable-objects/queue.spec.ts
+++ b/packages/cloudflare/src/api/durable-objects/queue.spec.ts
@@ -27,7 +27,9 @@ const createDurableObjectQueue = ({
       setAlarm: vi.fn(),
       getAlarm: vi.fn(),
       sql: {
-        exec: vi.fn(),
+        exec: vi.fn().mockImplementation(() => ({
+          one: vi.fn()
+        })),
       },
     },
   };

--- a/packages/cloudflare/src/api/durable-objects/queue.ts
+++ b/packages/cloudflare/src/api/durable-objects/queue.ts
@@ -272,17 +272,17 @@ export class DurableObjectQueueHandler extends DurableObject<CloudflareEnv> {
    */
   checkSyncTable(msg: QueueMessage) {
     try {
-      const isNewer = this.sql
+      const numNewer = this.sql
         .exec<{
-          isNewer: number;
+          numNewer: number;
         }>(
-          "SELECT COUNT(*) as isNewer FROM sync WHERE id = ? AND lastSuccess > ?",
+          "SELECT COUNT(*) as numNewer FROM sync WHERE id = ? AND lastSuccess > ? LIMIT 1",
           `${msg.MessageBody.host}${msg.MessageBody.url}`,
           Math.round(msg.MessageBody.lastModified / 1000)
         )
-        .one().isNewer;
+        .one().numNewer;
 
-      return isNewer > 0;
+      return numNewer > 0;
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
     } catch (e: unknown) {
       return false;

--- a/packages/cloudflare/src/api/durable-objects/queue.ts
+++ b/packages/cloudflare/src/api/durable-objects/queue.ts
@@ -32,10 +32,10 @@ export class DurableObjectQueueHandler extends DurableObject<CloudflareEnv> {
   service: NonNullable<CloudflareEnv["NEXT_CACHE_REVALIDATION_WORKER"]>;
 
   // Configurable params
-  maxRevalidations = DEFAULT_MAX_REVALIDATION_BY_DURABLE_OBJECT;
-  revalidationTimeout = DEFAULT_REVALIDATION_TIMEOUT_MS;
-  revalidationRetryInterval = DEFAULT_REVALIDATION_RETRY_INTERVAL_MS;
-  maxRevalidationAttempts = DEFAULT_MAX_REVALIDATION_ATTEMPTS;
+  readonly maxRevalidations: number;
+  readonly revalidationTimeout: number;
+  readonly revalidationRetryInterval: number;
+  readonly maxRevalidationAttempts: number;
 
   constructor(ctx: DurableObjectState, env: CloudflareEnv) {
     super(ctx, env);

--- a/packages/cloudflare/src/api/durable-objects/queue.ts
+++ b/packages/cloudflare/src/api/durable-objects/queue.ts
@@ -202,7 +202,8 @@ export class DurableObjectQueueHandler extends DurableObject<CloudflareEnv> {
         this.routeInFailedState.delete(msg.MessageDeduplicationId);
         return;
       }
-      const nextAlarmMs = Date.now() + Math.pow(2, existingFailedState.retryCount + 1) * this.revalidationRetryInterval;
+      const nextAlarmMs =
+        Date.now() + Math.pow(2, existingFailedState.retryCount + 1) * this.revalidationRetryInterval;
       updatedFailedState = {
         ...existingFailedState,
         retryCount: existingFailedState.retryCount + 1,

--- a/packages/cloudflare/src/api/durable-queue.ts
+++ b/packages/cloudflare/src/api/durable-queue.ts
@@ -11,10 +11,8 @@ export default {
 
     const id = durableObject.idFromName(msg.MessageGroupId);
     const stub = durableObject.get(id);
-    const previewModeId = process.env.__NEXT_PREVIEW_MODE_ID!;
     await stub.revalidate({
       ...msg,
-      previewModeId,
     });
   },
 } satisfies Queue;

--- a/packages/cloudflare/src/cli/build/build.ts
+++ b/packages/cloudflare/src/cli/build/build.ts
@@ -14,6 +14,7 @@ import type { ProjectOptions } from "../project-options.js";
 import { bundleServer } from "./bundle-server.js";
 import { compileCacheAssetsManifestSqlFile } from "./open-next/compile-cache-assets-manifest.js";
 import { compileEnvFiles } from "./open-next/compile-env-files.js";
+import { compileDurableObjects } from "./open-next/compileDurableObjects.js";
 import { copyCacheAssets } from "./open-next/copyCacheAssets.js";
 import { createServerBundle } from "./open-next/createServerBundle.js";
 import {
@@ -96,6 +97,8 @@ export async function build(projectOpts: ProjectOptions): Promise<void> {
   }
 
   await createServerBundle(options);
+
+  await compileDurableObjects(options);
 
   await bundleServer(options);
 

--- a/packages/cloudflare/src/cli/build/bundle-server.ts
+++ b/packages/cloudflare/src/cli/build/bundle-server.ts
@@ -58,14 +58,6 @@ export async function bundleServer(buildOpts: BuildOptions): Promise<void> {
   const serverFiles = path.join(baseManifestPath, "required-server-files.json");
   const nextConfig = JSON.parse(fs.readFileSync(serverFiles, "utf-8")).config;
 
-  // TODO: This is a temporary solution to get the previewModeId from the prerender-manifest.json
-  //       We should find a better way to get this value, probably directly provided from aws
-  //       probably in an env variable exactly as for BUILD_ID
-  const prerenderManifest = path.join(baseManifestPath, "prerender-manifest.json");
-  const prerenderManifestContent = fs.readFileSync(prerenderManifest, "utf-8");
-  const prerenderManifestJson = JSON.parse(prerenderManifestContent);
-  const previewModeId = prerenderManifestJson.preview.previewModeId;
-
   console.log(`\x1b[35m⚙️ Bundling the OpenNext server...\n\x1b[0m`);
 
   await patchWebpackRuntime(buildOpts);
@@ -153,8 +145,6 @@ export async function bundleServer(buildOpts: BuildOptions): Promise<void> {
       "process.env.TURBOPACK": "false",
       // This define should be safe to use for Next 14.2+, earlier versions (13.5 and less) will cause trouble
       "process.env.__NEXT_EXPERIMENTAL_REACT": `${needsExperimentalReact(nextConfig)}`,
-      // Used for the durable object queue handler
-      "process.env.__NEXT_PREVIEW_MODE_ID": `"${previewModeId}"`,
     },
     platform: "node",
     banner: {

--- a/packages/cloudflare/src/cli/build/open-next/compileDurableObjects.ts
+++ b/packages/cloudflare/src/cli/build/open-next/compileDurableObjects.ts
@@ -2,8 +2,7 @@ import fs from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
 
-import { type BuildOptions, getPackagePath } from "@opennextjs/aws/build/helper.js";
-import { build } from "esbuild";
+import { type BuildOptions, esbuildSync, getPackagePath } from "@opennextjs/aws/build/helper.js";
 
 export function compileDurableObjects(buildOpts: BuildOptions) {
   const _require = createRequire(import.meta.url);
@@ -26,16 +25,19 @@ export function compileDurableObjects(buildOpts: BuildOptions) {
 
   const BUILD_ID = fs.readFileSync(path.join(baseManifestPath, "BUILD_ID"), "utf-8");
 
-  return build({
-    entryPoints,
-    bundle: true,
-    platform: "node",
-    format: "esm",
-    outdir: path.join(buildOpts.buildDir, "durable-objects"),
-    external: ["cloudflare:workers"],
-    define: {
-      "process.env.__NEXT_PREVIEW_MODE_ID": `"${previewModeId}"`,
-      "process.env.__NEXT_BUILD_ID": `"${BUILD_ID}"`,
+  return esbuildSync(
+    {
+      entryPoints,
+      bundle: true,
+      platform: "node",
+      format: "esm",
+      outdir: path.join(buildOpts.buildDir, "durable-objects"),
+      external: ["cloudflare:workers"],
+      define: {
+        "process.env.__NEXT_PREVIEW_MODE_ID": `"${previewModeId}"`,
+        "process.env.__NEXT_BUILD_ID": `"${BUILD_ID}"`,
+      },
     },
-  });
+    buildOpts
+  );
 }

--- a/packages/cloudflare/src/cli/build/open-next/compileDurableObjects.ts
+++ b/packages/cloudflare/src/cli/build/open-next/compileDurableObjects.ts
@@ -1,7 +1,7 @@
-import fs from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
 
+import { loadBuildId, loadPrerenderManifest } from "@opennextjs/aws/adapters/config/util.js";
 import { type BuildOptions, esbuildSync, getPackagePath } from "@opennextjs/aws/build/helper.js";
 
 export function compileDurableObjects(buildOpts: BuildOptions) {
@@ -17,13 +17,12 @@ export function compileDurableObjects(buildOpts: BuildOptions) {
     ".next"
   );
 
-  // TODO: Reuse the manifest
-  const prerenderManifest = path.join(baseManifestPath, "prerender-manifest.json");
-  const prerenderManifestContent = fs.readFileSync(prerenderManifest, "utf-8");
-  const prerenderManifestJson = JSON.parse(prerenderManifestContent);
-  const previewModeId = prerenderManifestJson.preview.previewModeId;
+  // We need to change the type in aws
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const prerenderManifest = loadPrerenderManifest(baseManifestPath) as any;
+  const previewModeId = prerenderManifest.preview.previewModeId;
 
-  const BUILD_ID = fs.readFileSync(path.join(baseManifestPath, "BUILD_ID"), "utf-8");
+  const BUILD_ID = loadBuildId(baseManifestPath);
 
   return esbuildSync(
     {

--- a/packages/cloudflare/src/cli/build/open-next/compileDurableObjects.ts
+++ b/packages/cloudflare/src/cli/build/open-next/compileDurableObjects.ts
@@ -1,0 +1,41 @@
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+
+import { type BuildOptions, getPackagePath } from "@opennextjs/aws/build/helper.js";
+import { build } from "esbuild";
+
+export function compileDurableObjects(buildOpts: BuildOptions) {
+  const _require = createRequire(import.meta.url);
+  const entryPoints = [_require.resolve("@opennextjs/cloudflare/durable-objects/queue")];
+
+  const { outputDir } = buildOpts;
+
+  const baseManifestPath = path.join(
+    outputDir,
+    "server-functions/default",
+    getPackagePath(buildOpts),
+    ".next"
+  );
+
+  // TODO: Reuse the manifest
+  const prerenderManifest = path.join(baseManifestPath, "prerender-manifest.json");
+  const prerenderManifestContent = fs.readFileSync(prerenderManifest, "utf-8");
+  const prerenderManifestJson = JSON.parse(prerenderManifestContent);
+  const previewModeId = prerenderManifestJson.preview.previewModeId;
+
+  const BUILD_ID = fs.readFileSync(path.join(baseManifestPath, "BUILD_ID"), "utf-8");
+
+  return build({
+    entryPoints,
+    bundle: true,
+    platform: "node",
+    format: "esm",
+    outdir: path.join(buildOpts.buildDir, "durable-objects"),
+    external: ["cloudflare:workers"],
+    define: {
+      "process.env.__NEXT_PREVIEW_MODE_ID": `"${previewModeId}"`,
+      "process.env.__NEXT_BUILD_ID": `"${BUILD_ID}"`,
+    },
+  });
+}

--- a/packages/cloudflare/src/cli/templates/worker.ts
+++ b/packages/cloudflare/src/cli/templates/worker.ts
@@ -18,7 +18,7 @@ Object.defineProperty(globalThis, Symbol.for("__cloudflare-context__"), {
 });
 
 //@ts-expect-error: Will be resolved by wrangler build
-export { DurableObjectQueueHandler } from "@opennextjs/cloudflare/durable-objects/queue";
+export { DurableObjectQueueHandler } from "./.build/durable-objects/queue.js";
 
 // Populate process.env on the first request
 let processEnvPopulated = false;


### PR DESCRIPTION
It is a follow up of #459
It adds storage to the Durable object allowing it to better handle failure
It also allows it to handle eventually consistent incremental cache implementation by checking for every route if the route has been revalidated (Note that this does not cover On-Demand revalidation )

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #460 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #459 
<!-- GitButler Footer Boundary Bottom -->

