### PR TITLE
[TODO] Drop the patch for NextServer#getMiddlewareManifest

### DIFF
--- a/.changeset/wild-readers-remain.md
+++ b/.changeset/wild-readers-remain.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+Drop the patch for NextServer#getMiddlewareManifest

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -53,7 +53,7 @@
   "homepage": "https://github.com/opennextjs/opennextjs-cloudflare",
   "dependencies": {
     "@dotenvx/dotenvx": "catalog:",
-    "@opennextjs/aws": "3.6.5",
+    "@opennextjs/aws": "https://pkg.pr.new/@opennextjs/aws@892",
     "enquirer": "^2.4.1",
     "glob": "catalog:",
     "ts-tqdm": "^0.8.6"

--- a/packages/cloudflare/src/cli/build/patches/plugins/next-server.spec.ts
+++ b/packages/cloudflare/src/cli/build/patches/plugins/next-server.spec.ts
@@ -1,12 +1,7 @@
 import { patchCode } from "@opennextjs/aws/build/patch/astCodePatcher.js";
 import { describe, expect, test } from "vitest";
 
-import {
-  buildIdRule,
-  createCacheHandlerRule,
-  createComposableCacheHandlersRule,
-  createMiddlewareManifestRule,
-} from "./next-server.js";
+import { buildIdRule, createCacheHandlerRule, createComposableCacheHandlersRule } from "./next-server.js";
 
 describe("Next Server", () => {
   const nextServerCode = `
@@ -170,91 +165,6 @@ class NextNodeServer extends _baseserver.default {
             // ...
         }"
       `);
-  });
-
-  test("middleware manifest", () => {
-    expect(patchCode(nextServerCode, createMiddlewareManifestRule("manifest"))).toMatchInlineSnapshot(`
-      "class NextNodeServer extends _baseserver.default {
-          constructor(options){
-              // Initialize super class
-              super(options);
-              this.handleNextImageRequest = async (req, res, parsedUrl) => { /* ... */ };
-          }
-          async handleUpgrade() {
-          // The web server does not support web sockets, it's only used for HMR in
-          // development.
-          }
-          loadEnvConfig({ dev, forceReload, silent }) {
-              (0, _env.loadEnvConfig)(this.dir, dev, silent ? {
-                  info: ()=>{},
-                  error: ()=>{}
-              } : _log, forceReload);
-          }
-          async hasPage(pathname) {
-              var _this_nextConfig_i18n;
-              return !!(0, _require.getMaybePagePath)(pathname, this.distDir, (_this_nextConfig_i18n = this.nextConfig.i18n) == null ? void 0 : _this_nextConfig_i18n.locales, this.enabledDirectories.app);
-          }
-          getBuildId() {
-              const buildIdFile = (0, _path.join)(this.distDir, _constants.BUILD_ID_FILE);
-              try {
-                  return _fs.default.readFileSync(buildIdFile, "utf8").trim();
-              } catch (err) {
-                  if (err.code === "ENOENT") {
-                      throw new Error(\`Could not find a production build in the '\${this.distDir}' directory. Try building your app with 'next build' before starting the production server. https://nextjs.org/docs/messages/production-start-no-build-id\`);
-                  }
-                  throw err;
-              }
-          }
-          getMiddlewareManifest() {
-        return "manifest";
-      }
-          async loadCustomCacheHandlers() {
-              const { cacheHandlers } = this.nextConfig.experimental;
-              if (!cacheHandlers) return;
-              // If we've already initialized the cache handlers interface, don't do it
-              // again.
-              if (!(0, _handlers.initializeCacheHandlers)()) return;
-              for (const [kind, handler] of Object.entries(cacheHandlers)){
-                  if (!handler) continue;
-                  (0, _handlers.setCacheHandler)(kind, (0, _interopdefault.interopDefault)(await dynamicImportEsmDefault((0, _formatdynamicimportpath.formatDynamicImportPath)(this.distDir, handler))));
-              }
-          }
-          async getIncrementalCache({ requestHeaders, requestProtocol }) {
-              const dev = !!this.renderOpts.dev;
-              let CacheHandler;
-              const { cacheHandler } = this.nextConfig;
-              if (cacheHandler) {
-                  CacheHandler = (0, _interopdefault.interopDefault)(await dynamicImportEsmDefault((0, _formatdynamicimportpath.formatDynamicImportPath)(this.distDir, cacheHandler)));
-              }
-              await this.loadCustomCacheHandlers();
-              // incremental-cache is request specific
-              // although can have shared caches in module scope
-              // per-cache handler
-              return new _incrementalcache.IncrementalCache({
-                  fs: this.getCacheFilesystem(),
-                  dev,
-                  requestHeaders,
-                  requestProtocol,
-                  allowedRevalidateHeaderKeys: this.nextConfig.experimental.allowedRevalidateHeaderKeys,
-                  minimalMode: this.minimalMode,
-                  serverDistDir: this.serverDistDir,
-                  fetchCacheKeyPrefix: this.nextConfig.experimental.fetchCacheKeyPrefix,
-                  maxMemoryCacheSize: this.nextConfig.cacheMaxMemorySize,
-                  flushToDisk: !this.minimalMode && this.nextConfig.experimental.isrFlushToDisk,
-                  getPrerenderManifest: ()=>this.getPrerenderManifest(),
-                  CurCacheHandler: CacheHandler
-              });
-          }
-          getEnabledDirectories(dev) {
-              const dir = dev ? this.dir : this.serverDistDir;
-              return {
-                  app: (0, _findpagesdir.findDir)(dir, "app") ? true : false,
-                  pages: (0, _findpagesdir.findDir)(dir, "pages") ? true : false
-              };
-          }
-          // ...
-      }"
-    `);
   });
 
   test("cache handler", () => {

--- a/packages/cloudflare/src/cli/build/patches/plugins/next-server.ts
+++ b/packages/cloudflare/src/cli/build/patches/plugins/next-server.ts
@@ -4,11 +4,9 @@
  * Note: we will probably need to revisit the patches when the Next adapter API lands
  *
  * - Inline `getBuildId` as it relies on `readFileSync` that is not supported by workerd
- * - Inline the middleware manifest
  * - Override the cache and composable cache handlers
  */
 
-import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 
 import { type BuildOptions, getPackagePath } from "@opennextjs/aws/build/helper.js";
@@ -30,19 +28,6 @@ export function patchNextServer(updater: ContentUpdater, buildOpts: BuildOptions
           const { outputDir } = buildOpts;
 
           contents = patchCode(contents, buildIdRule);
-
-          const manifestPath = path.join(
-            outputDir,
-            "server-functions/default",
-            getPackagePath(buildOpts),
-            ".next/server/middleware-manifest.json"
-          );
-
-          const manifest = existsSync(manifestPath)
-            ? JSON.parse(await readFileSync(manifestPath, "utf-8"))
-            : {};
-
-          contents = patchCode(contents, createMiddlewareManifestRule(manifest));
 
           const outputPath = path.join(outputDir, "server-functions/default");
           const cacheHandler = path.join(outputPath, getPackagePath(buildOpts), "cache.cjs");
@@ -71,19 +56,6 @@ fix: |-
     return process.env.NEXT_BUILD_ID;
   }
 `;
-
-export function createMiddlewareManifestRule(manifest: unknown) {
-  return `
-rule:
-  pattern:
-    selector: method_definition
-    context: "class { getMiddlewareManifest($$$PARAMS) { $$$_ } }"
-fix: |-
-  getMiddlewareManifest($$$PARAMS) {
-    return ${JSON.stringify(manifest)};
-  }
-`;
-}
 
 /**
  * The cache handler used by Next.js is normally defined in the config file as a path. At runtime,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1035,8 +1035,8 @@ importers:
         specifier: 'catalog:'
         version: 1.31.0
       '@opennextjs/aws':
-        specifier: 3.6.5
-        version: 3.6.5
+        specifier: https://pkg.pr.new/@opennextjs/aws@892
+        version: https://pkg.pr.new/@opennextjs/aws@892
       enquirer:
         specifier: ^2.4.1
         version: 2.4.1
@@ -3753,8 +3753,9 @@ packages:
   '@octokit/types@13.10.0':
     resolution: {integrity: sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==}
 
-  '@opennextjs/aws@3.6.5':
-    resolution: {integrity: sha512-wni+CWlRCyWfhNfekQBBPPkrDDnaGdZLN9hMybKI0wKOKTO+zhPOqR65Eh3V0pzWAi84Sureb5mdMuLwCxAAcw==}
+  '@opennextjs/aws@https://pkg.pr.new/@opennextjs/aws@892':
+    resolution: {tarball: https://pkg.pr.new/@opennextjs/aws@892}
+    version: 3.6.5
     hasBin: true
 
   '@opentelemetry/api@1.9.0':
@@ -12701,7 +12702,7 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 24.2.0
 
-  '@opennextjs/aws@3.6.5':
+  '@opennextjs/aws@https://pkg.pr.new/@opennextjs/aws@892':
     dependencies:
       '@ast-grep/napi': 0.35.0
       '@aws-sdk/client-cloudfront': 3.398.0


### PR DESCRIPTION
There is no need to patch this unused method.

We can rely on aws patching the method to return null. It will patch regardless of the version when https://github.com/opennextjs/opennextjs-aws/pull/892 gets merged. 

TODO:

- [ ] update package.json after opennextjs/opennextjs-aws#892 is released