### PR TITLE
Make the require patch optional

### DIFF
--- a/.changeset/whole-spiders-stay.md
+++ b/.changeset/whole-spiders-stay.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+make the "require" patch optional

--- a/packages/cloudflare/src/cli/build/bundle-server.ts
+++ b/packages/cloudflare/src/cli/build/bundle-server.ts
@@ -174,7 +174,9 @@ export async function bundleServer(buildOpts: BuildOptions): Promise<void> {
  */
 export async function updateWorkerBundledCode(workerOutputFile: string): Promise<void> {
   const code = await readFile(workerOutputFile, "utf8");
-  const patchedCode = await patchCodeWithValidations(code, [["require", patches.patchRequire]]);
+  const patchedCode = await patchCodeWithValidations(code, [
+    ["require", patches.patchRequire, { isOptional: true }],
+  ]);
   await writeFile(workerOutputFile, patchedCode);
 }
 

--- a/packages/cloudflare/src/cli/build/patches/plugins/open-next.ts
+++ b/packages/cloudflare/src/cli/build/patches/plugins/open-next.ts
@@ -19,8 +19,6 @@ export function patchResolveCache(updater: ContentUpdater, buildOpts: BuildOptio
     path.join(outputPath, packagePath, `index.mjs`)
   );
 
-  console.error({ index: indexPath });
-
   return updater.updateContent("patch-resolve-cache", [
     {
       field: {

--- a/packages/cloudflare/src/cli/build/utils/apply-patches.ts
+++ b/packages/cloudflare/src/cli/build/utils/apply-patches.ts
@@ -25,6 +25,5 @@ export async function patchCodeWithValidations(
     }
   }
 
-  console.log(`All ${patches.length} patches applied\n`);
   return patchedCode;
 }


### PR DESCRIPTION
The "require" patch could be mark as optional - It triggered an error when I was playing with minification settings.

Also:
- Drop a debug `console.error`
- Make `patchCodeWithValidations` less verbose as it is now less used.

