### PR TITLE
add: Ensure that the initial request.signal is passed to the wrapper

### DIFF
--- a/packages/cloudflare/src/cli/templates/worker.ts
+++ b/packages/cloudflare/src/cli/templates/worker.ts
@@ -54,7 +54,7 @@ export default {
 			// @ts-expect-error: resolved by wrangler build
 			const { handler } = await import("./server-functions/default/handler.mjs");
 
-			return handler(reqOrResp, env, ctx);
+			return handler(reqOrResp, env, ctx, request.signal);
 		});
 	},
 } satisfies ExportedHandler<CloudflareEnv>;


### PR DESCRIPTION
For https://github.com/opennextjs/opennextjs-aws/pull/952

Pass along the original `AbortSignal` to the wrapper.

Will make `request.signal.onabort` work in route handlers.

Should also close #691 