### PR TITLE
Feat Sharding Replication

### DIFF
--- a/.changeset/modern-laws-happen.md
+++ b/.changeset/modern-laws-happen.md
@@ -2,4 +2,4 @@
 "@opennextjs/cloudflare": patch
 ---
 
-Add double sharding for the Durable Object Tag Cache
+Add sharding replication for the Durable Object Tag Cache

--- a/.changeset/modern-laws-happen.md
+++ b/.changeset/modern-laws-happen.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+Add double sharding for the Durable Object Tag Cache

--- a/examples/e2e/app-router/open-next.config.ts
+++ b/examples/e2e/app-router/open-next.config.ts
@@ -10,8 +10,8 @@ export default defineCloudflareConfig({
     numberOfShards: 12,
     enableShardReplication: true,
     shardReplicationOptions: {
-      softShards: 8,
-      hardShards: 2,
+      numberOfSoftReplicas: 8,
+      numberOfHardReplicas: 2,
     },
   }),
   queue: doQueue,

--- a/examples/e2e/app-router/open-next.config.ts
+++ b/examples/e2e/app-router/open-next.config.ts
@@ -5,6 +5,14 @@ import doQueue from "@opennextjs/cloudflare/durable-queue";
 
 export default defineCloudflareConfig({
   incrementalCache: kvIncrementalCache,
-  tagCache: shardedTagCache({ numberOfShards: 12}),
+  // With such a configuration, we could have up to 12 * 8 + 12 * 2 = 120 Durable Objects instances
+  tagCache: shardedTagCache({
+    numberOfShards: 12,
+    enableDoubleSharding: true,
+    doubleShardingOpts: {
+      softShards: 8,
+      hardShards: 2,
+    },
+  }),
   queue: doQueue,
 });

--- a/examples/e2e/app-router/open-next.config.ts
+++ b/examples/e2e/app-router/open-next.config.ts
@@ -5,7 +5,7 @@ import doQueue from "@opennextjs/cloudflare/durable-queue";
 
 export default defineCloudflareConfig({
   incrementalCache: kvIncrementalCache,
-  // With such a configuration, we could have up to 12 * 8 + 12 * 2 = 120 Durable Objects instances
+  // With such a configuration, we could have up to 12 * (8 + 2) = 120 Durable Objects instances
   tagCache: shardedTagCache({
     numberOfShards: 12,
     enableShardReplication: true,

--- a/examples/e2e/app-router/open-next.config.ts
+++ b/examples/e2e/app-router/open-next.config.ts
@@ -5,6 +5,6 @@ import doQueue from "@opennextjs/cloudflare/durable-queue";
 
 export default defineCloudflareConfig({
   incrementalCache: kvIncrementalCache,
-  tagCache: shardedTagCache({ numberOfShards: 12 }),
+  tagCache: shardedTagCache({ numberOfShards: 12}),
   queue: doQueue,
 });

--- a/examples/e2e/app-router/open-next.config.ts
+++ b/examples/e2e/app-router/open-next.config.ts
@@ -8,8 +8,8 @@ export default defineCloudflareConfig({
   // With such a configuration, we could have up to 12 * 8 + 12 * 2 = 120 Durable Objects instances
   tagCache: shardedTagCache({
     numberOfShards: 12,
-    enableDoubleSharding: true,
-    doubleShardingOpts: {
+    enableShardReplication: true,
+    shardReplicationOptions: {
       softShards: 8,
       hardShards: 2,
     },

--- a/examples/e2e/app-router/package.json
+++ b/examples/e2e/app-router/package.json
@@ -9,8 +9,7 @@
     "start": "next start --port 3001",
     "lint": "next lint",
     "clean": "rm -rf .turbo node_modules .next .open-next",
-    "d1:clean": "wrangler d1 execute NEXT_CACHE_D1 --command \"DROP TABLE IF EXISTS tags; DROP TABLE IF EXISTS revalidations\"",
-    "build:worker": "pnpm d1:clean && pnpm opennextjs-cloudflare build",
+    "build:worker": "pnpm opennextjs-cloudflare build",
     "preview:worker": "pnpm opennextjs-cloudflare preview",
     "preview": "pnpm build:worker && pnpm preview:worker",
     "e2e": "playwright test -c e2e/playwright.config.ts"

--- a/examples/e2e/app-router/wrangler.jsonc
+++ b/examples/e2e/app-router/wrangler.jsonc
@@ -15,7 +15,7 @@
         "class_name": "DurableObjectQueueHandler"
       },
       {
-        "name": "NEXT_CACHE_D1_SHARDED",
+        "name": "NEXT_CACHE_DO_SHARDED",
         "class_name": "DOShardedTagCache"
       }
     ]
@@ -30,13 +30,6 @@
     {
       "binding": "NEXT_CACHE_WORKERS_KV",
       "id": "<BINDING_ID>"
-    }
-  ],
-  "d1_databases": [
-    {
-      "binding": "NEXT_CACHE_D1",
-      "database_id": "NEXT_CACHE_D1",
-      "database_name": "NEXT_CACHE_D1"
     }
   ],
   "services": [

--- a/packages/cloudflare/src/api/cloudflare-context.ts
+++ b/packages/cloudflare/src/api/cloudflare-context.ts
@@ -24,7 +24,7 @@ declare global {
     // Durables object namespace to use for the sharded tag cache
     NEXT_CACHE_D1_SHARDED?: DurableObjectNamespace<DOShardedTagCache>;
     // Dead letter queue for the D1 sharded tag cache
-    NEXT_CACHE_D1_SHARDED_DLQ?: Queue
+    NEXT_CACHE_D1_SHARDED_DLQ?: Queue;
 
     // Asset binding
     ASSETS?: Fetcher;

--- a/packages/cloudflare/src/api/cloudflare-context.ts
+++ b/packages/cloudflare/src/api/cloudflare-context.ts
@@ -23,6 +23,8 @@ declare global {
     NEXT_CACHE_REVALIDATION_DURABLE_OBJECT?: DurableObjectNamespace<DurableObjectQueueHandler>;
     // Durables object namespace to use for the sharded tag cache
     NEXT_CACHE_D1_SHARDED?: DurableObjectNamespace<DOShardedTagCache>;
+    // Dead letter queue for the D1 sharded tag cache
+    NEXT_CACHE_D1_SHARDED_DLQ?: Queue
 
     // Asset binding
     ASSETS?: Fetcher;

--- a/packages/cloudflare/src/api/cloudflare-context.ts
+++ b/packages/cloudflare/src/api/cloudflare-context.ts
@@ -22,9 +22,11 @@ declare global {
     // Durable Object namespace to use for the durable object queue handler
     NEXT_CACHE_REVALIDATION_DURABLE_OBJECT?: DurableObjectNamespace<DurableObjectQueueHandler>;
     // Durables object namespace to use for the sharded tag cache
-    NEXT_CACHE_D1_SHARDED?: DurableObjectNamespace<DOShardedTagCache>;
-    // Dead letter queue for the D1 sharded tag cache
-    NEXT_CACHE_D1_SHARDED_DLQ?: Queue;
+    NEXT_CACHE_DO_SHARDED?: DurableObjectNamespace<DOShardedTagCache>;
+    // Queue of failed tag write
+    // It could be used for monitoring or to reprocess failed writes
+    // Entirely optional
+    NEXT_CACHE_DO_SHARDED_DLQ?: Queue;
 
     // Asset binding
     ASSETS?: Fetcher;

--- a/packages/cloudflare/src/api/do-sharded-tag-cache.spec.ts
+++ b/packages/cloudflare/src/api/do-sharded-tag-cache.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import doShardedTagCache, { DEFAULT_MAX_HARD_SHARDS, DEFAULT_MAX_SOFT_SHARDS } from "./do-sharded-tag-cache";
+import doShardedTagCache, { DEFAULT_HARD_REPLICAS, DEFAULT_SOFT_REPLICAS } from "./do-sharded-tag-cache";
 
 const hasBeenRevalidatedMock = vi.fn();
 const writeTagsMock = vi.fn();
@@ -13,8 +13,8 @@ const sendDLQMock = vi.fn();
 vi.mock("./cloudflare-context", () => ({
   getCloudflareContext: () => ({
     env: {
-      NEXT_CACHE_D1_SHARDED: { idFromName: idFromNameMock, get: getMock },
-      NEXT_CACHE_D1_SHARDED_DLQ: {
+      NEXT_CACHE_DO_SHARDED: { idFromName: idFromNameMock, get: getMock },
+      NEXT_CACHE_DO_SHARDED_DLQ: {
         send: sendDLQMock,
       },
     },
@@ -83,11 +83,11 @@ describe("DOShardedTagCache", () => {
         // We still need to check if the last part is between the correct boundaries
         const shardId = shardIds[0]?.substring(shardIds[0].lastIndexOf("-") + 1) ?? "";
         expect(parseInt(shardId)).toBeGreaterThanOrEqual(1);
-        expect(parseInt(shardId)).toBeLessThanOrEqual(DEFAULT_MAX_SOFT_SHARDS);
+        expect(parseInt(shardId)).toBeLessThanOrEqual(DEFAULT_SOFT_REPLICAS);
 
         const shardId2 = shardIds[1]?.substring(shardIds[1].lastIndexOf("-") + 1) ?? "";
         expect(parseInt(shardId2)).toBeGreaterThanOrEqual(1);
-        expect(parseInt(shardId2)).toBeLessThanOrEqual(DEFAULT_MAX_HARD_SHARDS);
+        expect(parseInt(shardId2)).toBeLessThanOrEqual(DEFAULT_HARD_REPLICAS);
       });
     });
   });

--- a/packages/cloudflare/src/api/do-sharded-tag-cache.spec.ts
+++ b/packages/cloudflare/src/api/do-sharded-tag-cache.spec.ts
@@ -12,9 +12,12 @@ const waitUntilMock = vi.fn().mockImplementation(async (fn) => fn());
 const sendDLQMock = vi.fn();
 vi.mock("./cloudflare-context", () => ({
   getCloudflareContext: () => ({
-    env: { NEXT_CACHE_D1_SHARDED: { idFromName: idFromNameMock, get: getMock }, NEXT_CACHE_D1_SHARDED_DLQ: {
-      send: sendDLQMock,
-    } },
+    env: {
+      NEXT_CACHE_D1_SHARDED: { idFromName: idFromNameMock, get: getMock },
+      NEXT_CACHE_D1_SHARDED_DLQ: {
+        send: sendDLQMock,
+      },
+    },
     ctx: { waitUntil: waitUntilMock },
   }),
 }));
@@ -175,7 +178,7 @@ describe("DOShardedTagCache", () => {
         dangerous: { disableTagCache: false },
       };
       vi.useFakeTimers();
-      vi.setSystemTime(1000)
+      vi.setSystemTime(1000);
     });
     afterEach(() => {
       vi.useRealTimers();
@@ -277,22 +280,19 @@ describe("DOShardedTagCache", () => {
   });
 
   describe("performWriteTagsWithRetry", () => {
-
     it("should retry if it fails", async () => {
       vi.useFakeTimers();
       vi.setSystemTime(1000);
       const cache = doShardedTagCache();
       writeTagsMock.mockImplementationOnce(() => {
         throw new Error("error");
-      }
-      );
+      });
       const spiedFn = vi.spyOn(cache, "performWriteTagsWithRetry");
       await cache.performWriteTagsWithRetry("shard", ["tag1"], Date.now());
       expect(writeTagsMock).toHaveBeenCalledTimes(2);
       expect(spiedFn).toHaveBeenCalledTimes(2);
       expect(spiedFn).toHaveBeenCalledWith("shard", ["tag1"], 1000, 1);
       expect(sendDLQMock).not.toHaveBeenCalled();
-      
 
       vi.useRealTimers();
     });
@@ -313,7 +313,6 @@ describe("DOShardedTagCache", () => {
       });
 
       vi.useRealTimers();
-    }
-    );
-  })
+    });
+  });
 });

--- a/packages/cloudflare/src/api/do-sharded-tag-cache.spec.ts
+++ b/packages/cloudflare/src/api/do-sharded-tag-cache.spec.ts
@@ -29,15 +29,15 @@ describe("DOShardedTagCache", () => {
     it("should generate a shardId", () => {
       const cache = doShardedTagCache();
       const expectedResult = new Map();
-      expectedResult.set("shard-hard-1-1", ["tag1"]);
-      expectedResult.set("shard-hard-2-1", ["tag2"]);
+      expectedResult.set("tag-hard;shard-1;replica-1", ["tag1"]);
+      expectedResult.set("tag-hard;shard-2;replica-1", ["tag2"]);
       expect(cache.generateShards({ tags: ["tag1", "tag2"] })).toEqual(expectedResult);
     });
 
     it("should group tags by shard", () => {
       const cache = doShardedTagCache();
       const expectedResult = new Map();
-      expectedResult.set("shard-hard-1-1", ["tag1", "tag6"]);
+      expectedResult.set("tag-hard;shard-1;replica-1", ["tag1", "tag6"]);
       expect(cache.generateShards({ tags: ["tag1", "tag6"] })).toEqual(expectedResult);
     });
 
@@ -51,21 +51,21 @@ describe("DOShardedTagCache", () => {
     it("should split hard and soft tags", () => {
       const cache = doShardedTagCache();
       const expectedResult = new Map();
-      expectedResult.set("shard-hard-1-1", ["tag1"]);
-      expectedResult.set("shard-soft-3-1", ["_N_T_/tag1"]);
+      expectedResult.set("tag-hard;shard-1;replica-1", ["tag1"]);
+      expectedResult.set("tag-soft;shard-3;replica-1", ["_N_T_/tag1"]);
       expect(cache.generateShards({ tags: ["tag1", "_N_T_/tag1"] })).toEqual(expectedResult);
     });
 
-    describe("with double sharding", () => {
+    describe("with shard replication", () => {
       it("should generate all shards if generateAllShards is true", () => {
         const cache = doShardedTagCache({ numberOfShards: 4, enableShardReplication: true });
         const expectedResult = new Map();
-        expectedResult.set("shard-hard-1-1", ["tag1"]);
-        expectedResult.set("shard-hard-1-2", ["tag1"]);
-        expectedResult.set("shard-soft-3-1", ["_N_T_/tag1"]);
-        expectedResult.set("shard-soft-3-2", ["_N_T_/tag1"]);
-        expectedResult.set("shard-soft-3-3", ["_N_T_/tag1"]);
-        expectedResult.set("shard-soft-3-4", ["_N_T_/tag1"]);
+        expectedResult.set("tag-hard;shard-1;replica-1", ["tag1"]);
+        expectedResult.set("tag-hard;shard-1;replica-2", ["tag1"]);
+        expectedResult.set("tag-soft;shard-3;replica-1", ["_N_T_/tag1"]);
+        expectedResult.set("tag-soft;shard-3;replica-2", ["_N_T_/tag1"]);
+        expectedResult.set("tag-soft;shard-3;replica-3", ["_N_T_/tag1"]);
+        expectedResult.set("tag-soft;shard-3;replica-4", ["_N_T_/tag1"]);
         expect(cache.generateShards({ tags: ["tag1", "_N_T_/tag1"], generateAllShards: true })).toEqual(
           expectedResult
         );
@@ -77,8 +77,8 @@ describe("DOShardedTagCache", () => {
         expect(shardedMap.size).toBe(2);
         const shardIds = Array.from(shardedMap.keys());
         // We can't test against a specific shard id because the last part is random
-        expect(shardIds[0]).toMatch(/shard-soft-3-\d/);
-        expect(shardIds[1]).toMatch(/shard-hard-1-\d/);
+        expect(shardIds[0]).toMatch(/tag-soft;shard-3;replica-\d/);
+        expect(shardIds[1]).toMatch(/tag-hard;shard-1;replica-\d/);
 
         // We still need to check if the last part is between the correct boundaries
         const shardId = shardIds[0]?.substring(shardIds[0].lastIndexOf("-") + 1) ?? "";
@@ -226,7 +226,7 @@ describe("DOShardedTagCache", () => {
       cache.deleteRegionalCache = vi.fn();
       await cache.writeTags(["tag1"]);
       expect(cache.deleteRegionalCache).toHaveBeenCalled();
-      expect(cache.deleteRegionalCache).toHaveBeenCalledWith("shard-hard-1-1", ["tag1"]);
+      expect(cache.deleteRegionalCache).toHaveBeenCalledWith("tag-hard;shard-1;replica-1", ["tag1"]);
     });
   });
 

--- a/packages/cloudflare/src/api/do-sharded-tag-cache.spec.ts
+++ b/packages/cloudflare/src/api/do-sharded-tag-cache.spec.ts
@@ -58,7 +58,7 @@ describe("DOShardedTagCache", () => {
 
     describe("with double sharding", () => {
       it("should generate all shards if generateAllShards is true", () => {
-        const cache = doShardedTagCache({ numberOfShards: 4, enableDoubleSharding: true });
+        const cache = doShardedTagCache({ numberOfShards: 4, enableShardReplication: true });
         const expectedResult = new Map();
         expectedResult.set("shard-hard-1-1", ["tag1"]);
         expectedResult.set("shard-hard-1-2", ["tag1"]);
@@ -72,7 +72,7 @@ describe("DOShardedTagCache", () => {
       });
 
       it("should generate only one shard if generateAllShards is false", () => {
-        const cache = doShardedTagCache({ numberOfShards: 4, enableDoubleSharding: true });
+        const cache = doShardedTagCache({ numberOfShards: 4, enableShardReplication: true });
         const shardedMap = cache.generateShards({ tags: ["tag1", "_N_T_/tag1"], generateAllShards: false });
         expect(shardedMap.size).toBe(2);
         const shardIds = Array.from(shardedMap.keys());
@@ -213,7 +213,7 @@ describe("DOShardedTagCache", () => {
     });
 
     it('should write to all the double sharded shards if "generateAllShards" is true', async () => {
-      const cache = doShardedTagCache({ numberOfShards: 4, enableDoubleSharding: true });
+      const cache = doShardedTagCache({ numberOfShards: 4, enableShardReplication: true });
       await cache.writeTags(["tag1", "_N_T_/tag1"]);
       expect(idFromNameMock).toHaveBeenCalledTimes(6);
       expect(writeTagsMock).toHaveBeenCalledTimes(6);

--- a/packages/cloudflare/src/api/do-sharded-tag-cache.spec.ts
+++ b/packages/cloudflare/src/api/do-sharded-tag-cache.spec.ts
@@ -23,15 +23,15 @@ describe("DOShardedTagCache", () => {
     it("should generate a shardId", () => {
       const cache = doShardedTagCache();
       const expectedResult = new Map();
-      expectedResult.set("shard-1", ["tag1"]);
-      expectedResult.set("shard-2", ["tag2"]);
+      expectedResult.set("shard-hard-1", ["tag1"]);
+      expectedResult.set("shard-hard-2", ["tag2"]);
       expect(cache.generateShards(["tag1", "tag2"])).toEqual(expectedResult);
     });
 
     it("should group tags by shard", () => {
       const cache = doShardedTagCache();
       const expectedResult = new Map();
-      expectedResult.set("shard-1", ["tag1", "tag6"]);
+      expectedResult.set("shard-hard-1", ["tag1", "tag6"]);
       expect(cache.generateShards(["tag1", "tag6"])).toEqual(expectedResult);
     });
 
@@ -40,6 +40,14 @@ describe("DOShardedTagCache", () => {
       const firstResult = cache.generateShards(["tag1"]);
       const secondResult = cache.generateShards(["tag1", "tag3", "tag4"]);
       expect(firstResult.get("shard-1")).toEqual(secondResult.get("shard-1"));
+    });
+
+    it("should split hard and soft tags", () => {
+      const cache = doShardedTagCache();
+      const expectedResult = new Map();
+      expectedResult.set("shard-hard-1", ["tag1"]);
+      expectedResult.set("shard-soft-3", ["_N_T_/tag1"]);
+      expect(cache.generateShards(["tag1", "_N_T_/tag1"])).toEqual(expectedResult);
     });
   });
 
@@ -163,7 +171,7 @@ describe("DOShardedTagCache", () => {
       cache.deleteRegionalCache = vi.fn();
       await cache.writeTags(["tag1"]);
       expect(cache.deleteRegionalCache).toHaveBeenCalled();
-      expect(cache.deleteRegionalCache).toHaveBeenCalledWith("shard-1", ["tag1"]);
+      expect(cache.deleteRegionalCache).toHaveBeenCalledWith("shard-hard-1", ["tag1"]);
     });
   });
 

--- a/packages/cloudflare/src/api/do-sharded-tag-cache.spec.ts
+++ b/packages/cloudflare/src/api/do-sharded-tag-cache.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import doShardedTagCache from "./do-sharded-tag-cache";
+import doShardedTagCache, { DEFAULT_MAX_HARD_SHARDS, DEFAULT_MAX_SOFT_SHARDS } from "./do-sharded-tag-cache";
 
 const hasBeenRevalidatedMock = vi.fn();
 const writeTagsMock = vi.fn();
@@ -23,15 +23,15 @@ describe("DOShardedTagCache", () => {
     it("should generate a shardId", () => {
       const cache = doShardedTagCache();
       const expectedResult = new Map();
-      expectedResult.set("shard-hard-1", ["tag1"]);
-      expectedResult.set("shard-hard-2", ["tag2"]);
+      expectedResult.set("shard-hard-1-1", ["tag1"]);
+      expectedResult.set("shard-hard-2-1", ["tag2"]);
       expect(cache.generateShards(["tag1", "tag2"])).toEqual(expectedResult);
     });
 
     it("should group tags by shard", () => {
       const cache = doShardedTagCache();
       const expectedResult = new Map();
-      expectedResult.set("shard-hard-1", ["tag1", "tag6"]);
+      expectedResult.set("shard-hard-1-1", ["tag1", "tag6"]);
       expect(cache.generateShards(["tag1", "tag6"])).toEqual(expectedResult);
     });
 
@@ -45,9 +45,42 @@ describe("DOShardedTagCache", () => {
     it("should split hard and soft tags", () => {
       const cache = doShardedTagCache();
       const expectedResult = new Map();
-      expectedResult.set("shard-hard-1", ["tag1"]);
-      expectedResult.set("shard-soft-3", ["_N_T_/tag1"]);
+      expectedResult.set("shard-hard-1-1", ["tag1"]);
+      expectedResult.set("shard-soft-3-1", ["_N_T_/tag1"]);
       expect(cache.generateShards(["tag1", "_N_T_/tag1"])).toEqual(expectedResult);
+    });
+
+    describe("with double sharding", () => {
+      it("should generate all shards if generateAllShards is true", () => {
+        const cache = doShardedTagCache({ numberOfShards: 4, enableDoubleSharding: true });
+        const expectedResult = new Map();
+        expectedResult.set("shard-hard-1-1", ["tag1"]);
+        expectedResult.set("shard-hard-1-2", ["tag1"]);
+        expectedResult.set("shard-soft-3-1", ["_N_T_/tag1"]);
+        expectedResult.set("shard-soft-3-2", ["_N_T_/tag1"]);
+        expectedResult.set("shard-soft-3-3", ["_N_T_/tag1"]);
+        expectedResult.set("shard-soft-3-4", ["_N_T_/tag1"]);
+        expect(cache.generateShards(["tag1", "_N_T_/tag1"], true)).toEqual(expectedResult);
+      });
+
+      it("should generate only one shard if generateAllShards is false", () => {
+        const cache = doShardedTagCache({ numberOfShards: 4, enableDoubleSharding: true });
+        const shardedMap = cache.generateShards(["tag1", "_N_T_/tag1"], false);
+        expect(shardedMap.size).toBe(2);
+        const shardIds = Array.from(shardedMap.keys());
+        // We can't test against a specific shard id because the last part is random
+        expect(shardIds[0]).toMatch(/shard-soft-3-\d/);
+        expect(shardIds[1]).toMatch(/shard-hard-1-\d/);
+
+        // We still need to check if the last part is between the correct boundaries
+        const shardId = shardIds[0]?.substring(shardIds[0].lastIndexOf("-") + 1) ?? "";
+        expect(parseInt(shardId)).toBeGreaterThanOrEqual(1);
+        expect(parseInt(shardId)).toBeLessThanOrEqual(DEFAULT_MAX_SOFT_SHARDS);
+
+        const shardId2 = shardIds[1]?.substring(shardIds[1].lastIndexOf("-") + 1) ?? "";
+        expect(parseInt(shardId2)).toBeGreaterThanOrEqual(1);
+        expect(parseInt(shardId2)).toBeLessThanOrEqual(DEFAULT_MAX_HARD_SHARDS);
+      });
     });
   });
 
@@ -166,12 +199,21 @@ describe("DOShardedTagCache", () => {
       expect(writeTagsMock).toHaveBeenCalledWith(["tag2"]);
     });
 
+    it('should write to all the double sharded shards if "generateAllShards" is true', async () => {
+      const cache = doShardedTagCache({ numberOfShards: 4, enableDoubleSharding: true });
+      await cache.writeTags(["tag1", "_N_T_/tag1"]);
+      expect(idFromNameMock).toHaveBeenCalledTimes(6);
+      expect(writeTagsMock).toHaveBeenCalledTimes(6);
+      expect(writeTagsMock).toHaveBeenCalledWith(["tag1"]);
+      expect(writeTagsMock).toHaveBeenCalledWith(["_N_T_/tag1"]);
+    });
+
     it("should call deleteRegionalCache", async () => {
       const cache = doShardedTagCache();
       cache.deleteRegionalCache = vi.fn();
       await cache.writeTags(["tag1"]);
       expect(cache.deleteRegionalCache).toHaveBeenCalled();
-      expect(cache.deleteRegionalCache).toHaveBeenCalledWith("shard-hard-1", ["tag1"]);
+      expect(cache.deleteRegionalCache).toHaveBeenCalledWith("shard-hard-1-1", ["tag1"]);
     });
   });
 
@@ -212,6 +254,17 @@ describe("DOShardedTagCache", () => {
       expect(await cache.getFromRegionalCache("shard-1", ["tag1"])).toBe("response");
       // @ts-expect-error - Defined on cloudfare context
       globalThis.caches = undefined;
+    });
+  });
+
+  describe("getCacheKey", () => {
+    it("should return the cache key without the random part", async () => {
+      const cache = doShardedTagCache();
+      const reqKey = await cache.getCacheKey("shard-soft-1-1", ["_N_T_/tag1"]);
+      expect(reqKey.url).toBe("http://local.cache/shard/shard-soft-1?tags=_N_T_%2Ftag1");
+
+      const reqKey2 = await cache.getCacheKey("shard-hard-1-18", ["tag1"]);
+      expect(reqKey2.url).toBe("http://local.cache/shard/shard-hard-1?tags=tag1");
     });
   });
 });

--- a/packages/cloudflare/src/api/do-sharded-tag-cache.spec.ts
+++ b/packages/cloudflare/src/api/do-sharded-tag-cache.spec.ts
@@ -262,9 +262,8 @@ describe("DOShardedTagCache", () => {
     it("should return undefined if regional cache is disabled", async () => {
       const cache = doShardedTagCache();
       const doId = new TagCacheDOId({
-        tag: "tag1",
+        baseShardId: "shard-1",
         numberOfReplicas: 1,
-        numberOfShards: 4,
         shardType: "hard",
       });
       expect(await cache.getFromRegionalCache(doId, ["tag1"])).toBeUndefined();
@@ -279,9 +278,8 @@ describe("DOShardedTagCache", () => {
       };
       const cache = doShardedTagCache({ numberOfShards: 4, regionalCache: true });
       const doId = new TagCacheDOId({
-        tag: "tag1",
+        baseShardId: "shard-1",
         numberOfReplicas: 1,
-        numberOfShards: 4,
         shardType: "hard",
       });
       expect(await cache.getFromRegionalCache(doId, ["tag1"])).toBe("response");
@@ -293,14 +291,13 @@ describe("DOShardedTagCache", () => {
   describe("getCacheKey", () => {
     it("should return the cache key without the random part", async () => {
       const cache = doShardedTagCache();
-      const doId1 = new TagCacheDOId({ tag: "", numberOfReplicas: 1, numberOfShards: 4, shardType: "hard" });
+      const doId1 = new TagCacheDOId({ baseShardId: "shard-0", numberOfReplicas: 1, shardType: "hard" });
       const reqKey = await cache.getCacheKey(doId1, ["_N_T_/tag1"]);
       expect(reqKey.url).toBe("http://local.cache/shard/tag-hard;shard-0?tags=_N_T_%2Ftag1");
 
       const doId2 = new TagCacheDOId({
-        tag: "tag1",
+        baseShardId: "shard-1",
         numberOfReplicas: 1,
-        numberOfShards: 4,
         shardType: "hard",
       });
       const reqKey2 = await cache.getCacheKey(doId2, ["tag1"]);
@@ -318,9 +315,8 @@ describe("DOShardedTagCache", () => {
       });
       const spiedFn = vi.spyOn(cache, "performWriteTagsWithRetry");
       const doId = new TagCacheDOId({
-        tag: "tag1",
+        baseShardId: "shard-1",
         numberOfReplicas: 1,
-        numberOfShards: 4,
         shardType: "hard",
       });
       await cache.performWriteTagsWithRetry(doId, ["tag1"], Date.now());
@@ -341,7 +337,7 @@ describe("DOShardedTagCache", () => {
       });
       const spiedFn = vi.spyOn(cache, "performWriteTagsWithRetry");
       await cache.performWriteTagsWithRetry(
-        new TagCacheDOId({ tag: "tag1", numberOfReplicas: 1, numberOfShards: 4, shardType: "hard" }),
+        new TagCacheDOId({ baseShardId: "shard-1", numberOfReplicas: 1, shardType: "hard" }),
         ["tag1"],
         Date.now(),
         3

--- a/packages/cloudflare/src/api/do-sharded-tag-cache.ts
+++ b/packages/cloudflare/src/api/do-sharded-tag-cache.ts
@@ -50,7 +50,7 @@ interface ShardedDOTagCacheOptions {
    * The number of replicas that will be used for shard replication
    * Soft shard replicas are more often accessed than hard shard replicas, so it is recommended to have more soft replicas than hard replicas
    * Soft replicas are for internal next tags used for `revalidatePath` (i.e. `_N_T_/layout`, `_N_T_/page1`), hard replicas are the tags defined in your app
-   * @default { numberOfSoftShards: 4, numberOfHardShards: 2 }
+   * @default { numberOfSoftReplicas: 4, numberOfHardReplicas: 2 }
    */
   shardReplicationOptions?: {
     numberOfSoftReplicas: number;

--- a/packages/cloudflare/src/api/do-sharded-tag-cache.ts
+++ b/packages/cloudflare/src/api/do-sharded-tag-cache.ts
@@ -50,8 +50,8 @@ interface ShardedDOTagCacheOptions {
    * @default { softShards: 4, hardShards: 2 }
    */
   shardReplicationOptions?: {
-    softShards: number;
-    hardShards: number;
+    numberOfSoftReplicas: number;
+    numberOfHardReplicas: number;
   };
 
   /**
@@ -69,8 +69,8 @@ class ShardedDOTagCache implements NextModeTagCache {
   localCache?: Cache;
 
   constructor(private opts: ShardedDOTagCacheOptions = { numberOfShards: 4 }) {
-    this.maxSoftShards = opts.shardReplicationOptions?.softShards ?? DEFAULT_MAX_SOFT_SHARDS;
-    this.maxHardShards = opts.shardReplicationOptions?.hardShards ?? DEFAULT_MAX_HARD_SHARDS;
+    this.maxSoftShards = opts.shardReplicationOptions?.numberOfSoftReplicas ?? DEFAULT_MAX_SOFT_SHARDS;
+    this.maxHardShards = opts.shardReplicationOptions?.numberOfHardReplicas ?? DEFAULT_MAX_HARD_SHARDS;
     this.maxWriteRetries = opts.maxWriteRetries ?? DEFAULT_MAX_WRITE_RETRIES;
   }
 

--- a/packages/cloudflare/src/api/do-sharded-tag-cache.ts
+++ b/packages/cloudflare/src/api/do-sharded-tag-cache.ts
@@ -223,7 +223,11 @@ class ShardedD1TagCache implements NextModeTagCache {
     if (retryNumber >= this.maxWriteRetries) {
       error("Error while writing tags, too many retries");
       // Do we want to throw an error here ?
-      //TODO: we'd probably want to send a message to a dead letter queue
+      await getCloudflareContext().env.NEXT_CACHE_D1_SHARDED_DLQ?.send({
+        failingShardId: shardId,
+        failingTags: tags,
+        lastModified,
+      });
       return;
     }
     try {

--- a/packages/cloudflare/src/api/do-sharded-tag-cache.ts
+++ b/packages/cloudflare/src/api/do-sharded-tag-cache.ts
@@ -11,7 +11,7 @@ export const DEFAULT_MAX_SOFT_SHARDS = 4;
 export const DEFAULT_MAX_HARD_SHARDS = 2;
 export const DEFAULT_MAX_WRITE_RETRIES = 3;
 
-interface ShardedD1TagCacheOptions {
+interface ShardedDOTagCacheOptions {
   /**
    * The number of shards that will be used.
    * 1 shards means 1 durable object instance.
@@ -60,7 +60,7 @@ interface ShardedD1TagCacheOptions {
    */
   maxWriteRetries?: number;
 }
-class ShardedD1TagCache implements NextModeTagCache {
+class ShardedDOTagCache implements NextModeTagCache {
   readonly mode = "nextMode" as const;
   readonly name = "sharded-d1-tag-cache";
   readonly maxSoftShards: number;
@@ -68,7 +68,7 @@ class ShardedD1TagCache implements NextModeTagCache {
   readonly maxWriteRetries: number;
   localCache?: Cache;
 
-  constructor(private opts: ShardedD1TagCacheOptions = { numberOfShards: 4 }) {
+  constructor(private opts: ShardedDOTagCacheOptions = { numberOfShards: 4 }) {
     this.maxSoftShards = opts.shardReplicationOptions?.softShards ?? DEFAULT_MAX_SOFT_SHARDS;
     this.maxHardShards = opts.shardReplicationOptions?.hardShards ?? DEFAULT_MAX_HARD_SHARDS;
     this.maxWriteRetries = opts.maxWriteRetries ?? DEFAULT_MAX_WRITE_RETRIES;
@@ -113,13 +113,13 @@ class ShardedD1TagCache implements NextModeTagCache {
         return tags
           .filter((tag) => (isSoft ? tag.startsWith(SOFT_TAG_PREFIX) : !tag.startsWith(SOFT_TAG_PREFIX)))
           .map((tag) => {
-            const baseShardId = generateShardId(tag, this.opts.numberOfShards, `shard-${shardType}`);
+            const baseShardId = generateShardId(tag, this.opts.numberOfShards, `tag-${shardType};shard`);
             const randomShardId = this.generateRandomNumberBetween(
               1,
               isSoft ? this.maxSoftShards : this.maxHardShards
             );
             return {
-              shardId: `${baseShardId}-${shard === -1 ? randomShardId : shard}`,
+              shardId: `${baseShardId};replica-${shard === -1 ? randomShardId : shard}`,
               tag,
             };
           });
@@ -308,4 +308,4 @@ class ShardedD1TagCache implements NextModeTagCache {
   }
 }
 
-export default (opts?: ShardedD1TagCacheOptions) => new ShardedD1TagCache(opts);
+export default (opts?: ShardedDOTagCacheOptions) => new ShardedDOTagCache(opts);

--- a/packages/cloudflare/src/api/durable-objects/sharded-tag-cache.ts
+++ b/packages/cloudflare/src/api/durable-objects/sharded-tag-cache.ts
@@ -24,12 +24,12 @@ export class DOShardedTagCache extends DurableObject<CloudflareEnv> {
     return result.cnt > 0;
   }
 
-  async writeTags(tags: string[]): Promise<void> {
+  async writeTags(tags: string[], lastModified: number): Promise<void> {
     tags.forEach((tag) => {
       this.sql.exec(
         `INSERT OR REPLACE INTO revalidations (tag, revalidatedAt) VALUES (?, ?)`,
         tag,
-        Date.now()
+        lastModified
       );
     });
   }


### PR DESCRIPTION
Implements sharding replication for the Durable Object tag cache.
Instead of being sharded only based on the tag, each shard will now also be replicated
This allow to scale way more (virtually infinitely)
A single tag could be read from any of the N random replicas associated with the tag shard.
On write we still need to write to every single replicas associated with this tag shard