### PR TITLE
refactor: only try to purge the cache when invalidation is configured

### DIFF
--- a/.changeset/cute-papayas-win.md
+++ b/.changeset/cute-papayas-win.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+refactor: only try to purge the cache when invalidation is configured

--- a/packages/cloudflare/src/api/overrides/internal.ts
+++ b/packages/cloudflare/src/api/overrides/internal.ts
@@ -32,6 +32,13 @@ export function computeCacheKey(key: string, options: KeyOptions) {
 	return `${prefix}/${buildId}/${hash}.${cacheType}`.replace(/\/+/g, "/");
 }
 
+export function isPurgeCacheEnabled(): boolean {
+	// The `?` is required at `openNextConfig?` or the Open Next build fails because of a type error
+	const cdnInvalidation = globalThis.openNextConfig?.default?.override?.cdnInvalidation;
+
+	return cdnInvalidation !== undefined && cdnInvalidation !== "dummy";
+}
+
 export async function purgeCacheByTags(tags: string[]) {
 	const { env } = getCloudflareContext();
 	// We have a durable object for purging cache

--- a/packages/cloudflare/src/api/overrides/tag-cache/d1-next-tag-cache.spec.ts
+++ b/packages/cloudflare/src/api/overrides/tag-cache/d1-next-tag-cache.spec.ts
@@ -21,6 +21,7 @@ vi.mock("../internal.js", () => ({
 	debugCache: vi.fn(),
 	FALLBACK_BUILD_ID: "fallback-build-id",
 	purgeCacheByTags: vi.fn(),
+	isPurgeCacheEnabled: () => true,
 }));
 
 describe("D1NextModeTagCache", () => {

--- a/packages/cloudflare/src/api/overrides/tag-cache/d1-next-tag-cache.ts
+++ b/packages/cloudflare/src/api/overrides/tag-cache/d1-next-tag-cache.ts
@@ -2,7 +2,7 @@ import { error } from "@opennextjs/aws/adapters/logger.js";
 import type { NextModeTagCache } from "@opennextjs/aws/types/overrides.js";
 
 import { getCloudflareContext } from "../../cloudflare-context.js";
-import { debugCache, FALLBACK_BUILD_ID, purgeCacheByTags } from "../internal.js";
+import { debugCache, FALLBACK_BUILD_ID, isPurgeCacheEnabled, purgeCacheByTags } from "../internal.js";
 
 export const NAME = "d1-next-mode-tag-cache";
 
@@ -67,7 +67,9 @@ export class D1NextModeTagCache implements NextModeTagCache {
 		);
 
 		// TODO: See https://github.com/opennextjs/opennextjs-aws/issues/986
-		await purgeCacheByTags(tags);
+		if (isPurgeCacheEnabled()) {
+			await purgeCacheByTags(tags);
+		}
 	}
 
 	private getConfig() {

--- a/packages/cloudflare/src/api/overrides/tag-cache/do-sharded-tag-cache.ts
+++ b/packages/cloudflare/src/api/overrides/tag-cache/do-sharded-tag-cache.ts
@@ -6,7 +6,7 @@ import { IgnorableError } from "@opennextjs/aws/utils/error.js";
 import { getCloudflareContext } from "../../cloudflare-context.js";
 import type { OpenNextConfig } from "../../config.js";
 import { DOShardedTagCache } from "../../durable-objects/sharded-tag-cache.js";
-import { debugCache, purgeCacheByTags } from "../internal.js";
+import { debugCache, isPurgeCacheEnabled, purgeCacheByTags } from "../internal.js";
 
 export const DEFAULT_WRITE_RETRIES = 3;
 export const DEFAULT_NUM_SHARDS = 4;
@@ -229,7 +229,9 @@ class ShardedDOTagCache implements NextModeTagCache {
 		);
 
 		// TODO: See https://github.com/opennextjs/opennextjs-aws/issues/986
-		await purgeCacheByTags(tags);
+		if (isPurgeCacheEnabled()) {
+			await purgeCacheByTags(tags);
+		}
 	}
 
 	/**

--- a/packages/cloudflare/src/api/overrides/tag-cache/kv-next-tag-cache.spec.ts
+++ b/packages/cloudflare/src/api/overrides/tag-cache/kv-next-tag-cache.spec.ts
@@ -18,6 +18,7 @@ vi.mock("../internal.js", () => ({
 	debugCache: vi.fn(),
 	FALLBACK_BUILD_ID: "fallback-build-id",
 	purgeCacheByTags: vi.fn(),
+	isPurgeCacheEnabled: () => true,
 }));
 
 describe("KVNextModeTagCache", () => {

--- a/packages/cloudflare/src/api/overrides/tag-cache/kv-next-tag-cache.ts
+++ b/packages/cloudflare/src/api/overrides/tag-cache/kv-next-tag-cache.ts
@@ -2,7 +2,7 @@ import { error } from "@opennextjs/aws/adapters/logger.js";
 import type { NextModeTagCache } from "@opennextjs/aws/types/overrides.js";
 
 import { getCloudflareContext } from "../../cloudflare-context.js";
-import { FALLBACK_BUILD_ID, purgeCacheByTags } from "../internal.js";
+import { FALLBACK_BUILD_ID, isPurgeCacheEnabled, purgeCacheByTags } from "../internal.js";
 
 export const NAME = "kv-next-mode-tag-cache";
 
@@ -65,7 +65,9 @@ export class KVNextModeTagCache implements NextModeTagCache {
 		);
 
 		// TODO: See https://github.com/opennextjs/opennextjs-aws/issues/986
-		await purgeCacheByTags(tags);
+		if (isPurgeCacheEnabled()) {
+			await purgeCacheByTags(tags);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Before this PR, `purgeCacheByTags` is called whether or not the invalidation is configured.

This result in logging an error when the invalidation is not configured.

This PR removes the error when the invalidation is not configured (calling `purgeCacheByTags` is a noop anyway).