### PR TITLE
perf: add an index on the tag column in D1 tag cache

### DIFF
--- a/.changeset/poor-points-work.md
+++ b/.changeset/poor-points-work.md
@@ -1,0 +1,7 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+perf: add an index on the tag column in D1 tag cache
+
+It only applies to newly created tables

--- a/packages/cloudflare/src/api/overrides/tag-cache/d1-next-tag-cache.ts
+++ b/packages/cloudflare/src/api/overrides/tag-cache/d1-next-tag-cache.ts
@@ -63,7 +63,7 @@ export class D1NextModeTagCache implements NextModeTagCache {
 		await db.batch(
 			tags.map((tag) =>
 				db
-					.prepare(`INSERT INTO revalidations (tag, revalidatedAt) VALUES (?, ?)`)
+					.prepare(`INSERT OR REPLACE INTO revalidations (tag, revalidatedAt) VALUES (?, ?)`)
 					.bind(this.getCacheKey(tag), Date.now())
 			)
 		);

--- a/packages/cloudflare/src/cli/commands/populate-cache.ts
+++ b/packages/cloudflare/src/cli/commands/populate-cache.ts
@@ -254,7 +254,7 @@ function populateD1TagCache(
 		[
 			"d1 execute",
 			D1_TAG_BINDING_NAME,
-			`--command "CREATE TABLE IF NOT EXISTS revalidations (tag TEXT NOT NULL, revalidatedAt INTEGER NOT NULL, UNIQUE(tag) ON CONFLICT REPLACE);"`,
+			`--command "CREATE TABLE IF NOT EXISTS revalidations (tag TEXT PRIMARY KEY, revalidatedAt INTEGER);"`,
 			`--preview ${populateCacheOptions.shouldUsePreviewId}`,
 		],
 		{


### PR DESCRIPTION
Adding an index to speed up reads which are dominant on the tag cache.

(D1 now uses the same SQL structure/queries than what is used on with DO)