### PR TITLE
fix: detection of cache purge

### DIFF
--- a/.changeset/tricky-monkeys-wear.md
+++ b/.changeset/tricky-monkeys-wear.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+fix: detection of cache purge

--- a/examples/e2e/app-router/open-next.config.ts
+++ b/examples/e2e/app-router/open-next.config.ts
@@ -3,7 +3,6 @@ import r2IncrementalCache from "@opennextjs/cloudflare/overrides/incremental-cac
 import shardedTagCache from "@opennextjs/cloudflare/overrides/tag-cache/do-sharded-tag-cache";
 import doQueue from "@opennextjs/cloudflare/overrides/queue/do-queue";
 import queueCache from "@opennextjs/cloudflare/overrides/queue/queue-cache";
-import { purgeCache } from "@opennextjs/cloudflare/overrides/cache-purge/index";
 
 export default defineCloudflareConfig({
 	incrementalCache: r2IncrementalCache,

--- a/packages/cloudflare/src/api/overrides/cache-purge/index.ts
+++ b/packages/cloudflare/src/api/overrides/cache-purge/index.ts
@@ -31,3 +31,5 @@ export const purgeCache = ({ type = "direct" }: PurgeOptions) => {
 		},
 	} satisfies CDNInvalidationHandler;
 };
+
+export default purgeCache;

--- a/packages/cloudflare/src/api/overrides/incremental-cache/regional-cache.ts
+++ b/packages/cloudflare/src/api/overrides/incremental-cache/regional-cache.ts
@@ -87,7 +87,7 @@ class RegionalCache implements IncrementalCache {
 	get #hasAutomaticCachePurging() {
 		const cdnInvalidation = globalThis.openNextConfig.default?.override?.cdnInvalidation;
 
-		return !(cdnInvalidation === undefined || cdnInvalidation === "dummy");
+		return cdnInvalidation !== undefined && cdnInvalidation !== "dummy";
 	}
 
 	async get<CacheType extends CacheEntryType = "cache">(

--- a/packages/cloudflare/src/api/overrides/incremental-cache/regional-cache.ts
+++ b/packages/cloudflare/src/api/overrides/incremental-cache/regional-cache.ts
@@ -81,8 +81,13 @@ class RegionalCache implements IncrementalCache {
 		}
 
 		// Otherwise we default to whether the automatic cache purging is enabled or not
-		const hasAutomaticCachePurging = !!getCloudflareContext().env.NEXT_CACHE_DO_PURGE;
-		return hasAutomaticCachePurging;
+		return this.#hasAutomaticCachePurging;
+	}
+
+	get #hasAutomaticCachePurging() {
+		const cdnInvalidation = globalThis.openNextConfig.default?.override?.cdnInvalidation;
+
+		return !(cdnInvalidation === undefined || cdnInvalidation === "dummy");
 	}
 
 	async get<CacheType extends CacheEntryType = "cache">(


### PR DESCRIPTION
relates to https://github.com/opennextjs/opennextjs-cloudflare/issues/879

Before this PR purge cache was detected by looking for the related DO but

- There could be a DO without cache purge being enabled (i.e. no override configured)
- Purge could be enabled in direct mode with no DO

