### PR TITLE
perf: minify the generated bundle by default

### DIFF
--- a/.changeset/giant-books-dream.md
+++ b/.changeset/giant-books-dream.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+perf: minify the generated bundle by default

--- a/packages/cloudflare/src/cli/build/bundle-server.ts
+++ b/packages/cloudflare/src/cli/build/bundle-server.ts
@@ -48,7 +48,7 @@ const optionalDependencies = [
 export async function bundleServer(buildOpts: BuildOptions): Promise<void> {
   patches.copyPackageCliFiles(packageDistDir, buildOpts);
 
-  const { appPath, outputDir, monorepoRoot } = buildOpts;
+  const { appPath, outputDir, monorepoRoot, debug } = buildOpts;
   const baseManifestPath = path.join(
     outputDir,
     "server-functions/default",
@@ -76,7 +76,11 @@ export async function bundleServer(buildOpts: BuildOptions): Promise<void> {
     outfile: openNextServerBundle,
     format: "esm",
     target: "esnext",
-    minify: false,
+    // Minify code as much as possible but stay safe by not renaming identifiers
+    minifyWhitespace: !debug,
+    minifyIdentifiers: false,
+    minifySyntax: !debug,
+    legalComments: "none",
     metafile: true,
     // Next traces files using the default conditions from `nft` (`node`, `require`, `import` and `default`)
     //


### PR DESCRIPTION
Turns on minifying by default as bundle size could have an impact on performance.

This PR stays on the safe side by only minifying whitespaces and syntax. Identifier are explicitly not renamed to avoid runtime issues.

Some result experimenting with a sample app.

The original code size was 7.7MB before bundling.

Before this PR, the output would be 10.2MB
Using the most agressive minification (`minify: true`) -> 6.7MB
Using the safe minification implemented in this PR -> 7.4MB

That a close to 30% improvement.