### PR TITLE
Set "cache-tag" on the regional cache entries

### DIFF
--- a/.changeset/happy-bananas-buy.md
+++ b/.changeset/happy-bananas-buy.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+Set `Cache-Tag` on the entries created by the regional cache, to be purged using the Cloudflare API.

--- a/.changeset/happy-bananas-buy.md
+++ b/.changeset/happy-bananas-buy.md
@@ -2,4 +2,4 @@
 "@opennextjs/cloudflare": patch
 ---
 
-Set `Cache-Tag` on the entries created by the regional cache, to be purged using the Cloudflare API.
+Set `Cache-Tag` on the entries created by the regional cache, to be purged using the Cloudflare API or dashboard.

--- a/packages/cloudflare/src/api/overrides/incremental-cache/regional-cache.ts
+++ b/packages/cloudflare/src/api/overrides/incremental-cache/regional-cache.ts
@@ -143,7 +143,11 @@ class RegionalCache implements IncrementalCache {
     );
   }
 
-  protected async putToCache(key: Request, entryKey: string, entry: IncrementalCacheEntry<boolean>): Promise<void> {
+  protected async putToCache(
+    key: Request,
+    entryKey: string,
+    entry: IncrementalCacheEntry<boolean>
+  ): Promise<void> {
     const cache = await this.getCacheInstance();
 
     const age =

--- a/packages/cloudflare/src/api/overrides/incremental-cache/regional-cache.ts
+++ b/packages/cloudflare/src/api/overrides/incremental-cache/regional-cache.ts
@@ -19,7 +19,7 @@ type Options = {
   mode: "short-lived" | "long-lived";
 
   /**
-   * The default age to use for long-lived cache entries.
+   * The default TTL of long-lived cache entries.
    * When no revalidate is provided, the default age will be used.
    *
    * @default `THIRTY_MINUTES_IN_SECONDS`

--- a/packages/cloudflare/src/api/overrides/incremental-cache/regional-cache.ts
+++ b/packages/cloudflare/src/api/overrides/incremental-cache/regional-cache.ts
@@ -24,7 +24,7 @@ type Options = {
    *
    * @default `THIRTY_MINUTES_IN_SECONDS`
    */
-  defaultLongLivedAge?: number;
+  defaultLongLivedTtlSec?: number;
 
   /**
    * Whether the regional cache entry should be updated in the background or not when it experiences
@@ -153,7 +153,7 @@ class RegionalCache implements IncrementalCache {
     const age =
       this.opts.mode === "short-lived"
         ? ONE_MINUTE_IN_SECONDS
-        : entry.value.revalidate || this.opts.defaultLongLivedAge || THIRTY_MINUTES_IN_SECONDS;
+        : entry.value.revalidate || this.opts.defaultLongLivedTtlSec || THIRTY_MINUTES_IN_SECONDS;
 
     // We default to the entry key if no tags are found.
     // so that we can also revalidate page router based entry this way.
@@ -191,7 +191,7 @@ class RegionalCache implements IncrementalCache {
  *                                  or an ISR/SSG entry for up to 30 minutes.
  * @param opts.shouldLazilyUpdateOnCacheHit Whether the regional cache entry should be updated in
  *                                          the background or not when it experiences a cache hit.
- * @param opts.defaultLongLivedAge The default age to use for long-lived cache entries.
+ * @param opts.defaultLongLivedTtlSec The default age to use for long-lived cache entries.
  *                                  When no revalidate is provided, the default age will be used.
  *                                  @default `THIRTY_MINUTES_IN_SECONDS`
  *

--- a/packages/cloudflare/src/api/overrides/incremental-cache/regional-cache.ts
+++ b/packages/cloudflare/src/api/overrides/incremental-cache/regional-cache.ts
@@ -19,6 +19,14 @@ type Options = {
   mode: "short-lived" | "long-lived";
 
   /**
+   * The default age to use for long-lived cache entries.
+   * When no revalidate is provided, the default age will be used.
+   *
+   * @default `THIRTY_MINUTES_IN_SECONDS`
+   */
+  defaultLongLivedAge?: number;
+
+  /**
    * Whether the regional cache entry should be updated in the background or not when it experiences
    * a cache hit.
    *
@@ -141,7 +149,7 @@ class RegionalCache implements IncrementalCache {
     const age =
       this.opts.mode === "short-lived"
         ? ONE_MINUTE_IN_SECONDS
-        : entry.value.revalidate || THIRTY_MINUTES_IN_SECONDS;
+        : entry.value.revalidate || this.opts.defaultLongLivedAge || THIRTY_MINUTES_IN_SECONDS;
 
     // We default to the entry key if no tags are found.
     // so that we can also revalidate page router based entry this way.
@@ -179,6 +187,9 @@ class RegionalCache implements IncrementalCache {
  *                                  or an ISR/SSG entry for up to 30 minutes.
  * @param opts.shouldLazilyUpdateOnCacheHit Whether the regional cache entry should be updated in
  *                                          the background or not when it experiences a cache hit.
+ * @param opts.defaultLongLivedAge The default age to use for long-lived cache entries.
+ *                                  When no revalidate is provided, the default age will be used.
+ *                                  @default `THIRTY_MINUTES_IN_SECONDS`
  *
  * @default `false` for the `short-lived` mode, and `true` for the `long-lived` mode.
  */


### PR DESCRIPTION
This PR aims at improving the use of the regional cache by making sure that entries on it can be purged by cache-tag on Cloudflare.

In our application (https://github.com/GitbookIO/gitbook), we purge the cache both using `revalidateTag` but also using the Cloudflare API (https://developers.cloudflare.com/cache/how-to/purge-cache/purge-by-tags/).

I think this header has no negative impact on any other OpenNext users while unblocking us but also potentially unblocking someone who is using the long-lived cache and needs to quickly purge it (they could do it from the CF dashboard).