### PR TITLE
Clean output directory before build to prevent recursive bundling

### DIFF
--- a/.changeset/six-days-watch.md
+++ b/.changeset/six-days-watch.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+Clean output directory before `next build`

--- a/packages/cloudflare/src/cli/build/build.ts
+++ b/packages/cloudflare/src/cli/build/build.ts
@@ -47,6 +47,9 @@ export async function build(
 	logger.info(`@opennextjs/cloudflare version: ${cloudflare}`);
 	logger.info(`@opennextjs/aws version: ${aws}`);
 
+	// Clean the output directory before building the Next app.
+	buildHelper.initOutputDir(options);
+
 	if (projectOpts.skipNextBuild) {
 		logger.warn("Skipping Next.js build");
 	} else {
@@ -58,7 +61,6 @@ export async function build(
 
 	// Generate deployable bundle
 	printHeader("Generating bundle");
-	buildHelper.initOutputDir(options);
 
 	compileCache(options);
 	compileEnvFiles(options);


### PR DESCRIPTION
Sync of https://github.com/opennextjs/opennextjs-aws/pull/953

Thanks to @szcharlesji for the fix