### PR TITLE
Add an option for disabling sqlite on the durable object queue

### DIFF
--- a/.changeset/silver-baboons-begin.md
+++ b/.changeset/silver-baboons-begin.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+add an option for disabling sqlite on the durable object queue

--- a/packages/cloudflare/src/api/cloudflare-context.ts
+++ b/packages/cloudflare/src/api/cloudflare-context.ts
@@ -37,6 +37,9 @@ declare global {
     REVALIDATION_RETRY_INTERVAL_MS?: string;
     // The maximum number of attempts that can be made to revalidate a path
     MAX_REVALIDATION_ATTEMPTS?: string;
+    // Disable SQLite for the durable object queue handler
+    // This can be safely used if you don't use an eventually consistent incremental cache (i.e. R2 without the regional cache for example)
+    REVALIDATION_DO_DISABLE_SQLITE?: string;
   }
 }
 


### PR DESCRIPTION
Useful when the incremental cache data can be trusted (i.e. not eventually consistent)