### PR TITLE
Fix check for missing `CACHE_PURGE_ZONE_ID`

### DIFF
--- a/.changeset/bright-planes-yawn.md
+++ b/.changeset/bright-planes-yawn.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+Fix check for missing CACHE_PURGE_ZONE_ID

--- a/packages/cloudflare/src/api/overrides/internal.ts
+++ b/packages/cloudflare/src/api/overrides/internal.ts
@@ -49,7 +49,7 @@ export async function purgeCacheByTags(tags: string[]) {
 }
 
 export async function internalPurgeCacheByTags(env: CloudflareEnv, tags: string[]) {
-	if (!env.CACHE_PURGE_ZONE_ID && !env.CACHE_PURGE_API_TOKEN) {
+	if (!env.CACHE_PURGE_ZONE_ID || !env.CACHE_PURGE_API_TOKEN) {
 		// THIS IS A NO-OP
 		error("No cache zone ID or API token provided. Skipping cache purge.");
 		return "missing-credentials";


### PR DESCRIPTION
The credentials check in `internalPurgeCacheByTags` only skips the operation if both required env vars are missing. However when an API token is provided but `CACHE_PURGE_ZONE_ID` is missing (or vice versa) it will proceed to execute a failing purge request.

Log example with missing zone id but existing token:

<img width="1048" height="102" alt="Bildschirmfoto 2025-09-03 um 12 11 53" src="https://github.com/user-attachments/assets/0d286512-feea-4f6a-a3dd-09d46deb185c" />
