### PR TITLE
fix cache population for R2

### DIFF
--- a/.changeset/violet-lemons-think.md
+++ b/.changeset/violet-lemons-think.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+fix cache population for R2

--- a/packages/cloudflare/src/cli/commands/populate-cache.ts
+++ b/packages/cloudflare/src/cli/commands/populate-cache.ts
@@ -125,7 +125,7 @@ async function populateR2IncrementalCache(
       ["r2 object put", quoteShellMeta(path.join(bucket, cacheKey)), `--file ${quoteShellMeta(fullPath)}`],
       // NOTE: R2 does not support the environment flag and results in the following error:
       // Incorrect type for the 'cacheExpiry' field on 'HttpMetadata': the provided value is not of type 'date'.
-      { target: populateCacheOptions.target, excludeRemoteFlag: true, logging: "error" }
+      { target: populateCacheOptions.target, logging: "error" }
     );
   }
   logger.info(`Successfully populated cache with ${assets.length} assets`);

--- a/packages/cloudflare/src/cli/utils/run-wrangler.ts
+++ b/packages/cloudflare/src/cli/utils/run-wrangler.ts
@@ -11,7 +11,6 @@ export type WranglerTarget = "local" | "remote";
 type WranglerOptions = {
   target?: WranglerTarget;
   environment?: string;
-  excludeRemoteFlag?: boolean;
   logging?: "all" | "error";
 };
 
@@ -66,7 +65,7 @@ export function runWrangler(options: BuildOptions, args: string[], wranglerOpts:
         [
           ...args,
           wranglerOpts.environment && `--env ${wranglerOpts.environment}`,
-          wranglerOpts.target === "remote" && !wranglerOpts.excludeRemoteFlag && "--remote",
+          wranglerOpts.target === "remote" && "--remote",
           wranglerOpts.target === "local" && "--local",
         ].filter((v): v is string => !!v)
       ),


### PR DESCRIPTION
`remote` used to be the default but should now be specified explicitly.

