### PR TITLE
Feat tag-cache-filter

### DIFF
--- a/.changeset/neat-hornets-call.md
+++ b/.changeset/neat-hornets-call.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+Add a new `withFilter` tag cache to allow to filter the tag cache used

--- a/packages/cloudflare/src/api/overrides/tag-cache/tag-cache-filter.spec.ts
+++ b/packages/cloudflare/src/api/overrides/tag-cache/tag-cache-filter.spec.ts
@@ -1,7 +1,7 @@
 import { NextModeTagCache } from "@opennextjs/aws/types/overrides";
-import {beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { softTagFilter,withFilter } from "./tag-cache-filter";
+import { softTagFilter, withFilter } from "./tag-cache-filter";
 
 const mockedTagCache = {
   name: "mocked",
@@ -28,9 +28,9 @@ describe("withFilter", () => {
 
     await tagCache.writeTags(tags);
     expect(mockedTagCache.writeTags).toHaveBeenCalledWith(["valid_tag"]);
-  })
+  });
 
-  it('should not call writeTags if no tags are valid', async () => {
+  it("should not call writeTags if no tags are valid", async () => {
     const tagCache = withFilter({
       originalTagCache: mockedTagCache,
       filterFn,
@@ -38,7 +38,7 @@ describe("withFilter", () => {
     const tags = ["invalid_tag"];
     await tagCache.writeTags(tags);
     expect(mockedTagCache.writeTags).not.toHaveBeenCalled();
-  })
+  });
 
   it("should filter out tags based on hasBeenRevalidated", async () => {
     const tagCache = withFilter({
@@ -51,10 +51,9 @@ describe("withFilter", () => {
 
     await tagCache.hasBeenRevalidated(tags, lastModified);
     expect(mockedTagCache.hasBeenRevalidated).toHaveBeenCalledWith(["valid_tag"], lastModified);
-  }
-  )
+  });
 
-  it('should not call hasBeenRevalidated if no tags are valid', async () => {
+  it("should not call hasBeenRevalidated if no tags are valid", async () => {
     const tagCache = withFilter({
       originalTagCache: mockedTagCache,
       filterFn,
@@ -63,7 +62,7 @@ describe("withFilter", () => {
     const lastModified = Date.now();
     await tagCache.hasBeenRevalidated(tags, lastModified);
     expect(mockedTagCache.hasBeenRevalidated).not.toHaveBeenCalled();
-  })
+  });
 
   it("should filter out tags based on getPathsByTags", async () => {
     const tagCache = withFilter({
@@ -75,10 +74,9 @@ describe("withFilter", () => {
 
     await tagCache.getPathsByTags?.(tags);
     expect(mockedTagCache.getPathsByTags).toHaveBeenCalledWith(["valid_tag"]);
-  }
-  )
+  });
 
-  it('should not call getPathsByTags if no tags are valid', async () => {
+  it("should not call getPathsByTags if no tags are valid", async () => {
     const tagCache = withFilter({
       originalTagCache: mockedTagCache,
       filterFn,
@@ -86,17 +84,16 @@ describe("withFilter", () => {
     const tags = ["invalid_tag"];
     await tagCache.getPathsByTags?.(tags);
     expect(mockedTagCache.getPathsByTags).not.toHaveBeenCalled();
-  })
+  });
 
-  it('should return the correct name', () => {
+  it("should return the correct name", () => {
     const tagCache = withFilter({
       originalTagCache: mockedTagCache,
       filterFn,
     });
 
-    expect(tagCache.name).toBe('filtered-mocked');
-  }
-  )
+    expect(tagCache.name).toBe("filtered-mocked");
+  });
 
   it("should not create a function if getPathsByTags is not defined", async () => {
     const tagCache = withFilter({
@@ -108,8 +105,7 @@ describe("withFilter", () => {
     });
 
     expect(tagCache.getPathsByTags).toBeUndefined();
-  }
-  )
+  });
 
   it("should properly filter soft tags", () => {
     const tagCache = withFilter({
@@ -119,5 +115,5 @@ describe("withFilter", () => {
 
     tagCache.writeTags(["valid_tag", "_N_T_/", "_N_T_/test", "_N_T_/layout"]);
     expect(mockedTagCache.writeTags).toHaveBeenCalledWith(["valid_tag"]);
-  })
+  });
 });

--- a/packages/cloudflare/src/api/overrides/tag-cache/tag-cache-filter.spec.ts
+++ b/packages/cloudflare/src/api/overrides/tag-cache/tag-cache-filter.spec.ts
@@ -1,0 +1,123 @@
+import { NextModeTagCache } from "@opennextjs/aws/types/overrides";
+import {beforeEach, describe, expect, it, vi } from "vitest";
+
+import { softTagFilter,withFilter } from "./tag-cache-filter";
+
+const mockedTagCache = {
+  name: "mocked",
+  mode: "nextMode",
+  getPathsByTags: vi.fn(),
+  hasBeenRevalidated: vi.fn(),
+  writeTags: vi.fn(),
+} satisfies NextModeTagCache;
+
+const filterFn = (tag: string) => tag.startsWith("valid_");
+
+describe("withFilter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should filter out tags based on writeTags", async () => {
+    const tagCache = withFilter({
+      originalTagCache: mockedTagCache,
+      filterFn,
+    });
+
+    const tags = ["valid_tag", "invalid_tag"];
+
+    await tagCache.writeTags(tags);
+    expect(mockedTagCache.writeTags).toHaveBeenCalledWith(["valid_tag"]);
+  })
+
+  it('should not call writeTags if no tags are valid', async () => {
+    const tagCache = withFilter({
+      originalTagCache: mockedTagCache,
+      filterFn,
+    });
+    const tags = ["invalid_tag"];
+    await tagCache.writeTags(tags);
+    expect(mockedTagCache.writeTags).not.toHaveBeenCalled();
+  })
+
+  it("should filter out tags based on hasBeenRevalidated", async () => {
+    const tagCache = withFilter({
+      originalTagCache: mockedTagCache,
+      filterFn,
+    });
+
+    const tags = ["valid_tag", "invalid_tag"];
+    const lastModified = Date.now();
+
+    await tagCache.hasBeenRevalidated(tags, lastModified);
+    expect(mockedTagCache.hasBeenRevalidated).toHaveBeenCalledWith(["valid_tag"], lastModified);
+  }
+  )
+
+  it('should not call hasBeenRevalidated if no tags are valid', async () => {
+    const tagCache = withFilter({
+      originalTagCache: mockedTagCache,
+      filterFn,
+    });
+    const tags = ["invalid_tag"];
+    const lastModified = Date.now();
+    await tagCache.hasBeenRevalidated(tags, lastModified);
+    expect(mockedTagCache.hasBeenRevalidated).not.toHaveBeenCalled();
+  })
+
+  it("should filter out tags based on getPathsByTags", async () => {
+    const tagCache = withFilter({
+      originalTagCache: mockedTagCache,
+      filterFn,
+    });
+
+    const tags = ["valid_tag", "invalid_tag"];
+
+    await tagCache.getPathsByTags?.(tags);
+    expect(mockedTagCache.getPathsByTags).toHaveBeenCalledWith(["valid_tag"]);
+  }
+  )
+
+  it('should not call getPathsByTags if no tags are valid', async () => {
+    const tagCache = withFilter({
+      originalTagCache: mockedTagCache,
+      filterFn,
+    });
+    const tags = ["invalid_tag"];
+    await tagCache.getPathsByTags?.(tags);
+    expect(mockedTagCache.getPathsByTags).not.toHaveBeenCalled();
+  })
+
+  it('should return the correct name', () => {
+    const tagCache = withFilter({
+      originalTagCache: mockedTagCache,
+      filterFn,
+    });
+
+    expect(tagCache.name).toBe('filtered-mocked');
+  }
+  )
+
+  it("should not create a function if getPathsByTags is not defined", async () => {
+    const tagCache = withFilter({
+      originalTagCache: {
+        ...mockedTagCache,
+        getPathsByTags: undefined,
+      },
+      filterFn,
+    });
+
+    expect(tagCache.getPathsByTags).toBeUndefined();
+  }
+  )
+
+  it("should properly filter soft tags", () => {
+    const tagCache = withFilter({
+      originalTagCache: mockedTagCache,
+      filterFn: softTagFilter,
+    });
+
+    tagCache.writeTags(["valid_tag", "_N_T_/", "_N_T_/test", "_N_T_/layout"]);
+    expect(mockedTagCache.writeTags).toHaveBeenCalledWith(["valid_tag"]);
+  })
+});

--- a/packages/cloudflare/src/api/overrides/tag-cache/tag-cache-filter.ts
+++ b/packages/cloudflare/src/api/overrides/tag-cache/tag-cache-filter.ts
@@ -18,20 +18,19 @@ interface WithFilterOptions {
  * Creates a new tag cache that filters tags based on the provided filter function.
  * This is usefult to remove tags that are not used by the app, this could reduce the number of request to the underlying tag cache.
  */
-export function withFilter({
-  originalTagCache,
-  filterFn,
-}: WithFilterOptions): NextModeTagCache {
+export function withFilter({ originalTagCache, filterFn }: WithFilterOptions): NextModeTagCache {
   return {
     name: `filtered-${originalTagCache.name}`,
     mode: "nextMode",
-    getPathsByTags: originalTagCache.getPathsByTags ? async (tags) => {
-      const filteredTags = tags.filter(filterFn);
-      if (filteredTags.length === 0) {
-        return [];
-      }
-      return originalTagCache.getPathsByTags!(filteredTags)
-    } : undefined,
+    getPathsByTags: originalTagCache.getPathsByTags
+      ? async (tags) => {
+          const filteredTags = tags.filter(filterFn);
+          if (filteredTags.length === 0) {
+            return [];
+          }
+          return originalTagCache.getPathsByTags!(filteredTags);
+        }
+      : undefined,
     hasBeenRevalidated: async (tags, lastModified) => {
       const filteredTags = tags.filter(filterFn);
       if (filteredTags.length === 0) {
@@ -45,7 +44,7 @@ export function withFilter({
         return;
       }
       return originalTagCache.writeTags(filteredTags);
-    }, 
+    },
   };
 }
 

--- a/packages/cloudflare/src/api/overrides/tag-cache/tag-cache-filter.ts
+++ b/packages/cloudflare/src/api/overrides/tag-cache/tag-cache-filter.ts
@@ -1,0 +1,59 @@
+import { NextModeTagCache } from "@opennextjs/aws/types/overrides";
+
+interface WithFilterOptions {
+  /**
+   * The original tag cache.
+   * Call to this will receive only the filtered tags.
+   */
+  originalTagCache: NextModeTagCache;
+  /**
+   * The function to filter tags.
+   * @param tag The tag to filter.
+   * @returns true if the tag should be forwarde, false otherwise.
+   */
+  filterFn: (tag: string) => boolean;
+}
+
+/**
+ * Creates a new tag cache that filters tags based on the provided filter function.
+ * This is usefult to remove tags that are not used by the app, this could reduce the number of request to the underlying tag cache.
+ */
+export function withFilter({
+  originalTagCache,
+  filterFn,
+}: WithFilterOptions): NextModeTagCache {
+  return {
+    name: `filtered-${originalTagCache.name}`,
+    mode: "nextMode",
+    getPathsByTags: originalTagCache.getPathsByTags ? async (tags) => {
+      const filteredTags = tags.filter(filterFn);
+      if (filteredTags.length === 0) {
+        return [];
+      }
+      return originalTagCache.getPathsByTags!(filteredTags)
+    } : undefined,
+    hasBeenRevalidated: async (tags, lastModified) => {
+      const filteredTags = tags.filter(filterFn);
+      if (filteredTags.length === 0) {
+        return false;
+      }
+      return originalTagCache.hasBeenRevalidated(filteredTags, lastModified);
+    },
+    writeTags: async (tags) => {
+      const filteredTags = tags.filter(filterFn);
+      if (filteredTags.length === 0) {
+        return;
+      }
+      return originalTagCache.writeTags(filteredTags);
+    }, 
+  };
+}
+
+/**
+ * Filter function to exclude tags that start with "_N_T_".
+ * This is used to filter out internal soft tags.
+ * Can be used if `revalidatePath` is not used.
+ */
+export function softTagFilter(tag: string): boolean {
+  return !tag.startsWith("_N_T_");
+}


### PR DESCRIPTION
Add a new `withFilter` "tag cache" that allows to filter the tag used.
It is mostly useful to reduce the load on the underlying tag cache.
It also introduce a `softTagFilter` function for those that uses `revalidateTag`, but not `revalidatePath`