### PR TITLE
fix: yarn v4 not passing args to wrangler correctly

### DIFF
--- a/.changeset/brave-snakes-roll.md
+++ b/.changeset/brave-snakes-roll.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+fix: yarn v4 not passing args to wrangler correctly

--- a/packages/cloudflare/src/cli/utils/run-wrangler.ts
+++ b/packages/cloudflare/src/cli/utils/run-wrangler.ts
@@ -28,6 +28,7 @@ function isYarnModern(options: BuildOptions) {
 
   if (!packageJson.packageManager?.startsWith("yarn")) return false;
 
+  const [, version] = packageJson.packageManager.split("@");
   return version ? compareSemver(version, ">=", "4.0.0") : false;
 }
 

--- a/packages/cloudflare/src/cli/utils/run-wrangler.ts
+++ b/packages/cloudflare/src/cli/utils/run-wrangler.ts
@@ -28,10 +28,7 @@ function isYarnModern(options: BuildOptions) {
 
   if (!packageJson.packageManager?.startsWith("yarn")) return false;
 
-  const [, version] = packageJson.packageManager.split("@");
-  if (!version) return false;
-
-  return compareSemver(version, ">=", "4.0.0");
+  return version ? compareSemver(version, ">=", "4.0.0") : false;
 }
 
 /**

--- a/packages/cloudflare/src/cli/utils/run-wrangler.ts
+++ b/packages/cloudflare/src/cli/utils/run-wrangler.ts
@@ -1,6 +1,9 @@
 import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
 
 import type { BuildOptions } from "@opennextjs/aws/build/helper.js";
+import { compareSemver } from "@opennextjs/aws/build/helper.js";
 import logger from "@opennextjs/aws/logger.js";
 
 export type WranglerTarget = "local" | "remote";
@@ -13,17 +16,36 @@ type WranglerOptions = {
 };
 
 /**
+ * Checks the package.json `packageManager` field to determine whether yarn modern is used.
+ *
+ * @param options Build options.
+ * @returns Whether yarn modern is used.
+ */
+function isYarnModern(options: BuildOptions) {
+  const packageJson: { packageManager?: string } = JSON.parse(
+    readFileSync(path.join(options.monorepoRoot, "package.json"), "utf-8")
+  );
+
+  if (!packageJson.packageManager?.startsWith("yarn")) return false;
+
+  const [, version] = packageJson.packageManager.split("@");
+  if (!version) return false;
+
+  return compareSemver(version, ">=", "4.0.0");
+}
+
+/**
  * Prepends CLI flags with `--` so that certain package managers can pass args through to wrangler
  * properly.
  *
- * npm and yarn require `--` to be used, while pnpm and bun require that it is not used.
+ * npm and yarn classic require `--` to be used, while pnpm and bun require that it is not used.
  *
  * @param options Build options.
  * @param args CLI args.
  * @returns Arguments with a passthrough flag injected when needed.
  */
 function injectPassthroughFlagForArgs(options: BuildOptions, args: string[]) {
-  if (options.packager !== "npm" && options.packager !== "yarn") {
+  if (options.packager !== "npm" && (options.packager !== "yarn" || isYarnModern(options))) {
     return args;
   }
 


### PR DESCRIPTION
Yarn classic and yarn modern appear to pass args around differently. Yarn modern uses the `packageManager` field in package.json, so this PR uses that to compare the semver to check if it's used or not.