### PR TITLE
fix: npm failing to pass args to wrangler

### DIFF
--- a/.changeset/strange-icons-camp.md
+++ b/.changeset/strange-icons-camp.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+fix: npm failing to pass args to wrangler

--- a/packages/cloudflare/src/cli/utils/run-wrangler.ts
+++ b/packages/cloudflare/src/cli/utils/run-wrangler.ts
@@ -29,7 +29,7 @@ function injectPassthroughFlagForArgs(options: BuildOptions, args: string[]) {
 
   const flagInArgsIndex = args.findIndex((v) => v.startsWith("--"));
   if (flagInArgsIndex !== -1) {
-    return [...args.slice(0, flagInArgsIndex), "--", ...args.slice(flagInArgsIndex)];
+    args.splice(flagInArgsIndex, 0, '--');
   }
 
   return args;

--- a/packages/cloudflare/src/cli/utils/run-wrangler.ts
+++ b/packages/cloudflare/src/cli/utils/run-wrangler.ts
@@ -12,6 +12,16 @@ type WranglerOptions = {
   logging?: "all" | "error";
 };
 
+/**
+ * Prepends CLI flags with `--` so that certain package managers can pass args through to wrangler
+ * properly.
+ *
+ * npm and yarn require `--` to be used, while pnpm and bun require that it is not used.
+ *
+ * @param options Build options.
+ * @param args CLI args.
+ * @returns Arguments with a passthrough flag injected when needed.
+ */
 function injectPassthroughFlagForArgs(options: BuildOptions, args: string[]) {
   if (options.packager !== "npm" && options.packager !== "yarn") {
     return args;

--- a/packages/cloudflare/src/cli/utils/run-wrangler.ts
+++ b/packages/cloudflare/src/cli/utils/run-wrangler.ts
@@ -29,7 +29,7 @@ function injectPassthroughFlagForArgs(options: BuildOptions, args: string[]) {
 
   const flagInArgsIndex = args.findIndex((v) => v.startsWith("--"));
   if (flagInArgsIndex !== -1) {
-    args.splice(flagInArgsIndex, 0, '--');
+    args.splice(flagInArgsIndex, 0, "--");
   }
 
   return args;


### PR DESCRIPTION
Another package manager inconsistency. npm and yarn both need `--` to pass args to wrangler properly, whereas pnpm and bun will fail to pass args properly to wrangler if `--` is supplied...