### PR TITLE
fix: type error during build

### DIFF
--- a/.changeset/polite-poems-fall.md
+++ b/.changeset/polite-poems-fall.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+fix: type error during build

--- a/packages/cloudflare/src/api/overrides/incremental-cache/regional-cache.ts
+++ b/packages/cloudflare/src/api/overrides/incremental-cache/regional-cache.ts
@@ -97,7 +97,8 @@ class RegionalCache implements IncrementalCache {
 	}
 
 	get #hasAutomaticCachePurging() {
-		const cdnInvalidation = globalThis.openNextConfig.default?.override?.cdnInvalidation;
+		// The `?` is required at `openNextConfig?` or the Open Next build fails because of a type error
+		const cdnInvalidation = globalThis.openNextConfig?.default?.override?.cdnInvalidation;
 
 		return cdnInvalidation !== undefined && cdnInvalidation !== "dummy";
 	}


### PR DESCRIPTION
Fix this error with 1.8.1:

```
TypeError: Cannot read properties of undefined (reading 'default')
    at get #hasAutomaticCachePurging (file:///private/var/folders/hv/nckx8r6d7px_xx1kcb4vg0pm0000gn/T/open-next-tmpv3ohFm/open-next.config.mjs:482:55)
    at new RegionalCache (file:///private/var/folders/hv/nckx8r6d7px_xx1kcb4vg0pm0000gn/T/open-next-tmpv3ohFm/open-next.config.mjs:473:89)
    at withRegionalCache (file:///private/var/folders/hv/nckx8r6d7px_xx1kcb4vg0pm0000gn/T/open-next-tmpv3ohFm/open-next.config.mjs:569:10)
    at file:///private/var/folders/hv/nckx8r6d7px_xx1kcb4vg0pm0000gn/T/open-next-tmpv3ohFm/open-next.config.mjs:588:21
    at ModuleJob.run (node:internal/modules/esm/module_job:274:25)
    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:644:26)
    [...]
```

