### PR TITLE
feat: support passing options to init open-next cloudflare dev function

### DIFF
--- a/.changeset/shaggy-bobcats-battle.md
+++ b/.changeset/shaggy-bobcats-battle.md
@@ -14,4 +14,4 @@ initOpenNextCloudflareForDev({
 });
 ```
 
-You can find the type with the available options [here](https://github.com/cloudflare/workers-sdk/blob/main/packages/wrangler/src/api/integrations/platform/index.ts#L32) in the Wrangler source code. Please note that the `environment` field is not customizable as it's used internally by OpenNext.js. If you have a use case where overriding `environment` is necessary, please let us know by opening a [feature request](https://github.com/cloudflare/workers-sdk/issues).
+You can find the configuration type with it's available options [here](https://github.com/cloudflare/workers-sdk/blob/main/packages/wrangler/src/api/integrations/platform/index.ts#L32) in the Wrangler source code.

--- a/.changeset/shaggy-bobcats-battle.md
+++ b/.changeset/shaggy-bobcats-battle.md
@@ -1,0 +1,15 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+Adds support for passing options to initOpenNextCloudflareForDev().
+
+For example:
+
+```ts
+initOpenNextCloudflareForDev({
+  persist: {
+    path: "../../.wrangler/state/v3/custom-dir",
+  },
+});
+```

--- a/.changeset/shaggy-bobcats-battle.md
+++ b/.changeset/shaggy-bobcats-battle.md
@@ -2,9 +2,9 @@
 "@opennextjs/cloudflare": patch
 ---
 
-Adds support for passing options to initOpenNextCloudflareForDev().
+Adds support for passing options to `initOpenNextCloudflareForDev()`. This allows you to configure how your Cloudflare bindings will behave during [local development](https://opennext.js.org/cloudflare/get-started#11-develop-locally).
 
-For example:
+For example, the below configuration will persist the local state of bindings to a custom directory. Which can be useful if you want to share the state between different apps that reuse the same bindings in a monorepo.
 
 ```ts
 initOpenNextCloudflareForDev({
@@ -13,3 +13,5 @@ initOpenNextCloudflareForDev({
   },
 });
 ```
+
+You can find the type with the available options [here](https://github.com/cloudflare/workers-sdk/blob/main/packages/wrangler/src/api/integrations/platform/index.ts#L32) in the Wrangler source code. Please note that the `environment` field is not customizable as it's used internally by OpenNext.js. If you have a use case where overriding `environment` is necessary, please let us know by opening a [feature request](https://github.com/cloudflare/workers-sdk/issues).

--- a/packages/cloudflare/src/api/cloudflare-context.ts
+++ b/packages/cloudflare/src/api/cloudflare-context.ts
@@ -299,7 +299,7 @@ async function getCloudflareContextFromWrangler<
   const { env, cf, ctx } = await getPlatformProxy({
     // This allows the selection of a wrangler environment while running in next dev mode
     ...options,
-    environment: process.env.NEXT_DEV_WRANGLER_ENV,   
+    environment: process.env.NEXT_DEV_WRANGLER_ENV,
   });
   return {
     env,

--- a/packages/cloudflare/src/api/cloudflare-context.ts
+++ b/packages/cloudflare/src/api/cloudflare-context.ts
@@ -208,12 +208,13 @@ async function getCloudflareContextAsync<
  * with the open-next Cloudflare adapter
  *
  * Note: this function should only be called inside the Next.js config file, and although async it doesn't need to be `await`ed
+ * @param options options how the function should operate and if/where to persist the platform data
  */
-export async function initOpenNextCloudflareForDev() {
+export async function initOpenNextCloudflareForDev(options?: Omit<GetPlatformProxyOptions, "environment">) {
   const shouldInitializationRun = shouldContextInitializationRun();
   if (!shouldInitializationRun) return;
 
-  const context = await getCloudflareContextFromWrangler();
+  const context = await getCloudflareContextFromWrangler(options);
 
   addCloudflareContextToNodejsGlobal(context);
 

--- a/packages/cloudflare/src/api/cloudflare-context.ts
+++ b/packages/cloudflare/src/api/cloudflare-context.ts
@@ -210,9 +210,16 @@ async function getCloudflareContextAsync<
  * Note: this function should only be called inside the Next.js config file, and although async it doesn't need to be `await`ed
  * @param options options on how the function should operate and if/where to persist the platform data
  */
-export async function initOpenNextCloudflareForDev(options?: Omit<GetPlatformProxyOptions, "environment">) {
+export async function initOpenNextCloudflareForDev(options?: GetPlatformProxyOptions) {
   const shouldInitializationRun = shouldContextInitializationRun();
   if (!shouldInitializationRun) return;
+
+  if (options?.environment && process.env.NEXT_DEV_WRANGLER_ENV) {
+    console.warn(
+      `'initOpenNextCloudflareForDev' has been called with an environment option while NEXT_DEV_WRANGLER_ENV is set.` +
+        ` NEXT_DEV_WRANGLER_ENV will be ignored and the environment will be set to: '${options.environment}'`
+    );
+  }
 
   const context = await getCloudflareContextFromWrangler(options);
 
@@ -293,13 +300,16 @@ async function monkeyPatchVmModuleEdgeContext(cloudflareContext: CloudflareConte
 async function getCloudflareContextFromWrangler<
   CfProperties extends Record<string, unknown> = IncomingRequestCfProperties,
   Context = ExecutionContext,
->(options?: Omit<GetPlatformProxyOptions, "environment">): Promise<CloudflareContext<CfProperties, Context>> {
+>(options?: GetPlatformProxyOptions): Promise<CloudflareContext<CfProperties, Context>> {
   // Note: we never want wrangler to be bundled in the Next.js app, that's why the import below looks like it does
   const { getPlatformProxy } = await import(/* webpackIgnore: true */ `${"__wrangler".replaceAll("_", "")}`);
+
+  // This allows the selection of a wrangler environment while running in next dev mode
+  const environment = options?.environment ?? process.env.NEXT_DEV_WRANGLER_ENV;
+
   const { env, cf, ctx } = await getPlatformProxy({
-    // This allows the selection of a wrangler environment while running in next dev mode
     ...options,
-    environment: process.env.NEXT_DEV_WRANGLER_ENV,
+    environment,
   });
   return {
     env,

--- a/packages/cloudflare/src/api/cloudflare-context.ts
+++ b/packages/cloudflare/src/api/cloudflare-context.ts
@@ -208,7 +208,7 @@ async function getCloudflareContextAsync<
  * with the open-next Cloudflare adapter
  *
  * Note: this function should only be called inside the Next.js config file, and although async it doesn't need to be `await`ed
- * @param options options how the function should operate and if/where to persist the platform data
+ * @param options options on how the function should operate and if/where to persist the platform data
  */
 export async function initOpenNextCloudflareForDev(options?: Omit<GetPlatformProxyOptions, "environment">) {
   const shouldInitializationRun = shouldContextInitializationRun();

--- a/packages/cloudflare/src/api/cloudflare-context.ts
+++ b/packages/cloudflare/src/api/cloudflare-context.ts
@@ -1,5 +1,7 @@
 import type { Context, RunningCodeOptions } from "node:vm";
 
+import type { GetPlatformProxyOptions } from "wrangler";
+
 import type { DurableObjectQueueHandler } from "./durable-objects/queue";
 import { DOShardedTagCache } from "./durable-objects/sharded-tag-cache";
 
@@ -290,12 +292,13 @@ async function monkeyPatchVmModuleEdgeContext(cloudflareContext: CloudflareConte
 async function getCloudflareContextFromWrangler<
   CfProperties extends Record<string, unknown> = IncomingRequestCfProperties,
   Context = ExecutionContext,
->(): Promise<CloudflareContext<CfProperties, Context>> {
+>(options?: Omit<GetPlatformProxyOptions, "environment">): Promise<CloudflareContext<CfProperties, Context>> {
   // Note: we never want wrangler to be bundled in the Next.js app, that's why the import below looks like it does
   const { getPlatformProxy } = await import(/* webpackIgnore: true */ `${"__wrangler".replaceAll("_", "")}`);
   const { env, cf, ctx } = await getPlatformProxy({
     // This allows the selection of a wrangler environment while running in next dev mode
     environment: process.env.NEXT_DEV_WRANGLER_ENV,
+    ...options,
   });
   return {
     env,

--- a/packages/cloudflare/src/api/cloudflare-context.ts
+++ b/packages/cloudflare/src/api/cloudflare-context.ts
@@ -298,8 +298,8 @@ async function getCloudflareContextFromWrangler<
   const { getPlatformProxy } = await import(/* webpackIgnore: true */ `${"__wrangler".replaceAll("_", "")}`);
   const { env, cf, ctx } = await getPlatformProxy({
     // This allows the selection of a wrangler environment while running in next dev mode
-    environment: process.env.NEXT_DEV_WRANGLER_ENV,
     ...options,
+    environment: process.env.NEXT_DEV_WRANGLER_ENV,   
   });
   return {
     env,


### PR DESCRIPTION
To allow same behaviour as `setupDevPlatform()` from next-on-pages. In this case I assume the removal of passing options was not intended. If not, are there any alternatives to the below?

```ts
import { initOpenNextCloudflareForDev } from "@opennextjs/cloudflare";

initOpenNextCloudflareForDev({
  persist: {
    path: "../../.wrangler/state/v3/custom-dir",
  },
});
```

When testing with ` pnpm --filter playground15 preview` the `.wrangler` directory is correctly created in the root of the project. But a `.wrangler` directory also appears within the playground15 directory. So I'm creating this PR so I can use a preview deployment to be able to test in my own app with D1. Or are there better ways to test in this repo itself?

![image](https://github.com/user-attachments/assets/1288aa9a-29da-45a1-8cf1-536cc1dd4f0c)
