### PR TITLE
refactor ShardedDOTagCache

### DIFF
--- a/packages/cloudflare/src/api/overrides/tag-cache/do-sharded-tag-cache.ts
+++ b/packages/cloudflare/src/api/overrides/tag-cache/do-sharded-tag-cache.ts
@@ -106,30 +106,6 @@ interface DOIdOptions {
 	region?: DurableObjectLocationHint;
 }
 
-export class DOId {
-	shardId: string;
-	replicaId: number;
-	region?: DurableObjectLocationHint;
-	constructor(public options: DOIdOptions) {
-		const { baseShardId, shardType, numberOfReplicas, replicaId, region } = options;
-		this.shardId = `tag-${shardType};${baseShardId}`;
-		this.replicaId = replicaId ?? this.generateRandomNumberBetween(1, numberOfReplicas);
-		this.region = region;
-	}
-
-	private generateRandomNumberBetween(min: number, max: number) {
-		return Math.floor(Math.random() * (max - min + 1) + min);
-	}
-
-	get key() {
-		return `${this.shardId};replica-${this.replicaId}${this.region ? `;region-${this.region}` : ""}`;
-	}
-}
-
-interface CacheTagKeyOptions {
-	doId: DOId;
-	tags: string[];
-}
 class ShardedDOTagCache implements NextModeTagCache {
 	readonly mode = "nextMode" as const;
 	readonly name = NAME;
@@ -147,6 +123,283 @@ class ShardedDOTagCache implements NextModeTagCache {
 		this.enableRegionalReplication = Boolean(opts.shardReplication?.regionalReplication);
 		this.defaultRegion = opts.shardReplication?.regionalReplication?.defaultRegion ?? DEFAULT_REGION;
 	}
+
+	/**
+	 * Public API
+	 */
+
+	public async getLastRevalidated(tags: string[]): Promise<number> {
+		const { isDisabled } = this.getConfig();
+		if (isDisabled) return 0;
+		if (tags.length === 0) return 0; // No tags to check
+		const deduplicatedTags = Array.from(new Set(tags)); // We deduplicate the tags to avoid unnecessary requests
+		try {
+			const shardedTagGroups = this.groupTagsByDO({ tags: deduplicatedTags });
+			const shardedTagRevalidationOutcomes = await Promise.all(
+				shardedTagGroups.map(async ({ doId, tags }) => {
+					const cachedValue = await this.getFromRegionalCache({ doId, tags });
+					// If all the value were found in the regional cache, we can just return the max value
+					if (cachedValue.length === tags.length) {
+						return Math.max(...cachedValue.map((item) => item.time));
+					}
+					// Otherwise we need to check the durable object on the ones that were not found in the cache
+					const filteredTags = deduplicatedTags.filter(
+						(tag) => !cachedValue.some((item) => item.tag === tag)
+					);
+
+					const stub = this.getDurableObjectStub(doId);
+					const lastRevalidated = await stub.getLastRevalidated(filteredTags);
+
+					const result = Math.max(...cachedValue.map((item) => item.time), lastRevalidated);
+
+					// We then need to populate the regional cache with the missing tags
+					getCloudflareContext().ctx.waitUntil(this.putToRegionalCache({ doId, tags }, stub));
+
+					return result;
+				})
+			);
+			return Math.max(...shardedTagRevalidationOutcomes);
+		} catch (e) {
+			error("Error while checking revalidation", e);
+			return 0;
+		}
+	}
+
+	/**
+	 * This function checks if the tags have been revalidated
+	 * It is never supposed to throw and in case of error, it will return false
+	 * @param tags
+	 * @param lastModified default to `Date.now()`
+	 * @returns
+	 */
+	public async hasBeenRevalidated(tags: string[], lastModified?: number): Promise<boolean> {
+		const { isDisabled } = this.getConfig();
+		if (isDisabled) return false;
+		try {
+			const shardedTagGroups = this.groupTagsByDO({ tags });
+			const shardedTagRevalidationOutcomes = await Promise.all(
+				shardedTagGroups.map(async ({ doId, tags }) => {
+					const cachedValue = await this.getFromRegionalCache({ doId, tags });
+
+					// If one of the cached values is newer than the lastModified, we can return true
+					const cacheHasBeenRevalidated = cachedValue.some((cachedValue) => {
+						return (cachedValue.time ?? 0) > (lastModified ?? Date.now());
+					});
+
+					if (cacheHasBeenRevalidated) {
+						return true;
+					}
+					const stub = this.getDurableObjectStub(doId);
+					const _hasBeenRevalidated = await stub.hasBeenRevalidated(tags, lastModified);
+
+					const remainingTags = tags.filter((tag) => !cachedValue.some((item) => item.tag === tag));
+					if (remainingTags.length > 0) {
+						// We need to put the missing tags in the regional cache
+						getCloudflareContext().ctx.waitUntil(
+							this.putToRegionalCache({ doId, tags: remainingTags }, stub)
+						);
+					}
+
+					return _hasBeenRevalidated;
+				})
+			);
+			return shardedTagRevalidationOutcomes.some((result) => result);
+		} catch (e) {
+			error("Error while checking revalidation", e);
+			return false;
+		}
+	}
+
+	/**
+	 * This function writes the tags to the cache
+	 * Due to the way shards and regional cache are implemented, the regional cache may not be properly invalidated
+	 * @param tags
+	 * @returns
+	 */
+	public async writeTags(tags: string[]): Promise<void> {
+		const { isDisabled } = this.getConfig();
+		if (isDisabled) return;
+		const shardedTagGroups = this.groupTagsByDO({ tags, generateAllReplicas: true });
+		// We want to use the same revalidation time for all tags
+		const currentTime = Date.now();
+		await Promise.all(
+			shardedTagGroups.map(async ({ doId, tags }) => {
+				await this.performWriteTagsWithRetry(doId, tags, currentTime);
+			})
+		);
+		await purgeCacheByTags(tags);
+	}
+
+	/**
+	 * The following methods are public only because they are accessed from the tests
+	 */
+
+	public async performWriteTagsWithRetry(doId: DOId, tags: string[], lastModified: number, retryNumber = 0) {
+		try {
+			const stub = this.getDurableObjectStub(doId);
+			await stub.writeTags(tags, lastModified);
+			// Depending on the shards and the tags, deleting from the regional cache will not work for every tag
+			// We also need to delete both cache
+			await Promise.all([this.deleteRegionalCache({ doId, tags })]);
+		} catch (e) {
+			error("Error while writing tags", e);
+			if (retryNumber >= this.maxWriteRetries) {
+				error("Error while writing tags, too many retries");
+				// Do we want to throw an error here ?
+				await getCloudflareContext().env.NEXT_TAG_CACHE_DO_SHARDED_DLQ?.send({
+					failingShardId: doId.key,
+					failingTags: tags,
+					lastModified,
+				});
+				return;
+			}
+			await this.performWriteTagsWithRetry(doId, tags, lastModified, retryNumber + 1);
+		}
+	}
+
+	public getCacheUrlKey(doId: DOId, tag: string) {
+		return `http://local.cache/shard/${doId.shardId}?tag=${encodeURIComponent(tag)}`;
+	}
+
+	public async getCacheInstance() {
+		if (!this.localCache && this.opts.regionalCache) {
+			this.localCache = await caches.open("sharded-do-tag-cache");
+		}
+		return this.localCache;
+	}
+
+	/**
+	 * Get the last revalidation time for the tags from the regional cache
+	 * If the cache is not enabled, it will return an empty array
+	 * @returns An array of objects with the tag and the last revalidation time
+	 */
+	public async getFromRegionalCache(opts: CacheTagKeyOptions) {
+		try {
+			if (!this.opts.regionalCache) return [];
+			const cache = await this.getCacheInstance();
+			if (!cache) return [];
+			const result = await Promise.all(
+				opts.tags.map(async (tag) => {
+					const cachedResponse = await cache.match(this.getCacheUrlKey(opts.doId, tag));
+					if (!cachedResponse) return null;
+					const cachedText = await cachedResponse.text();
+					try {
+						return { tag, time: parseInt(cachedText, 10) };
+					} catch (e) {
+						debugCache("Error while parsing cached value", e);
+						return null;
+					}
+				})
+			);
+			return result.filter((item) => item !== null);
+		} catch (e) {
+			error("Error while fetching from regional cache", e);
+			return [];
+		}
+	}
+
+	public async putToRegionalCache(optsKey: CacheTagKeyOptions, stub: DurableObjectStub<DOShardedTagCache>) {
+		if (!this.opts.regionalCache) return;
+		const cache = await this.getCacheInstance();
+		if (!cache) return;
+		const tags = optsKey.tags;
+		const tagsLastRevalidated = await stub.getRevalidationTimes(tags);
+		await Promise.all(
+			tags.map(async (tag) => {
+				let lastRevalidated = tagsLastRevalidated[tag];
+				if (lastRevalidated === undefined) {
+					if (this.opts.regionalCacheDangerouslyPersistMissingTags) {
+						lastRevalidated = 0; // If the tag is not found, we set it to 0 as it means it has never been revalidated before.
+					} else {
+						debugCache("Tag not found in revalidation times", { tag, optsKey });
+						return; // If the tag is not found, we skip it
+					}
+				}
+				const cacheKey = this.getCacheUrlKey(optsKey.doId, tag);
+				debugCache("Putting to regional cache", { cacheKey, lastRevalidated });
+				await cache.put(
+					cacheKey,
+					new Response(lastRevalidated.toString(), {
+						status: 200,
+						headers: {
+							"cache-control": `max-age=${this.opts.regionalCacheTtlSec ?? 5}`,
+							...(tags.length > 0
+								? {
+										"cache-tag": tags.join(","),
+									}
+								: {}),
+						},
+					})
+				);
+			})
+		);
+	}
+
+	/**
+	 * Deletes the regional cache for the given tags
+	 * This is used to ensure that the cache is cleared when the tags are revalidated
+	 */
+	public async deleteRegionalCache(optsKey: CacheTagKeyOptions) {
+		// We never want to crash because of the cache
+		try {
+			if (!this.opts.regionalCache) return;
+			const cache = await this.getCacheInstance();
+			if (!cache) return;
+			await Promise.all(
+				optsKey.tags.map(async (tag) => {
+					const cacheKey = this.getCacheUrlKey(optsKey.doId, tag);
+					debugCache("Deleting from regional cache", { cacheKey });
+					await cache.delete(cacheKey);
+				})
+			);
+		} catch (e) {
+			debugCache("Error while deleting from regional cache", e);
+		}
+	}
+
+	/**
+	 * Same tags are guaranteed to be in the same shard
+	 * @param tags
+	 * @returns An array of DO ids and tags
+	 */
+	public groupTagsByDO({
+		tags,
+		generateAllReplicas = false,
+	}: {
+		tags: string[];
+		generateAllReplicas?: boolean;
+	}) {
+		// Here we'll start by splitting soft tags from hard tags
+		// This will greatly increase the cache hit rate for the soft tag (which are the most likely to cause issue because of load)
+		const softTags = this.generateDOIdArray({ tags, shardType: "soft", generateAllReplicas });
+
+		const hardTags = this.generateDOIdArray({ tags, shardType: "hard", generateAllReplicas });
+
+		const tagIdCollection = [...softTags, ...hardTags];
+
+		// We then group the tags by DO id
+		const tagsByDOId = new Map<
+			string,
+			{
+				doId: DOId;
+				tags: string[];
+			}
+		>();
+		for (const { doId, tag } of tagIdCollection) {
+			const doIdString = doId.key;
+			const tagsArray = tagsByDOId.get(doIdString)?.tags ?? [];
+			tagsArray.push(tag);
+			tagsByDOId.set(doIdString, {
+				// We override the doId here, but it should be the same for all tags
+				doId,
+				tags: tagsArray,
+			});
+		}
+		const result = Array.from(tagsByDOId.values());
+		return result;
+	}
+
+	// Private methods
 
 	private getDurableObjectStub(doId: DOId) {
 		const durableObject = getCloudflareContext().env.NEXT_TAG_CACHE_DO_SHARDED;
@@ -225,7 +478,7 @@ class ShardedDOTagCache implements NextModeTagCache {
 		return regionalReplicasInAllRegions;
 	}
 
-	getClosestRegion() {
+	private getClosestRegion() {
 		const continent = getCloudflareContext().cf?.continent;
 		if (!continent) return this.defaultRegion;
 		debug("[shardedTagCache] - Continent : ", continent);
@@ -247,43 +500,7 @@ class ShardedDOTagCache implements NextModeTagCache {
 		}
 	}
 
-	/**
-	 * Same tags are guaranteed to be in the same shard
-	 * @param tags
-	 * @returns An array of DO ids and tags
-	 */
-	groupTagsByDO({ tags, generateAllReplicas = false }: { tags: string[]; generateAllReplicas?: boolean }) {
-		// Here we'll start by splitting soft tags from hard tags
-		// This will greatly increase the cache hit rate for the soft tag (which are the most likely to cause issue because of load)
-		const softTags = this.generateDOIdArray({ tags, shardType: "soft", generateAllReplicas });
-
-		const hardTags = this.generateDOIdArray({ tags, shardType: "hard", generateAllReplicas });
-
-		const tagIdCollection = [...softTags, ...hardTags];
-
-		// We then group the tags by DO id
-		const tagsByDOId = new Map<
-			string,
-			{
-				doId: DOId;
-				tags: string[];
-			}
-		>();
-		for (const { doId, tag } of tagIdCollection) {
-			const doIdString = doId.key;
-			const tagsArray = tagsByDOId.get(doIdString)?.tags ?? [];
-			tagsArray.push(tag);
-			tagsByDOId.set(doIdString, {
-				// We override the doId here, but it should be the same for all tags
-				doId,
-				tags: tagsArray,
-			});
-		}
-		const result = Array.from(tagsByDOId.values());
-		return result;
-	}
-
-	private async getConfig() {
+	private getConfig() {
 		const cfEnv = getCloudflareContext().env;
 		const db = cfEnv.NEXT_TAG_CACHE_DO_SHARDED;
 
@@ -298,231 +515,31 @@ class ShardedDOTagCache implements NextModeTagCache {
 					db,
 				};
 	}
+}
 
-	async getLastRevalidated(tags: string[]): Promise<number> {
-		const { isDisabled } = await this.getConfig();
-		if (isDisabled) return 0;
-		if (tags.length === 0) return 0; // No tags to check
-		const deduplicatedTags = Array.from(new Set(tags)); // We deduplicate the tags to avoid unnecessary requests
-		try {
-			const shardedTagGroups = this.groupTagsByDO({ tags: deduplicatedTags });
-			const shardedTagRevalidationOutcomes = await Promise.all(
-				shardedTagGroups.map(async ({ doId, tags }) => {
-					const cachedValue = await this.getFromRegionalCache({ doId, tags });
-					// If all the value were found in the regional cache, we can just return the max value
-					if (cachedValue.length === tags.length) {
-						return Math.max(...cachedValue.map((item) => item.time));
-					}
-					// Otherwise we need to check the durable object on the ones that were not found in the cache
-					const filteredTags = deduplicatedTags.filter(
-						(tag) => !cachedValue.some((item) => item.tag === tag)
-					);
-
-					const stub = this.getDurableObjectStub(doId);
-					const lastRevalidated = await stub.getLastRevalidated(filteredTags);
-
-					const result = Math.max(...cachedValue.map((item) => item.time), lastRevalidated);
-
-					// We then need to populate the regional cache with the missing tags
-					getCloudflareContext().ctx.waitUntil(this.putToRegionalCache({ doId, tags }, stub));
-
-					return result;
-				})
-			);
-			return Math.max(...shardedTagRevalidationOutcomes);
-		} catch (e) {
-			error("Error while checking revalidation", e);
-			return 0;
-		}
+export class DOId {
+	shardId: string;
+	replicaId: number;
+	region?: DurableObjectLocationHint;
+	constructor(public options: DOIdOptions) {
+		const { baseShardId, shardType, numberOfReplicas, replicaId, region } = options;
+		this.shardId = `tag-${shardType};${baseShardId}`;
+		this.replicaId = replicaId ?? this.generateRandomNumberBetween(1, numberOfReplicas);
+		this.region = region;
 	}
 
-	/**
-	 * This function checks if the tags have been revalidated
-	 * It is never supposed to throw and in case of error, it will return false
-	 * @param tags
-	 * @param lastModified default to `Date.now()`
-	 * @returns
-	 */
-	async hasBeenRevalidated(tags: string[], lastModified?: number): Promise<boolean> {
-		const { isDisabled } = await this.getConfig();
-		if (isDisabled) return false;
-		try {
-			const shardedTagGroups = this.groupTagsByDO({ tags });
-			const shardedTagRevalidationOutcomes = await Promise.all(
-				shardedTagGroups.map(async ({ doId, tags }) => {
-					const cachedValue = await this.getFromRegionalCache({ doId, tags });
-
-					// If one of the cached values is newer than the lastModified, we can return true
-					const cacheHasBeenRevalidated = cachedValue.some((cachedValue) => {
-						return (cachedValue.time ?? 0) > (lastModified ?? Date.now());
-					});
-
-					if (cacheHasBeenRevalidated) {
-						return true;
-					}
-					const stub = this.getDurableObjectStub(doId);
-					const _hasBeenRevalidated = await stub.hasBeenRevalidated(tags, lastModified);
-
-					const remainingTags = tags.filter((tag) => !cachedValue.some((item) => item.tag === tag));
-					if (remainingTags.length > 0) {
-						// We need to put the missing tags in the regional cache
-						getCloudflareContext().ctx.waitUntil(
-							this.putToRegionalCache({ doId, tags: remainingTags }, stub)
-						);
-					}
-
-					return _hasBeenRevalidated;
-				})
-			);
-			return shardedTagRevalidationOutcomes.some((result) => result);
-		} catch (e) {
-			error("Error while checking revalidation", e);
-			return false;
-		}
+	private generateRandomNumberBetween(min: number, max: number) {
+		return Math.floor(Math.random() * (max - min + 1) + min);
 	}
 
-	/**
-	 * This function writes the tags to the cache
-	 * Due to the way shards and regional cache are implemented, the regional cache may not be properly invalidated
-	 * @param tags
-	 * @returns
-	 */
-	async writeTags(tags: string[]): Promise<void> {
-		const { isDisabled } = await this.getConfig();
-		if (isDisabled) return;
-		const shardedTagGroups = this.groupTagsByDO({ tags, generateAllReplicas: true });
-		// We want to use the same revalidation time for all tags
-		const currentTime = Date.now();
-		await Promise.all(
-			shardedTagGroups.map(async ({ doId, tags }) => {
-				await this.performWriteTagsWithRetry(doId, tags, currentTime);
-			})
-		);
-		await purgeCacheByTags(tags);
+	get key() {
+		return `${this.shardId};replica-${this.replicaId}${this.region ? `;region-${this.region}` : ""}`;
 	}
+}
 
-	async performWriteTagsWithRetry(doId: DOId, tags: string[], lastModified: number, retryNumber = 0) {
-		try {
-			const stub = this.getDurableObjectStub(doId);
-			await stub.writeTags(tags, lastModified);
-			// Depending on the shards and the tags, deleting from the regional cache will not work for every tag
-			// We also need to delete both cache
-			await Promise.all([this.deleteRegionalCache({ doId, tags })]);
-		} catch (e) {
-			error("Error while writing tags", e);
-			if (retryNumber >= this.maxWriteRetries) {
-				error("Error while writing tags, too many retries");
-				// Do we want to throw an error here ?
-				await getCloudflareContext().env.NEXT_TAG_CACHE_DO_SHARDED_DLQ?.send({
-					failingShardId: doId.key,
-					failingTags: tags,
-					lastModified,
-				});
-				return;
-			}
-			await this.performWriteTagsWithRetry(doId, tags, lastModified, retryNumber + 1);
-		}
-	}
-
-	// Cache API
-	async getCacheInstance() {
-		if (!this.localCache && this.opts.regionalCache) {
-			this.localCache = await caches.open("sharded-do-tag-cache");
-		}
-		return this.localCache;
-	}
-
-	getCacheUrlKey(doId: DOId, tag: string) {
-		return `http://local.cache/shard/${doId.shardId}?tag=${encodeURIComponent(tag)}`;
-	}
-
-	/**
-	 * Get the last revalidation time for the tags from the regional cache
-	 * If the cache is not enabled, it will return an empty array
-	 * @returns An array of objects with the tag and the last revalidation time
-	 */
-	async getFromRegionalCache(opts: CacheTagKeyOptions) {
-		try {
-			if (!this.opts.regionalCache) return [];
-			const cache = await this.getCacheInstance();
-			if (!cache) return [];
-			const result = await Promise.all(
-				opts.tags.map(async (tag) => {
-					const cachedResponse = await cache.match(this.getCacheUrlKey(opts.doId, tag));
-					if (!cachedResponse) return null;
-					const cachedText = await cachedResponse.text();
-					try {
-						return { tag, time: parseInt(cachedText, 10) };
-					} catch (e) {
-						debugCache("Error while parsing cached value", e);
-						return null;
-					}
-				})
-			);
-			return result.filter((item) => item !== null);
-		} catch (e) {
-			error("Error while fetching from regional cache", e);
-			return [];
-		}
-	}
-	async putToRegionalCache(optsKey: CacheTagKeyOptions, stub: DurableObjectStub<DOShardedTagCache>) {
-		if (!this.opts.regionalCache) return;
-		const cache = await this.getCacheInstance();
-		if (!cache) return;
-		const tags = optsKey.tags;
-		const tagsLastRevalidated = await stub.getRevalidationTimes(tags);
-		await Promise.all(
-			tags.map(async (tag) => {
-				let lastRevalidated = tagsLastRevalidated[tag];
-				if (lastRevalidated === undefined) {
-					if (this.opts.regionalCacheDangerouslyPersistMissingTags) {
-						lastRevalidated = 0; // If the tag is not found, we set it to 0 as it means it has never been revalidated before.
-					} else {
-						debugCache("Tag not found in revalidation times", { tag, optsKey });
-						return; // If the tag is not found, we skip it
-					}
-				}
-				const cacheKey = this.getCacheUrlKey(optsKey.doId, tag);
-				debugCache("Putting to regional cache", { cacheKey, lastRevalidated });
-				await cache.put(
-					cacheKey,
-					new Response(lastRevalidated.toString(), {
-						status: 200,
-						headers: {
-							"cache-control": `max-age=${this.opts.regionalCacheTtlSec ?? 5}`,
-							...(tags.length > 0
-								? {
-										"cache-tag": tags.join(","),
-									}
-								: {}),
-						},
-					})
-				);
-			})
-		);
-	}
-
-	/**
-	 * Deletes the regional cache for the given tags
-	 * This is used to ensure that the cache is cleared when the tags are revalidated
-	 */
-	async deleteRegionalCache(optsKey: CacheTagKeyOptions) {
-		// We never want to crash because of the cache
-		try {
-			if (!this.opts.regionalCache) return;
-			const cache = await this.getCacheInstance();
-			if (!cache) return;
-			await Promise.all(
-				optsKey.tags.map(async (tag) => {
-					const cacheKey = this.getCacheUrlKey(optsKey.doId, tag);
-					debugCache("Deleting from regional cache", { cacheKey });
-					await cache.delete(cacheKey);
-				})
-			);
-		} catch (e) {
-			debugCache("Error while deleting from regional cache", e);
-		}
-	}
+interface CacheTagKeyOptions {
+	doId: DOId;
+	tags: string[];
 }
 
 export default (opts?: ShardedDOTagCacheOptions) => new ShardedDOTagCache(opts);


### PR DESCRIPTION
Minor refactor:

- `getConfig` doesn't need to be async
- move the public API towards the top of the file