### PR TITLE
Fix node timers

### DIFF
--- a/.changeset/famous-weeks-deliver.md
+++ b/.changeset/famous-weeks-deliver.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+global `setTimeout`, `setInterval` and `setImmediate` now use the one from node

--- a/.changeset/famous-weeks-deliver.md
+++ b/.changeset/famous-weeks-deliver.md
@@ -2,4 +2,4 @@
 "@opennextjs/cloudflare": patch
 ---
 
-global `setTimeout`, `setInterval` and `setImmediate` now use the one from node
+global timer functions now use the one from node:timers

--- a/examples/playground15/instrumentation.js
+++ b/examples/playground15/instrumentation.js
@@ -6,13 +6,13 @@ export function register() {
   const timeout = setTimeout(() => {
     console.log("This is a delayed log from the instrumentation register callback");
   }, 0);
-  // This is to test that we have access to the node version of setTimeout
-  timeout.unref();
-  clearTimeout(timeout);
 
   if (process.env.NEXT_RUNTIME === "nodejs") {
     globalThis["__NODEJS_INSTRUMENTATION_SETUP"] =
       "this value has been set by calling the instrumentation `register` callback in the nodejs runtime";
+    // This is to test that we have access to the node version of setTimeout
+    timeout.unref();
+    clearTimeout(timeout);
   }
 
   if (process.env.NEXT_RUNTIME === "edge") {

--- a/examples/playground15/instrumentation.js
+++ b/examples/playground15/instrumentation.js
@@ -3,6 +3,12 @@ export function register() {
   //       variable as recommended in the official docs:
   //         https://nextjs.org/docs/app/building-your-application/optimizing/instrumentation#importing-runtime-specific-code
 
+  const timeout = setTimeout(() => {
+    console.log("This is a delayed log from the instrumentation register callback");
+  }, 0);
+  // This is to test that we have access to the node version of setTimeout
+  timeout.unref();
+
   if (process.env.NEXT_RUNTIME === "nodejs") {
     globalThis["__NODEJS_INSTRUMENTATION_SETUP"] =
       "this value has been set by calling the instrumentation `register` callback in the nodejs runtime";

--- a/examples/playground15/instrumentation.js
+++ b/examples/playground15/instrumentation.js
@@ -8,6 +8,7 @@ export function register() {
   }, 0);
   // This is to test that we have access to the node version of setTimeout
   timeout.unref();
+  clearTimeout(timeout);
 
   if (process.env.NEXT_RUNTIME === "nodejs") {
     globalThis["__NODEJS_INSTRUMENTATION_SETUP"] =

--- a/packages/cloudflare/src/cli/build/bundle-server.ts
+++ b/packages/cloudflare/src/cli/build/bundle-server.ts
@@ -146,7 +146,7 @@ export async function bundleServer(buildOpts: BuildOptions): Promise<void> {
     },
     banner: {
       // We need to import them here, assigning them to `globalThis` does not work because node:timers use `globalThis` and thus create an infinite loop
-      js: `import {setInterval, setTimeout, setImmediate} from "node:timers"`,
+      js: `import {setInterval, clearInterval, setTimeout, clearTimeout, setImmediate, clearImmediate} from "node:timers"`,
     },
     platform: "node",
   });

--- a/packages/cloudflare/src/cli/build/bundle-server.ts
+++ b/packages/cloudflare/src/cli/build/bundle-server.ts
@@ -146,6 +146,7 @@ export async function bundleServer(buildOpts: BuildOptions): Promise<void> {
     },
     banner: {
       // We need to import them here, assigning them to `globalThis` does not work because node:timers use `globalThis` and thus create an infinite loop
+      // See https://github.com/cloudflare/workerd/blob/d6a764c/src/node/internal/internal_timers.ts#L56-L70
       js: `import {setInterval, clearInterval, setTimeout, clearTimeout, setImmediate, clearImmediate} from "node:timers"`,
     },
     platform: "node",

--- a/packages/cloudflare/src/cli/build/bundle-server.ts
+++ b/packages/cloudflare/src/cli/build/bundle-server.ts
@@ -144,6 +144,10 @@ export async function bundleServer(buildOpts: BuildOptions): Promise<void> {
       // This define should be safe to use for Next 14.2+, earlier versions (13.5 and less) will cause trouble
       "process.env.__NEXT_EXPERIMENTAL_REACT": `${needsExperimentalReact(nextConfig)}`,
     },
+    banner: {
+      // We need to import them here, assigning them to `globalThis` does not work because node:timers use `globalThis` and thus create an infinite loop
+      js: `import {setInterval, setTimeout, setImmediate} from "node:timers"`,
+    },
     platform: "node",
   });
 

--- a/packages/cloudflare/src/cli/templates/init.ts
+++ b/packages/cloudflare/src/cli/templates/init.ts
@@ -20,35 +20,6 @@ Object.defineProperty(globalThis, Symbol.for("__cloudflare-context__"), {
   },
 });
 
-class Timeout implements NodeJS.Timeout {
-  constructor(private id: number, private disposer: (id: number) => void) {}
-
-  ref(): this {
-    return this;
-  }
-
-  close() {
-    this.disposer(this.id);
-  }
-
-  unref(): this {
-    return this;
-  }
-  hasRef(): boolean {
-    return false;
-  }
-  refresh(): this {
-    throw new Error("Method not implemented.");
-  }
-  [Symbol.toPrimitive](): number {
-    return this.id;
-  }
-  [Symbol.dispose](): void {
-    this.disposer(this.id);
-  }
-  
-}
-
 /**
  * Executes the handler with the Cloudflare context.
  */
@@ -123,21 +94,6 @@ function initRuntime() {
     __BUILD_TIMESTAMP_MS__: __BUILD_TIMESTAMP_MS__,
     __NEXT_BASE_PATH__: __NEXT_BASE_PATH__,
   });
-
-  const oldSetInterval = globalThis.setInterval;
-  const oldSetTimeout = globalThis.setTimeout;
-
-  // @ts-expect-error: workerd does not have the same types as node
-  globalThis.setInterval = (cb: (...args: unknown[]) => void, ms: number, ...args: unknown[]) => {
-    const id = oldSetInterval(cb, ms, ...args) as unknown as number;
-    return new Timeout(id, globalThis.clearInterval);
-  };
-
-  // @ts-expect-error: workerd does not have the same types as node
-  globalThis.setTimeout = (cb: (...args: unknown[]) => void, ms: number, ...args: unknown[]) => {
-    const id = oldSetTimeout(cb, ms, ...args) as unknown as number;
-    return new Timeout(id, globalThis.clearTimeout);
-  }
 }
 
 /**


### PR DESCRIPTION
It is expected that the global timers (i.e. `setInterval`, `setTimeout`) in Node returns a `Nodejs.Timeout` instead of a number. On cloudflare workers they return a number.

This can cause some unexpected crash like in #587, where sentry tries to call `unref()` on the created interval.
This PR fix #587

The only downsides to doing that is that in the middleware we'll have access to the Node version as well, but i don't think this is too big of an issue