### PR TITLE
Feat: Disable config validation

### DIFF
--- a/.changeset/fresh-crews-move.md
+++ b/.changeset/fresh-crews-move.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+add an option to not throw on validation of the config

--- a/.changeset/fresh-crews-move.md
+++ b/.changeset/fresh-crews-move.md
@@ -2,4 +2,4 @@
 "@opennextjs/cloudflare": patch
 ---
 
-add an option to not throw on validation of the config
+add a `cloudflare.dangerousDisableConfigValidation` config option to not throw on validation of the config

--- a/packages/cloudflare/src/api/config.ts
+++ b/packages/cloudflare/src/api/config.ts
@@ -116,6 +116,14 @@ interface OpenNextConfig extends AwsOpenNextConfig {
      * @default true
      */
     useWorkerdCondition?: boolean;
+
+    /**
+     * Disable throwing an error when the config validation fails.
+     * This is useful for overriding some of the default provided by cloudflare.
+     * **USE AT YOUR OWN RISK**
+     * @default false
+     */
+    dangerousDisableConfigValidation?: boolean;
   };
 }
 

--- a/packages/cloudflare/src/cli/build/utils/ensure-cf-config.ts
+++ b/packages/cloudflare/src/cli/build/utils/ensure-cf-config.ts
@@ -36,9 +36,9 @@ export function ensureCloudflareConfig(config: OpenNextConfig) {
   }
 
   if (Object.values(requirements).some((satisfied) => !satisfied)) {
-    throw new Error(
+    const errorMessage =
       "The `open-next.config.ts` should have a default export like this:\n\n" +
-        `{
+      `{
           default: {
             override: {
               wrapper: "cloudflare-node",
@@ -61,7 +61,11 @@ export function ensureCloudflareConfig(config: OpenNextConfig) {
               queue: "dummy" | "direct" | function,
             },
           },
-        }\n\n`.replace(/^ {8}/gm, "")
-    );
+        }\n\n`.replace(/^ {8}/gm, "");
+    if (config.cloudflare?.dangerousDisableConfigValidation) {
+      logger.warn(errorMessage);
+      return;
+    }
+    throw new Error(errorMessage);
   }
 }


### PR DESCRIPTION
In some cases it's interesting to override some of the default provided by cloudflare.
This add an option in `open-next.config.ts` to only add a warning in case of incorrect validation instead of throwing an error