### PR TITLE
fix(preview): Ensure the protocol is correct in redirects from server actions during preview mode

### DIFF
--- a/.changeset/hip-bags-argue.md
+++ b/.changeset/hip-bags-argue.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+fix: Ensure the protocol is correct for redirects in server actions during preview mode

--- a/packages/cloudflare/src/cli/templates/init.ts
+++ b/packages/cloudflare/src/cli/templates/init.ts
@@ -132,6 +132,14 @@ function populateProcessEnv(url: URL, env: CloudflareEnv) {
       port: url.port,
     },
   });
+
+  /* We need to set this environment variable to make redirects work properly in preview mode.
+   * Next sets this in standalone mode during `startServer`. Without this the protocol would always be `https` here:
+   * https://github.com/vercel/next.js/blob/6b1e48080e896e0d44a05fe009cb79d2d3f91774/packages/next/src/server/app-render/action-handler.ts#L307-L316
+   */
+  if (url.hostname === "localhost") {
+    process.env.__NEXT_PRIVATE_ORIGIN = url.origin;
+  }
 }
 
 /* eslint-disable no-var */

--- a/packages/cloudflare/src/cli/templates/init.ts
+++ b/packages/cloudflare/src/cli/templates/init.ts
@@ -137,9 +137,7 @@ function populateProcessEnv(url: URL, env: CloudflareEnv) {
    * Next sets this in standalone mode during `startServer`. Without this the protocol would always be `https` here:
    * https://github.com/vercel/next.js/blob/6b1e48080e896e0d44a05fe009cb79d2d3f91774/packages/next/src/server/app-render/action-handler.ts#L307-L316
    */
-  if (url.hostname === "localhost") {
-    process.env.__NEXT_PRIVATE_ORIGIN = url.origin;
-  }
+  process.env.__NEXT_PRIVATE_ORIGIN = url.origin;
 }
 
 /* eslint-disable no-var */


### PR DESCRIPTION
Closes #686. 

**Important** to note this didn't only affect `next-auth`. All redirects from server actions was affected in preview mode. `wrangler dev` would hang and give an error as it would try to send a request to `https`. 

Through my research I figured out that Next internally uses `process.env.__NEXT_PRIVATE_ORIGIN` in standalone mode. They set it during `startServer` on this [line](https://github.com/vercel/next.js/blob/6b1e48080e896e0d44a05fe009cb79d2d3f91774/packages/next/src/server/lib/start-server.ts#L275). To align with this behavior in preview mode this should be set to the origin during the initialization. 

Affected lines in Next:
- https://github.com/vercel/next.js/blob/6b1e48080e896e0d44a05fe009cb79d2d3f91774/packages/next/src/server/app-render/action-handler.ts#L177-L184
- https://github.com/vercel/next.js/blob/6b1e48080e896e0d44a05fe009cb79d2d3f91774/packages/next/src/server/app-render/action-handler.ts#L307-L308

`proto` would always be `https` here, thus the `fetch` below would recieve the wrong protocol in its `fetchUrl`.