### PR TITLE
Use valid names for R2 buckets

### DIFF
--- a/examples/e2e/app-pages-router/wrangler.jsonc
+++ b/examples/e2e/app-pages-router/wrangler.jsonc
@@ -11,7 +11,7 @@
   "r2_buckets": [
     {
       "binding": "NEXT_INC_CACHE_R2_BUCKET",
-      "bucket_name": "<BUCKET_NAME>"
+      "bucket_name": "cache"
     }
   ],
   "services": [

--- a/examples/e2e/app-router/wrangler.jsonc
+++ b/examples/e2e/app-router/wrangler.jsonc
@@ -29,7 +29,7 @@
   "r2_buckets": [
     {
       "binding": "NEXT_INC_CACHE_R2_BUCKET",
-      "bucket_name": "<BUCKET_NAME>"
+      "bucket_name": "cache"
     }
   ],
   "services": [

--- a/examples/e2e/experimental/wrangler.jsonc
+++ b/examples/e2e/experimental/wrangler.jsonc
@@ -32,7 +32,7 @@
   "r2_buckets": [
     {
       "binding": "NEXT_INC_CACHE_R2_BUCKET",
-      "bucket_name": "<BUCKET_NAME>"
+      "bucket_name": "cache"
     }
   ],
   "services": [

--- a/examples/e2e/pages-router/wrangler.jsonc
+++ b/examples/e2e/pages-router/wrangler.jsonc
@@ -11,7 +11,7 @@
   "r2_buckets": [
     {
       "binding": "NEXT_INC_CACHE_R2_BUCKET",
-      "bucket_name": "<BUCKET_NAME>"
+      "bucket_name": "cache"
     }
   ],
   "services": [

--- a/examples/overrides/r2-incremental-cache/wrangler.jsonc
+++ b/examples/overrides/r2-incremental-cache/wrangler.jsonc
@@ -26,7 +26,7 @@
       "r2_buckets": [
         {
           "binding": "NEXT_INC_CACHE_R2_BUCKET",
-          "bucket_name": "NEXT_INC_CACHE_R2_BUCKET"
+          "bucket_name": "cache"
         }
       ]
     },

--- a/packages/cloudflare/templates/wrangler.jsonc
+++ b/packages/cloudflare/templates/wrangler.jsonc
@@ -14,6 +14,7 @@
     {
       "binding": "NEXT_INC_CACHE_R2_BUCKET",
       // Create the bucket before deploying
+      // You can change the bucket name if you want
       // See https://developers.cloudflare.com/workers/wrangler/commands/#r2-bucket-create
       "bucket_name": "cache"
     }

--- a/packages/cloudflare/templates/wrangler.jsonc
+++ b/packages/cloudflare/templates/wrangler.jsonc
@@ -13,9 +13,9 @@
     // See https://opennext.js.org/cloudflare/caching
     {
       "binding": "NEXT_INC_CACHE_R2_BUCKET",
-      // Create a bucket before deploying
+      // Create the bucket before deploying
       // See https://developers.cloudflare.com/workers/wrangler/commands/#r2-bucket-create
-      "bucket_name": "<BUCKET_NAME>"
+      "bucket_name": "cache"
     }
   ]
 }


### PR DESCRIPTION
Wrangler will start enforcing valid bucket names even in dev, see https://github.com/cloudflare/workers-sdk/pull/9165