### PR TITLE
Add support for passing multiple configs to wrangler

### DIFF
--- a/.changeset/weak-crews-tickle.md
+++ b/.changeset/weak-crews-tickle.md
@@ -1,0 +1,11 @@
+---
+"@opennextjs/cloudflare": minor
+---
+
+Support multiple Wrangler configuration files via `--config` flag
+
+Enable passing multiple configuration files to the OpenNext.js Cloudflare CLI
+using the `--config` flag, matching Wrangler's native capability. This allows
+running multiple workers in a single dev session, which is essential for RPC
+communication with Durable Objects during local development as documented in the
+[Wrangler API bindings guide](https://developers.cloudflare.com/workers/wrangler/api/#supported-bindings)

--- a/packages/cloudflare/src/cli/commands/deploy.ts
+++ b/packages/cloudflare/src/cli/commands/deploy.ts
@@ -28,7 +28,7 @@ export async function deployCommand(args: WithWranglerArgs<{ cacheChunkSize: num
 	const wranglerConfig = readWranglerConfig(args);
 
 	const envVars = await getEnvFromPlatformProxy({
-		configPath: args.wranglerConfigPath,
+		configPath: args.nextjsWranglerConfigPath,
 		environment: args.env,
 	});
 
@@ -37,7 +37,7 @@ export async function deployCommand(args: WithWranglerArgs<{ cacheChunkSize: num
 	await populateCache(options, config, wranglerConfig, {
 		target: "remote",
 		environment: args.env,
-		wranglerConfigPath: args.wranglerConfigPath,
+		wranglerConfigPath: args.nextjsWranglerConfigPath,
 		cacheChunkSize: args.cacheChunkSize,
 	});
 

--- a/packages/cloudflare/src/cli/commands/populate-cache.ts
+++ b/packages/cloudflare/src/cli/commands/populate-cache.ts
@@ -313,7 +313,7 @@ async function populateCacheCommand(
 	await populateCache(options, config, wranglerConfig, {
 		target,
 		environment: args.env,
-		wranglerConfigPath: args.wranglerConfigPath,
+		wranglerConfigPath: args.nextjsWranglerConfigPath,
 		cacheChunkSize: args.cacheChunkSize,
 	});
 }

--- a/packages/cloudflare/src/cli/commands/preview.ts
+++ b/packages/cloudflare/src/cli/commands/preview.ts
@@ -27,7 +27,7 @@ export async function previewCommand(args: WithWranglerArgs<{ cacheChunkSize: nu
 	await populateCache(options, config, wranglerConfig, {
 		target: "local",
 		environment: args.env,
-		wranglerConfigPath: args.wranglerConfigPath,
+		wranglerConfigPath: args.nextjsWranglerConfigPath,
 		cacheChunkSize: args.cacheChunkSize,
 	});
 

--- a/packages/cloudflare/src/cli/commands/upload.ts
+++ b/packages/cloudflare/src/cli/commands/upload.ts
@@ -28,7 +28,7 @@ export async function uploadCommand(args: WithWranglerArgs<{ cacheChunkSize: num
 	const wranglerConfig = readWranglerConfig(args);
 
 	const envVars = await getEnvFromPlatformProxy({
-		configPath: args.wranglerConfigPath,
+		configPath: args.nextjsWranglerConfigPath,
 		environment: args.env,
 	});
 
@@ -37,7 +37,7 @@ export async function uploadCommand(args: WithWranglerArgs<{ cacheChunkSize: num
 	await populateCache(options, config, wranglerConfig, {
 		target: "remote",
 		environment: args.env,
-		wranglerConfigPath: args.wranglerConfigPath,
+		wranglerConfigPath: args.nextjsWranglerConfigPath,
 		cacheChunkSize: args.cacheChunkSize,
 	});
 

--- a/packages/cloudflare/src/cli/commands/utils.ts
+++ b/packages/cloudflare/src/cli/commands/utils.ts
@@ -15,7 +15,9 @@ import { createOpenNextConfigIfNotExistent, ensureCloudflareConfig } from "../bu
 export type WithWranglerArgs<T = unknown> = T & {
 	// Array of arguments that can be given to wrangler commands, including the `--config` and `--env` args.
 	wranglerArgs: string[];
-	wranglerConfigPath: string | undefined;
+	wranglerConfigPath: string[] | undefined;
+	// The first wrangler config path passed into the CLI, if any. Assumed to be the one used for OpenNext.
+	nextjsWranglerConfigPath: string | undefined;
 	env: string | undefined;
 };
 
@@ -101,7 +103,7 @@ export function getNormalizedOptions(config: OpenNextConfig, buildDir = nextAppD
  * @returns Wrangler config.
  */
 export function readWranglerConfig(args: WithWranglerArgs) {
-	return unstable_readConfig({ env: args.env, config: args.wranglerConfigPath });
+	return unstable_readConfig({ env: args.env, config: args.nextjsWranglerConfigPath });
 }
 
 /**
@@ -111,6 +113,7 @@ export function withWranglerOptions<T extends yargs.Argv>(args: T) {
 	return args
 		.option("config", {
 			type: "string",
+			array: true,
 			alias: "c",
 			desc: "Path to Wrangler configuration file",
 		})
@@ -128,7 +131,7 @@ export function withWranglerOptions<T extends yargs.Argv>(args: T) {
 
 type WranglerInputArgs = {
 	configPath: string | undefined;
-	config: string | undefined;
+	config: string[] | undefined;
 	env: string | undefined;
 };
 
@@ -143,7 +146,7 @@ function getWranglerArgs(args: WranglerInputArgs & { _: (string | number)[] }): 
 
 		if (args.config) {
 			logger.error(
-				"Multiple config flags found. Please use the `--config` flag for your Wrangler config path."
+				"Duplicate config flags found. Unable to pass both `--config` and `--configPath`. Please use the `--config` flag for your Wrangler config path."
 			);
 			process.exit(1);
 		}
@@ -151,7 +154,7 @@ function getWranglerArgs(args: WranglerInputArgs & { _: (string | number)[] }): 
 
 	return [
 		...(args.configPath ? ["--config", args.configPath] : []),
-		...(args.config ? ["--config", args.config] : []),
+		...(args.config ? args.config.flatMap((c) => ["--config", c]) : []),
 		...(args.env ? ["--env", args.env] : []),
 		// Note: the first args in `_` will be the commands.
 		...args._.slice(args._[0] === "populateCache" ? 2 : 1).map((a) => `${a}`),
@@ -166,9 +169,15 @@ function getWranglerArgs(args: WranglerInputArgs & { _: (string | number)[] }): 
 export function withWranglerPassthroughArgs<T extends yargs.ArgumentsCamelCase<WranglerInputArgs>>(
 	args: T
 ): WithWranglerArgs<T> {
+	const wranglerConfigPath = args.config ?? (args.configPath ? [args.configPath] : undefined);
+	if (wranglerConfigPath && wranglerConfigPath?.length > 1) {
+		logger.info("Multiple Wrangler config paths found, first config assumed as opennext config.");
+	}
+
 	return {
 		...args,
-		wranglerConfigPath: args.config ?? args.configPath,
+		wranglerConfigPath,
+		nextjsWranglerConfigPath: wranglerConfigPath?.[0],
 		wranglerArgs: getWranglerArgs(args),
 	};
 }


### PR DESCRIPTION
This PR updates the opennextjs-cloudflare CLI to correctly pass through multiple configuration files to Wrangler, allowing multiple workers to be bound to a single dev session. This is helpful when using Durable Objects, which aren't bound to the worker when using Miniflare locally, as per the CLI warning.

<img width="2542" height="298" alt="CleanShot 2025-09-21 at 13 22 23@2x" src="https://github.com/user-attachments/assets/2ead7e80-7053-4c55-be23-7e686c28b53a" />

This reduces the need to run two dev sessions locally and ensures you can use RPC with DO locally, as per the [supported binding docs](https://developers.cloudflare.com/workers/wrangler/api/#supported-bindings).

Developers can enable this by updating preview to:
```
pnpm run build && opennextjs-cloudflare preview -c wrangler.jsonc -c src/agents/wrangler.jsonc
``` 

You can do this today; however, you'll encounter an error when an array is passed through to unstable_readConfig unexpectedly, as yargs will return an array of strings for config without error, misaligned with its typing.

As the CLI has to read the config file used for OpenNext to support some features, I've made the choice to assume the first config passed is the one used to define the worker for Next.js. This might not be the best choice but felt more aligned with Wrangler than adding additional config flags.

Given this usage is probably an edge case and most users don't pass config, it seemed like a reasonable trade-off.

One item that could use more work but would require more code changes is ensuring the info message I added is below the header. I'm happy to make this change if people would consider merging this.

<img width="1536" height="992" alt="CleanShot 2025-09-21 at 14 03 24@2x" src="https://github.com/user-attachments/assets/52ba400a-ba48-44fe-8041-955a8ca6a496" />
