### PR TITLE
Fix `blockConcurrencyWhile` in DO queue

### DIFF
--- a/.changeset/nine-months-enter.md
+++ b/.changeset/nine-months-enter.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+fix blockConcurrencyWhile on DO queue

--- a/packages/cloudflare/src/api/durable-objects/queue.spec.ts
+++ b/packages/cloudflare/src/api/durable-objects/queue.spec.ts
@@ -111,10 +111,6 @@ describe("DurableObjectQueue", () => {
       expect(queue.ongoingRevalidations.has("id6")).toBe(false);
       expect(Array.from(queue.ongoingRevalidations.keys())).toEqual(["id", "id2", "id3", "id4", "id5"]);
 
-      // BlockConcurrencyWhile is called twice here, first time during creation of the object and second time when we try to revalidate
-      // @ts-expect-error
-      expect(queue.ctx.blockConcurrencyWhile).toHaveBeenCalledTimes(2);
-
       // Here we await the blocked request to ensure it's resolved
       await blockedReq;
       // We then need to await for the actual revalidation to finish

--- a/packages/cloudflare/src/api/durable-objects/queue.ts
+++ b/packages/cloudflare/src/api/durable-objects/queue.ts
@@ -84,6 +84,11 @@ export class DOQueueHandler extends DurableObject<CloudflareEnv> {
     if (this.checkSyncTable(msg)) return;
 
     if (this.ongoingRevalidations.size >= this.maxRevalidations) {
+      if (this.ongoingRevalidations.size > 2 * this.maxRevalidations) {
+        console.warn(
+          `Your durable object has 2 times the maximum number of revalidations (${this.maxRevalidations}) in progress. If this happens often, you should consider increasing the NEXT_CACHE_DO_QUEUE_MAX_REVALIDATION or the number of durable objects with the MAX_REVALIDATE_CONCURRENCY env var.`
+        );
+      }
       debug(
         `The maximum number of revalidations (${this.maxRevalidations}) is reached. Blocking until one of the revalidations finishes.`
       );


### PR DESCRIPTION
Right now there is an issue with `blockConcurrencyWhile` that will make it block for 30s and fail.
When there is too much revalidate request at a fast enough pace, it seems that there is multiple call to `blockConcurrencyWhile` and they seem to block each other.

This PR fixes it by removing the `blockConcurrencyWhile` and just waiting for `ongoingRevalidation` to go below `maxRevalidate`