### PR TITLE
feat: `upload` command for worker versions

### DIFF
--- a/.changeset/light-insects-kiss.md
+++ b/.changeset/light-insects-kiss.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+feat: `upload` command for worker versions'

--- a/packages/cloudflare/src/cli/args.ts
+++ b/packages/cloudflare/src/cli/args.ts
@@ -13,7 +13,7 @@ export type Arguments = (
       minify: boolean;
     }
   | {
-      command: "preview" | "deploy";
+      command: "preview" | "deploy" | "upload";
       passthroughArgs: string[];
     }
   | {
@@ -53,6 +53,7 @@ export function getArgs(): Arguments {
       };
     case "preview":
     case "deploy":
+    case "upload":
       return {
         command: positionals[0],
         outputDir,
@@ -69,7 +70,9 @@ export function getArgs(): Arguments {
         environment: getWranglerEnvironmentFlag(passthroughArgs),
       };
     default:
-      throw new Error("Error: invalid command, expected 'build' | 'preview' | 'deploy' | 'populateCache'");
+      throw new Error(
+        "Error: invalid command, expected 'build' | 'preview' | 'deploy' | 'upload' | 'populateCache'"
+      );
   }
 }
 

--- a/packages/cloudflare/src/cli/commands/upload.ts
+++ b/packages/cloudflare/src/cli/commands/upload.ts
@@ -1,0 +1,18 @@
+import { BuildOptions } from "@opennextjs/aws/build/helper.js";
+import { OpenNextConfig } from "@opennextjs/aws/types/open-next.js";
+
+import { getWranglerEnvironmentFlag, runWrangler } from "../utils/run-wrangler.js";
+import { populateCache } from "./populate-cache.js";
+
+export async function upload(
+  options: BuildOptions,
+  config: OpenNextConfig,
+  uploadOptions: { passthroughArgs: string[] }
+) {
+  await populateCache(options, config, {
+    target: "remote",
+    environment: getWranglerEnvironmentFlag(uploadOptions.passthroughArgs),
+  });
+
+  runWrangler(options, ["versions upload", ...uploadOptions.passthroughArgs], { logging: "all" });
+}

--- a/packages/cloudflare/src/cli/index.ts
+++ b/packages/cloudflare/src/cli/index.ts
@@ -13,6 +13,7 @@ import { createOpenNextConfigIfNotExistent, ensureCloudflareConfig } from "./bui
 import { deploy } from "./commands/deploy.js";
 import { populateCache } from "./commands/populate-cache.js";
 import { preview } from "./commands/preview.js";
+import { upload } from "./commands/upload.js";
 
 const nextAppDir = process.cwd();
 
@@ -43,6 +44,8 @@ async function runCommand(args: Arguments) {
       return preview(options, config, args);
     case "deploy":
       return deploy(options, config, args);
+    case "upload":
+      return upload(options, config, args);
     case "populateCache":
       return populateCache(options, config, args);
   }


### PR DESCRIPTION
There are two ways to [create a new version](https://developers.cloudflare.com/workers/configuration/versions-and-deployments/#create-a-new-version) of a worker; immediate deployment with `wrangler deploy`, or gradual/delayed deployment with `wrangler versions upload`.

This adds a separate command called `opennextjs-cloudflare upload` that can be used to upload a new version of a worker.