### PR TITLE
perf: drop the babel dependency

### DIFF
--- a/.changeset/neat-jars-listen.md
+++ b/.changeset/neat-jars-listen.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+perf: drop the babel dependency

--- a/packages/cloudflare/src/cli/build/bundle-server.ts
+++ b/packages/cloudflare/src/cli/build/bundle-server.ts
@@ -16,6 +16,7 @@ import { inlineFindDir } from "./patches/plugins/find-dir.js";
 import { patchInstrumentation } from "./patches/plugins/instrumentation.js";
 import { inlineLoadManifest } from "./patches/plugins/load-manifest.js";
 import { patchNextServer } from "./patches/plugins/next-server.js";
+import { patchNodeEnvironment } from "./patches/plugins/node-environment.js";
 import { patchResolveCache } from "./patches/plugins/open-next.js";
 import { handleOptionalDependencies } from "./patches/plugins/optional-deps.js";
 import { patchPagesRouterContext } from "./patches/plugins/pages-router-context.js";
@@ -107,6 +108,7 @@ export async function bundleServer(buildOpts: BuildOptions, projectOpts: Project
 			patchRouteModules(updater, buildOpts),
 			patchDepdDeprecations(updater),
 			patchResolveCache(updater, buildOpts),
+			patchNodeEnvironment(updater),
 			// Apply updater updates, must be the last plugin
 			updater.plugin,
 		] as Plugin[],

--- a/packages/cloudflare/src/cli/build/patches/plugins/node-environment.spec.ts
+++ b/packages/cloudflare/src/cli/build/patches/plugins/node-environment.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "vitest";
+
+import { computePatchDiff } from "../../utils/test-patch.js";
+import { errorInspectRule } from "./node-environment.js";
+
+describe("NodeEnvironment", () => {
+	const code = `
+// This file should be imported before any others. It sets up the environment
+// for later imports to work properly.
+"use strict";
+Object.defineProperty(exports, "__esModule", {
+		value: true
+});
+require("./node-environment-baseline");
+require("./node-environment-extensions/error-inspect");
+require("./node-environment-extensions/random");
+require("./node-environment-extensions/date");
+require("./node-environment-extensions/web-crypto");
+require("./node-environment-extensions/node-crypto");
+if (process.env.NODE_ENV === 'development') {
+		require('./node-environment-extensions/console-dev');
+}
+
+//# sourceMappingURL=node-environment.js.map
+`;
+
+	test("error inspect", () => {
+		expect(computePatchDiff("node-environment.js", code, errorInspectRule)).toMatchInlineSnapshot(`
+			"Index: node-environment.js
+			===================================================================
+			--- node-environment.js
+			+++ node-environment.js
+			@@ -1,13 +1,13 @@
+			-
+			 // This file should be imported before any others. It sets up the environment
+			 // for later imports to work properly.
+			 "use strict";
+			 Object.defineProperty(exports, "__esModule", {
+			 		value: true
+			 });
+			 require("./node-environment-baseline");
+			-require("./node-environment-extensions/error-inspect");
+			+// Removed by OpenNext
+			+// require("./node-environment-extensions/error-inspect");
+			 require("./node-environment-extensions/random");
+			 require("./node-environment-extensions/date");
+			 require("./node-environment-extensions/web-crypto");
+			 require("./node-environment-extensions/node-crypto");
+			"
+		`);
+	});
+});

--- a/packages/cloudflare/src/cli/build/patches/plugins/node-environment.ts
+++ b/packages/cloudflare/src/cli/build/patches/plugins/node-environment.ts
@@ -1,0 +1,30 @@
+/**
+ * Remove a dependency on Babel by dropping the require of error-inspect
+ */
+
+import { patchCode } from "@opennextjs/aws/build/patch/astCodePatcher.js";
+import type { ContentUpdater, Plugin } from "@opennextjs/aws/plugins/content-updater.js";
+import { getCrossPlatformPathRegex } from "@opennextjs/aws/utils/regex.js";
+
+export function patchNodeEnvironment(updater: ContentUpdater): Plugin {
+	return updater.updateContent("node-environment", [
+		{
+			filter: getCrossPlatformPathRegex(String.raw`/next/dist/server/node-environment\.js$`, {
+				escape: false,
+			}),
+			contentFilter: /error-inspect/,
+			callback: async ({ contents }) => patchCode(contents, errorInspectRule),
+		},
+	]);
+}
+
+/**
+ * Drops `require("./node-environment-extensions/error-inspect");`
+ */
+export const errorInspectRule = `
+rule:
+  pattern: require("./node-environment-extensions/error-inspect");
+fix: |-
+  // Removed by OpenNext
+  // require("./node-environment-extensions/error-inspect");
+`;


### PR DESCRIPTION
The [former patch of next server is not enough](https://github.com/opennextjs/opennextjs-aws/blob/e1048ac9bfffa79d32b1cab810619c41a66187c3/packages/open-next/src/build/patch/patches/patchNextServer.ts#L94).

The code was changed sometimes in Next 15.

We should upstream that to aws.

Before (e2e/experimental)

<img width="1636" height="924" alt="image" src="https://github.com/user-attachments/assets/863180ee-f05f-495b-8225-d21ef96410d9" />

After

<img width="1636" height="853" alt="image" src="https://github.com/user-attachments/assets/1dbbfbb9-e9d4-4fd0-9cd4-bc9584039e06" />


/cc @conico974 @sommeeeer 



