### PR TITLE
Log cache purge errors as errors

### DIFF
--- a/.changeset/good-eyes-jog.md
+++ b/.changeset/good-eyes-jog.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+Log cache purge errors as errors

--- a/examples/e2e/app-router/open-next.config.ts
+++ b/examples/e2e/app-router/open-next.config.ts
@@ -20,7 +20,8 @@ export default defineCloudflareConfig({
 			},
 		},
 	}),
-	cachePurge: purgeCache({ type: "durableObject" }),
+	// `CACHE_PURGE_ZONE_ID` and `CACHE_PURGE_API_TOKEN` are required to enable cache purge
+	// cachePurge: purgeCache({ type: "durableObject" }),
 	enableCacheInterception: true,
 	queue: queueCache(doQueue),
 });

--- a/packages/cloudflare/src/api/cloudflare-context.ts
+++ b/packages/cloudflare/src/api/cloudflare-context.ts
@@ -56,10 +56,10 @@ declare global {
 		// This can be safely used if you don't use an eventually consistent incremental cache (i.e. R2 without the regional cache for example)
 		NEXT_CACHE_DO_QUEUE_DISABLE_SQLITE?: string;
 
-		// Below are the optional env variables for purging the cache
-		// Durable Object namespace to use for the durable object cache purge
+		// Below are the env variables to use for purging the cache
+		// Durable Object namespace to use for the durable object cache purge (not needed in direct mode)
 		NEXT_CACHE_DO_PURGE?: DurableObjectNamespace<BucketCachePurge>;
-		// The amount of time in seconds that the cache purge will wait before purging the cache
+		// The amount of time in seconds that the cache purge will wait before purging the cache (not needed in direct mode)
 		NEXT_CACHE_DO_PURGE_BUFFER_TIME_IN_SECONDS?: string;
 		// The zone ID to use for the cache purge https://developers.cloudflare.com/fundamentals/setup/find-account-and-zone-ids/
 		CACHE_PURGE_ZONE_ID?: string;

--- a/packages/cloudflare/src/api/overrides/cache-purge/index.ts
+++ b/packages/cloudflare/src/api/overrides/cache-purge/index.ts
@@ -1,3 +1,4 @@
+import { error } from "@opennextjs/aws/adapters/logger.js";
 import type { CDNInvalidationHandler } from "@opennextjs/aws/types/overrides.js";
 
 import { getCloudflareContext } from "../../cloudflare-context.js";
@@ -19,7 +20,7 @@ export const purgeCache = ({ type = "direct" }: PurgeOptions) => {
 			} else {
 				const durableObject = env.NEXT_CACHE_DO_PURGE;
 				if (!durableObject) {
-					debugCache("cdnInvalidation", "No durable object found. Skipping cache purge.");
+					error("Purge cache: NEXT_CACHE_DO_PURGE not found. Skipping cache purge.");
 					return;
 				}
 				const id = durableObject.idFromName("cache-purge");


### PR DESCRIPTION
Cache purge errors when only logs when debugging Next cache.
They are now log unconditionally as errors.

Other minor changes:
- disable `cachePurge` in the `app-router` e2e (no token / zone id is provided)
- clarify the inline documentation