### PR TITLE
Serve `/cdn-cgi/image/...` images in dev

### DIFF
--- a/.changeset/wise-gifts-sit.md
+++ b/.changeset/wise-gifts-sit.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+Serve `/cdn-cgi/image/...` images in dev

--- a/packages/cloudflare/src/cli/templates/worker.ts
+++ b/packages/cloudflare/src/cli/templates/worker.ts
@@ -40,10 +40,9 @@ export default {
           return new Response("Not Found!", { status: 404 });
         }
         const imageUrl = m.groups!.url!;
-        if (imageUrl.match(/^https?:\/\//)) {
-          return fetch(imageUrl, { cf: { cacheEverything: true } });
-        }
-        return env.ASSETS.fetch(new URL(`/${imageUrl}`, url));
+        return imageUrl.match(/^https?:\/\//)
+          ? fetch(imageUrl, { cf: { cacheEverything: true } })
+          : env.ASSETS.fetch(new URL(`/${imageUrl}`, url));
       }
 
       // Fallback for the Next default image loader.

--- a/packages/cloudflare/src/cli/templates/worker.ts
+++ b/packages/cloudflare/src/cli/templates/worker.ts
@@ -33,6 +33,7 @@ export default {
       populateProcessEnv(url, env.NEXTJS_ENV);
 
       // Serve images in development.
+      // Note: "/cdn-cgi/image/..." requests do not reach production workers.
       if (url.pathname.startsWith("/cdn-cgi/image/")) {
         const m = url.pathname.match(/\/cdn-cgi\/image\/.+?\/(?<url>.+)$/);
         if (m === null) {

--- a/packages/cloudflare/src/cli/templates/worker.ts
+++ b/packages/cloudflare/src/cli/templates/worker.ts
@@ -40,7 +40,7 @@ export default {
           return new Response("Not Found!", { status: 404 });
         }
         const imageUrl = m.groups!.url!;
-        if (imageUrl.startsWith("http://") || imageUrl.startsWith("https://")) {
+        if (imageUrl.match(/^https?:\/\//)) {
           return fetch(imageUrl, { cf: { cacheEverything: true } });
         }
         return env.ASSETS.fetch(new URL(`/${imageUrl}`, url));

--- a/packages/cloudflare/src/cli/templates/worker.ts
+++ b/packages/cloudflare/src/cli/templates/worker.ts
@@ -32,6 +32,20 @@ export default {
 
       populateProcessEnv(url, env.NEXTJS_ENV);
 
+      // Serve images in development.
+      if (url.pathname.startsWith("/cdn-cgi/image/")) {
+        const m = url.pathname.match(/\/cdn-cgi\/image\/.+?\/(?<url>.+)$/);
+        if (m === null) {
+          return new Response("Not Found!", { status: 404 });
+        }
+        const imageUrl = m.groups!.url!;
+        if (imageUrl.startsWith("http://") || imageUrl.startsWith("https://")) {
+          return fetch(imageUrl, { cf: { cacheEverything: true } });
+        }
+        return env.ASSETS.fetch(new URL(`/${imageUrl}`, url));
+      }
+
+      // Fallback for the Next default image loader.
       if (url.pathname === "/_next/image") {
         const imageUrl = url.searchParams.get("url") ?? "";
         return imageUrl.startsWith("/")


### PR DESCRIPTION
We recommend using https://developers.cloudflare.com/images/transform-images/integrate-with-frameworks/ for cloudflare. However `/cdn-cgi/image/...` are not handled by `wrangler dev`.

What this PR does is serve the (original) images for `/cdn-cgi/image/...` urls.

I plan to improve the OpenNext docs, creating an HowTo referring to the page linked above.

_I created [a feature request](https://github.com/cloudflare/workers-sdk/issues/8637) for this to be implemented in miniflare._