### PR TITLE
fix(patches): Update patchInstrumentation and loadManifest to work with Next 15.4

### DIFF
--- a/.changeset/modern-buses-think.md
+++ b/.changeset/modern-buses-think.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+fix(patches): Update patchInstrumentation and loadManifest to work with Next 15.4

--- a/packages/cloudflare/src/cli/build/bundle-server.ts
+++ b/packages/cloudflare/src/cli/build/bundle-server.ts
@@ -147,7 +147,7 @@ export async function bundleServer(buildOpts: BuildOptions): Promise<void> {
 			"process.env.TURBOPACK": "false",
 			// This define should be safe to use for Next 14.2+, earlier versions (13.5 and less) will cause trouble
 			"process.env.__NEXT_EXPERIMENTAL_REACT": `${needsExperimentalReact(nextConfig)}`,
-			"process.env__NEXT_BUILD_ID": JSON.stringify(loadBuildId(baseManifestPath)),
+			"process.env.__NEXT_BUILD_ID": JSON.stringify(loadBuildId(baseManifestPath)),
 		},
 		banner: {
 			// We need to import them here, assigning them to `globalThis` does not work because node:timers use `globalThis` and thus create an infinite loop

--- a/packages/cloudflare/src/cli/build/bundle-server.ts
+++ b/packages/cloudflare/src/cli/build/bundle-server.ts
@@ -3,7 +3,6 @@ import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { loadBuildId } from "@opennextjs/aws/adapters/config/util.js";
 import { type BuildOptions, getPackagePath } from "@opennextjs/aws/build/helper.js";
 import { ContentUpdater } from "@opennextjs/aws/plugins/content-updater.js";
 import { build, type Plugin } from "esbuild";
@@ -147,7 +146,6 @@ export async function bundleServer(buildOpts: BuildOptions): Promise<void> {
 			"process.env.TURBOPACK": "false",
 			// This define should be safe to use for Next 14.2+, earlier versions (13.5 and less) will cause trouble
 			"process.env.__NEXT_EXPERIMENTAL_REACT": `${needsExperimentalReact(nextConfig)}`,
-			"process.env.__NEXT_BUILD_ID": JSON.stringify(loadBuildId(baseManifestPath)),
 		},
 		banner: {
 			// We need to import them here, assigning them to `globalThis` does not work because node:timers use `globalThis` and thus create an infinite loop

--- a/packages/cloudflare/src/cli/build/bundle-server.ts
+++ b/packages/cloudflare/src/cli/build/bundle-server.ts
@@ -3,6 +3,7 @@ import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { loadBuildId } from "@opennextjs/aws/adapters/config/util.js";
 import { type BuildOptions, getPackagePath } from "@opennextjs/aws/build/helper.js";
 import { ContentUpdater } from "@opennextjs/aws/plugins/content-updater.js";
 import { build, type Plugin } from "esbuild";
@@ -146,6 +147,7 @@ export async function bundleServer(buildOpts: BuildOptions): Promise<void> {
 			"process.env.TURBOPACK": "false",
 			// This define should be safe to use for Next 14.2+, earlier versions (13.5 and less) will cause trouble
 			"process.env.__NEXT_EXPERIMENTAL_REACT": `${needsExperimentalReact(nextConfig)}`,
+			"process.env__NEXT_BUILD_ID": JSON.stringify(loadBuildId(baseManifestPath)),
 		},
 		banner: {
 			// We need to import them here, assigning them to `globalThis` does not work because node:timers use `globalThis` and thus create an infinite loop

--- a/packages/cloudflare/src/cli/build/patches/plugins/instrumentation.spec.ts
+++ b/packages/cloudflare/src/cli/build/patches/plugins/instrumentation.spec.ts
@@ -104,7 +104,7 @@ describe("getInstrumenationModule (Next154)", () => {
         return cachedInstrumentationModule;
       }
       try {
-        cachedInstrumentationModule = (0, _interopdefault.interopDefault)(await require(_nodepath.default.join(projectDir, distDir, "server", \`\${_constants.INSTRUMENTATION_HOOK_FILENAME}.js\`\)));
+        cachedInstrumentationModule = (0, _interopdefault.interopDefault)(await require(_nodepath.default.join(projectDir, distDir, "server", \`\${_constants.INSTRUMENTATION_HOOK_FILENAME}.js\`)));
         return cachedInstrumentationModule;
       } catch (err) {
         if ((0, _iserror.default)(err) && err.code !== "ENOENT" && err.code !== "MODULE_NOT_FOUND" && err.code !== "ERR_MODULE_NOT_FOUND") {

--- a/packages/cloudflare/src/cli/build/patches/plugins/instrumentation.spec.ts
+++ b/packages/cloudflare/src/cli/build/patches/plugins/instrumentation.spec.ts
@@ -1,7 +1,7 @@
 import { patchCode } from "@opennextjs/aws/build/patch/astCodePatcher.js";
 import { describe, expect, test } from "vitest";
 
-import { getNext14Rule, getNext15Rule } from "./instrumentation.js";
+import { getNext14Rule, getNext15Rule, getNext154Rule } from "./instrumentation.js";
 
 describe("LoadInstrumentationModule (Next15)", () => {
 	const code = `
@@ -94,5 +94,61 @@ describe("prepareImpl (Next14)", () => {
             }
           "
     `);
+	});
+});
+
+describe("getInstrumenationModule (Next154)", () => {
+	const code = `
+    async function getInstrumentationModule(projectDir, distDir) {
+      if (cachedInstrumentationModule) {
+        return cachedInstrumentationModule;
+      }
+      try {
+        cachedInstrumentationModule = (0, _interopdefault.interopDefault)(await require(_nodepath.default.join(projectDir, distDir, "server", \`\${_constants.INSTRUMENTATION_HOOK_FILENAME}.js\`\)));
+        return cachedInstrumentationModule;
+      } catch (err) {
+        if ((0, _iserror.default)(err) && err.code !== "ENOENT" && err.code !== "MODULE_NOT_FOUND" && err.code !== "ERR_MODULE_NOT_FOUND") {
+          throw err;
+        }
+      }
+    }
+  `;
+
+	test("patch when an instrumentation file is not present", async () => {
+		expect(patchCode(code, getNext154Rule(null))).toMatchInlineSnapshot(`
+			"async function getInstrumentationModule(projectDir, distDir) {
+			  if (cachedInstrumentationModule) {
+			    return cachedInstrumentationModule;
+			  }
+			  try {
+			    cachedInstrumentationModule = null;
+			    return cachedInstrumentationModule;
+			  } catch (err) {
+			    if ((0, _iserror.default)(err) && err.code !== "ENOENT" && err.code !== "MODULE_NOT_FOUND" && err.code !== "ERR_MODULE_NOT_FOUND") {
+			      throw err;
+			    }
+			  }
+			}
+			  "
+		`);
+	});
+
+	test("patch when an instrumentation file is present", async () => {
+		expect(patchCode(code, getNext154Rule("/_file_exists_/instrumentation.js"))).toMatchInlineSnapshot(`
+			"async function getInstrumentationModule(projectDir, distDir) {
+			  if (cachedInstrumentationModule) {
+			    return cachedInstrumentationModule;
+			  }
+			  try {
+			    cachedInstrumentationModule = require('/_file_exists_/instrumentation.js');
+			    return cachedInstrumentationModule;
+			  } catch (err) {
+			    if ((0, _iserror.default)(err) && err.code !== "ENOENT" && err.code !== "MODULE_NOT_FOUND" && err.code !== "ERR_MODULE_NOT_FOUND") {
+			      throw err;
+			    }
+			  }
+			}
+			  "
+		`);
 	});
 });

--- a/packages/cloudflare/src/cli/build/patches/plugins/instrumentation.spec.ts
+++ b/packages/cloudflare/src/cli/build/patches/plugins/instrumentation.spec.ts
@@ -97,7 +97,7 @@ describe("prepareImpl (Next14)", () => {
 	});
 });
 
-describe("getInstrumenationModule (Next154)", () => {
+describe("getInstrumenationModule (Next15.4)", () => {
 	const code = `
     async function getInstrumentationModule(projectDir, distDir) {
       if (cachedInstrumentationModule) {

--- a/packages/cloudflare/src/cli/build/patches/plugins/instrumentation.spec.ts
+++ b/packages/cloudflare/src/cli/build/patches/plugins/instrumentation.spec.ts
@@ -117,18 +117,18 @@ describe("getInstrumenationModule (Next154)", () => {
 	test("patch when an instrumentation file is not present", async () => {
 		expect(patchCode(code, getNext154Rule(null))).toMatchInlineSnapshot(`
 			"async function getInstrumentationModule(projectDir, distDir) {
-			  if (cachedInstrumentationModule) {
-			    return cachedInstrumentationModule;
-			  }
-			  try {
-			    cachedInstrumentationModule = null;
-			    return cachedInstrumentationModule;
-			  } catch (err) {
-			    if ((0, _iserror.default)(err) && err.code !== "ENOENT" && err.code !== "MODULE_NOT_FOUND" && err.code !== "ERR_MODULE_NOT_FOUND") {
-			      throw err;
+			      if (cachedInstrumentationModule) {
+			        return cachedInstrumentationModule;
+			      }
+			      try {
+			        cachedInstrumentationModule = null;
+			        return cachedInstrumentationModule;
+			      } catch (err) {
+			        if ((0, _iserror.default)(err) && err.code !== "ENOENT" && err.code !== "MODULE_NOT_FOUND" && err.code !== "ERR_MODULE_NOT_FOUND") {
+			          throw err;
+			        }
+			      }
 			    }
-			  }
-			}
 			  "
 		`);
 	});
@@ -136,18 +136,18 @@ describe("getInstrumenationModule (Next154)", () => {
 	test("patch when an instrumentation file is present", async () => {
 		expect(patchCode(code, getNext154Rule("/_file_exists_/instrumentation.js"))).toMatchInlineSnapshot(`
 			"async function getInstrumentationModule(projectDir, distDir) {
-			  if (cachedInstrumentationModule) {
-			    return cachedInstrumentationModule;
-			  }
-			  try {
-			    cachedInstrumentationModule = require('/_file_exists_/instrumentation.js');
-			    return cachedInstrumentationModule;
-			  } catch (err) {
-			    if ((0, _iserror.default)(err) && err.code !== "ENOENT" && err.code !== "MODULE_NOT_FOUND" && err.code !== "ERR_MODULE_NOT_FOUND") {
-			      throw err;
+			      if (cachedInstrumentationModule) {
+			        return cachedInstrumentationModule;
+			      }
+			      try {
+			        cachedInstrumentationModule = require('/_file_exists_/instrumentation.js');
+			        return cachedInstrumentationModule;
+			      } catch (err) {
+			        if ((0, _iserror.default)(err) && err.code !== "ENOENT" && err.code !== "MODULE_NOT_FOUND" && err.code !== "ERR_MODULE_NOT_FOUND") {
+			          throw err;
+			        }
+			      }
 			    }
-			  }
-			}
 			  "
 		`);
 	});

--- a/packages/cloudflare/src/cli/build/patches/plugins/instrumentation.ts
+++ b/packages/cloudflare/src/cli/build/patches/plugins/instrumentation.ts
@@ -59,23 +59,16 @@ rule:
   has:
     kind: assignment_expression
     all:
-      - has: {kind: identifier, pattern: cachedInstrumentationModule}
-    has:
-      kind: call_expression
-      all:
-        - has: {kind: arguments, regex: _constants.INSTRUMENTATION_HOOK_FILENAME}
+      - has: { pattern: "cachedInstrumentationModule" }
+      - has: { kind: call_expression, regex: "INSTRUMENTATION_HOOK_FILENAME"}
   inside:
     kind: try_statement
     stopBy: end
-    has:
-      all:
-        - has: {kind: return_statement, pattern: return cachedInstrumentationModule}
+    has: { regex: "return cachedInstrumentationModule" }
     inside:
-      kind: statement_block
-      inside:
-        kind: function_declaration
-        all:
-         - has: {field: name, pattern: getInstrumentationModule}
+      kind: function_declaration
+      stopBy: end
+      has: { field: name, pattern: getInstrumentationModule }
 fix: |-
       cachedInstrumentationModule = ${builtInstrumentationPath ? `require('${builtInstrumentationPath}')` : "null"};
 `;

--- a/packages/cloudflare/src/cli/build/patches/plugins/instrumentation.ts
+++ b/packages/cloudflare/src/cli/build/patches/plugins/instrumentation.ts
@@ -20,7 +20,7 @@ export function patchInstrumentation(updater: ContentUpdater, buildOpts: BuildOp
 						escape: false,
 					}
 				),
-				contentFilter: /async function getInstrumentationModule\(/,
+				contentFilter: /getInstrumentationModule\(/,
 				callback: ({ contents }) => patchCode(contents, getNext154Rule(builtInstrumentationPath)),
 			},
 		},

--- a/packages/cloudflare/src/cli/build/patches/plugins/load-manifest.ts
+++ b/packages/cloudflare/src/cli/build/patches/plugins/load-manifest.ts
@@ -63,10 +63,10 @@ function loadManifest($PATH, $$$ARGS) {
 		},
 		fix: `
 function loadManifest($PATH, $$$ARGS) {
- if ($PATH === "/.next/BUILD_ID") {
+  $PATH = $PATH.replaceAll(${JSON.stringify(sep)}, ${JSON.stringify(posix.sep)});
+  if ($PATH === "/.next/BUILD_ID") {
   return process.env.NEXT_BUILD_ID;
 	}
-  $PATH = $PATH.replaceAll(${JSON.stringify(sep)}, ${JSON.stringify(posix.sep)});
   ${returnManifests}
   throw new Error(\`Unexpected loadManifest(\${$PATH}) call!\`);
 }`,

--- a/packages/cloudflare/src/cli/build/patches/plugins/load-manifest.ts
+++ b/packages/cloudflare/src/cli/build/patches/plugins/load-manifest.ts
@@ -39,7 +39,9 @@ async function getLoadManifestRule(buildOpts: BuildOptions) {
 	const baseDir = join(outputDir, "server-functions/default", getPackagePath(buildOpts));
 	const dotNextDir = join(baseDir, ".next");
 
-	const manifests = await glob(join(dotNextDir, "**/*-manifest.json"), { windowsPathsNoEscape: true });
+	const manifests = await glob(join(dotNextDir, "**/{*-manifest,required-server-files}.json"), {
+		windowsPathsNoEscape: true,
+	});
 
 	const returnManifests = (
 		await Promise.all(
@@ -61,6 +63,9 @@ function loadManifest($PATH, $$$ARGS) {
 		},
 		fix: `
 function loadManifest($PATH, $$$ARGS) {
+ if ($PATH === "/.next/BUILD_ID") {
+  return process.env.__NEXT_BUILD_ID;
+	}
   $PATH = $PATH.replaceAll(${JSON.stringify(sep)}, ${JSON.stringify(posix.sep)});
   ${returnManifests}
   throw new Error(\`Unexpected loadManifest(\${$PATH}) call!\`);

--- a/packages/cloudflare/src/cli/build/patches/plugins/load-manifest.ts
+++ b/packages/cloudflare/src/cli/build/patches/plugins/load-manifest.ts
@@ -64,7 +64,7 @@ function loadManifest($PATH, $$$ARGS) {
 		fix: `
 function loadManifest($PATH, $$$ARGS) {
  if ($PATH === "/.next/BUILD_ID") {
-  return process.env.__NEXT_BUILD_ID;
+  return process.env.NEXT_BUILD_ID;
 	}
   $PATH = $PATH.replaceAll(${JSON.stringify(sep)}, ${JSON.stringify(posix.sep)});
   ${returnManifests}


### PR DESCRIPTION
For #667, #794 and #792.

[This](https://github.com/vercel/next.js/blob/f1b88b4cfa63a6560a04baa209c09065c419969c/packages/next/src/server/lib/router-utils/instrumentation-globals.external.ts#L12-L43) code in Next needs to be patched, and also `loadManifest` also needs to be patched. It will get a path for `required-server-files.json` and `.next/BUILD_ID`.

Tested on `next@15.4.2-canary.1`

Update: This will make instrumenation and loadManifest work on `>=15.4.2`, but there is more patches that need update. Incremental Cache is not getting applied and possibly more issues. Needs more investigation.