### PR TITLE
fix: enable using workerd process v2

### DIFF
--- a/.changeset/stale-adults-divide.md
+++ b/.changeset/stale-adults-divide.md
@@ -1,0 +1,7 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+fix: enable using workerd process v2
+
+process v2 is an updated version of `node:process` active by default after 2025-09-15

--- a/examples/playground15/wrangler.jsonc
+++ b/examples/playground15/wrangler.jsonc
@@ -2,7 +2,7 @@
 	"$schema": "node_modules/wrangler/config-schema.json",
 	"main": ".open-next/worker.js",
 	"name": "playground15",
-	"compatibility_date": "2024-12-30",
+	"compatibility_date": "2025-09-15",
 	"compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public", "enable_request_signal"],
 	"assets": {
 		"directory": ".open-next/assets",

--- a/packages/cloudflare/src/cli/build/bundle-server.ts
+++ b/packages/cloudflare/src/cli/build/bundle-server.ts
@@ -16,7 +16,7 @@ import { inlineFindDir } from "./patches/plugins/find-dir.js";
 import { patchInstrumentation } from "./patches/plugins/instrumentation.js";
 import { inlineLoadManifest } from "./patches/plugins/load-manifest.js";
 import { patchNextServer } from "./patches/plugins/next-server.js";
-import { patchResolveCache } from "./patches/plugins/open-next.js";
+import { patchResolveCache, patchSetWorkingDirectory } from "./patches/plugins/open-next.js";
 import { handleOptionalDependencies } from "./patches/plugins/optional-deps.js";
 import { patchPagesRouterContext } from "./patches/plugins/pages-router-context.js";
 import { patchDepdDeprecations } from "./patches/plugins/patch-depd-deprecations.js";
@@ -107,6 +107,7 @@ export async function bundleServer(buildOpts: BuildOptions, projectOpts: Project
 			patchRouteModules(updater, buildOpts),
 			patchDepdDeprecations(updater),
 			patchResolveCache(updater, buildOpts),
+			patchSetWorkingDirectory(updater, buildOpts),
 			// Apply updater updates, must be the last plugin
 			updater.plugin,
 		] as Plugin[],


### PR DESCRIPTION
fixes https://github.com/opennextjs/opennextjs-cloudflare/issues/899

`node:process` has a new implementation in workerd ("v2" enabled by default on 2025-09-15).
v2 supports `process.chdir()` so it now errors when a non existent directory is passed (the cloudflare adapter passes "").
(The `unenv` implementation used before was a no-op).