### PR TITLE
Define `process.version` and `process.versions.node`

### DIFF
--- a/.changeset/cyan-ears-know.md
+++ b/.changeset/cyan-ears-know.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+Define `process.version` and `process.versions.node`

--- a/packages/cloudflare/src/cli/templates/worker.ts
+++ b/packages/cloudflare/src/cli/templates/worker.ts
@@ -1,4 +1,5 @@
 import { AsyncLocalStorage } from "node:async_hooks";
+import process from "node:process";
 
 import type { CloudflareContext } from "../../api";
 // @ts-expect-error: resolved by wrangler build
@@ -67,6 +68,13 @@ function populateProcessEnv(url: URL, env: CloudflareEnv) {
   if (processEnvPopulated) {
     return;
   }
+
+  // Some packages rely on `process.version` and `process.versions.node` (i.e. Jose@4)
+  // TODO: Remove when https://github.com/unjs/unenv/pull/493 is merged
+  Object.assign(process, { version: process.version || "v22.14.0" });
+  // @ts-expect-error Node type does not match workerd
+  Object.assign(process.versions, { node: "22.14.0", ...process.versions });
+
   processEnvPopulated = true;
 
   for (const [key, value] of Object.entries(env)) {


### PR DESCRIPTION
fixes #333 

Jose (and other packages) relies on `process.version` and `process.versions.node`.

Defining them here until https://github.com/unjs/unenv/pull/493 is merged

/cc @petebacondarwin @mhart


