### PR TITLE
feat: export cli internals for programmatic usage

### DIFF
--- a/.changeset/ninety-plums-roll.md
+++ b/.changeset/ninety-plums-roll.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": minor
+---
+
+Introduce two new entry points to the @opennextjs/cloudflare package, `/cli` and `/lib`. `/cli` is intended to be an entry point for developers looking to use the CLI programmatically, which is a use case especially relevant for using @opennextjs/cloudflare with Workers for Platforms. The new `/lib` entry point is a duplicate of the existing catch-all (`/*`) entry point, but can be used in the future to more explicitly differentiate between exports intended for a Next.js app being deployed to Cloudflare, vs. exports related to programmatic usage of the CLI.

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -28,6 +28,16 @@
 			"import": "./dist/api/*.js",
 			"types": "./dist/api/*.d.ts",
 			"default": "./dist/api/*.js"
+		},
+		"./lib/*": {
+			"import": "./dist/api/*.js",
+			"types": "./dist/api/*.d.ts",
+			"default": "./dist/api/*.js"
+		},
+		"./cli/*": {
+			"import": "./dist/cli/*.js",
+			"types": "./dist/cli/*.d.ts",
+			"default": "./dist/cli/*.js"
 		}
 	},
 	"files": [


### PR DESCRIPTION
This PR adds two more entry points to the `@opennextjs/cloudflare package`: 
1. `"./cli/*"`
2. `"./lib/*"`

`"./cli/*"` is intended to be an entry point used by developers who are looking to use the `opennextjs-cloudflare` CLI programmatically, which is a use case especially relevant for using `@opennextjs/cloudflare` with [Workers for Platforms](https://developers.cloudflare.com/cloudflare-for-platforms/workers-for-platforms/). 

`"./lib/*"` is an entry point that intentionally duplicates the existing catch-all (`"./*"`) entry point; undocumented for now, but in the future can be used to more explicitly differentiate between exports intended for the Next.js app being deployed to Cloudflare, vs. exports related to programmatic usage of the CLI.