### PR TITLE
fix: nextjs handler not detected in worker

### DIFF
--- a/.changeset/little-seals-impress.md
+++ b/.changeset/little-seals-impress.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+fix: nextjs handler not detected in worker

--- a/packages/cloudflare/src/cli/build/bundle-server.ts
+++ b/packages/cloudflare/src/cli/build/bundle-server.ts
@@ -194,7 +194,7 @@ globalThis.__BUILD_TIMESTAMP_MS__ = ${Date.now()};
   if (isMonorepo) {
     fs.writeFileSync(
       path.join(outputPath, "handler.mjs"),
-      `export * from "./${normalizePath(packagePath)}/handler.mjs";`
+      `export { handler } from "./${normalizePath(packagePath)}/handler.mjs";`
     );
   }
 


### PR DESCRIPTION
Fixes https://github.com/opennextjs/opennextjs-cloudflare/issues/508

Full disclosure (also see issue above):

I don't know why this issue occurs. I just found this fix by experimenting. In the original situation, the worker detects the handler as a 'Getter', but if you use the 'handler' getter the result is undefined, but only on 'cold' boots. In a warm worker the Getter is initialized and it just works. By changing how we export in `handler.mjs` to a named export, it no longer detects it as a Getter but as a async function and it now works properly on cold boots. If someone could explain why this happens, please do!