### PR TITLE
 bump @opennextjs/aws to 3.7.7

### DIFF
--- a/.changeset/evil-ravens-unite.md
+++ b/.changeset/evil-ravens-unite.md
@@ -1,0 +1,7 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+Bump @opennextjs/aws to 3.7.7
+
+See details at <https://github.com/opennextjs/opennextjs-aws/releases/tag/v3.7.7>

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -53,7 +53,7 @@
 	"homepage": "https://github.com/opennextjs/opennextjs-cloudflare",
 	"dependencies": {
 		"@dotenvx/dotenvx": "catalog:",
-		"@opennextjs/aws": "3.7.6",
+		"@opennextjs/aws": "3.7.7",
 		"cloudflare": "^4.4.1",
 		"enquirer": "^2.4.1",
 		"glob": "catalog:",

--- a/packages/cloudflare/src/cli/commands/utils.ts
+++ b/packages/cloudflare/src/cli/commands/utils.ts
@@ -52,8 +52,7 @@ export async function compileConfig(configPath: string | undefined) {
 		configPath = await createOpenNextConfigIfNotExistent(nextAppDir);
 	}
 
-	// TODO: remove the hack passing the `configPath` as the `baseDir` when https://github.com/opennextjs/opennextjs-aws/pull/972 is merged
-	const { config, buildDir } = await compileOpenNextConfig(configPath, "", { compileEdge: true });
+	const { config, buildDir } = await compileOpenNextConfig(configPath, { compileEdge: true });
 	ensureCloudflareConfig(config);
 
 	return { config, buildDir };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1041,8 +1041,8 @@ importers:
         specifier: 'catalog:'
         version: 1.31.0
       '@opennextjs/aws':
-        specifier: 3.7.6
-        version: 3.7.6
+        specifier: 3.7.7
+        version: 3.7.7
       cloudflare:
         specifier: ^4.4.1
         version: 4.4.1
@@ -3777,8 +3777,8 @@ packages:
   '@octokit/types@13.10.0':
     resolution: {integrity: sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==}
 
-  '@opennextjs/aws@3.7.6':
-    resolution: {integrity: sha512-l4UGkmaZaAjWER+PuZ/zNziMnrbf6oA9B1RUDKcyKsX+hEES1b7h6kLgpo4a4maf01M+k0yJUZQyF4sf+vI+Iw==}
+  '@opennextjs/aws@3.7.7':
+    resolution: {integrity: sha512-rkBpNfBsq3XvbBh+VcNI9dvs0UkuuJH5I7SvVdPx12LudiErShL/9RoA7iF9tpkfRizcwGRIhsedrHKmcs9kqw==}
     hasBin: true
 
   '@opentelemetry/api@1.9.0':
@@ -12899,7 +12899,7 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 24.2.0
 
-  '@opennextjs/aws@3.7.6':
+  '@opennextjs/aws@3.7.7':
     dependencies:
       '@ast-grep/napi': 0.35.0
       '@aws-sdk/client-cloudfront': 3.398.0


### PR DESCRIPTION
See https://github.com/opennextjs/opennextjs-aws/releases/tag/v3.7.7

Notably the tag cache can now be bypassed when the cache interceptor is enabled