### PR TITLE
polyfill import.meta.url

### DIFF
--- a/packages/cloudflare/src/cli/templates/init.ts
+++ b/packages/cloudflare/src/cli/templates/init.ts
@@ -94,6 +94,11 @@ function initRuntime() {
     __BUILD_TIMESTAMP_MS__: __BUILD_TIMESTAMP_MS__,
     __NEXT_BASE_PATH__: __NEXT_BASE_PATH__,
   });
+
+  // Some packages rely on `import.meta.url` (i.e. payload) but it is undefined in workerd
+  // It cause a bunch of issue, and will make even import crash
+  // TODO: verify that it won't cause other issues later with other packages
+  import.meta.url = "file:///worker.js";
 }
 
 /**


### PR DESCRIPTION
This PR polyfill `import.meta.url` for packages that may rely on it.
I'm not 100% sure that is what we'd want to end up doing long term.
I feel like this could backfire in the future, a better but more complicated fix would be to replace these values at build time.