### PR TITLE
fix: bun failing to spawn wrangler

### DIFF
--- a/.changeset/ten-parents-add.md
+++ b/.changeset/ten-parents-add.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+fix: bun failing to spawn wrangler

--- a/packages/cloudflare/src/cli/utils/run-wrangler.ts
+++ b/packages/cloudflare/src/cli/utils/run-wrangler.ts
@@ -16,7 +16,7 @@ export function runWrangler(options: BuildOptions, args: string[], wranglerOpts:
   const result = spawnSync(
     options.packager,
     [
-      "exec",
+      options.packager === "bun" ? "x" : "exec",
       "wrangler",
       ...args,
       wranglerOpts.environment && `--env ${wranglerOpts.environment}`,


### PR DESCRIPTION
Bun seems to be the only package manager that does not support `exec` in the same way. Instead, they use it for their built-in shell.