### PR TITLE
refactor: account for empty tag list in tag cache

### DIFF
--- a/.changeset/great-eyes-tan.md
+++ b/.changeset/great-eyes-tan.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+refactor: account for empty tag list in tag cache

--- a/packages/cloudflare/src/api/overrides/tag-cache/d1-next-tag-cache.ts
+++ b/packages/cloudflare/src/api/overrides/tag-cache/d1-next-tag-cache.ts
@@ -14,7 +14,9 @@ export class D1NextModeTagCache implements NextModeTagCache {
 
 	async getLastRevalidated(tags: string[]): Promise<number> {
 		const { isDisabled, db } = this.getConfig();
-		if (isDisabled) return 0;
+		if (isDisabled || tags.length === 0) {
+			return 0;
+		}
 		try {
 			const result = await db
 				.prepare(
@@ -36,7 +38,9 @@ export class D1NextModeTagCache implements NextModeTagCache {
 
 	async hasBeenRevalidated(tags: string[], lastModified?: number): Promise<boolean> {
 		const { isDisabled, db } = this.getConfig();
-		if (isDisabled) return false;
+		if (isDisabled || tags.length === 0) {
+			return false;
+		}
 		try {
 			const result = await db
 				.prepare(

--- a/packages/cloudflare/src/api/overrides/tag-cache/do-sharded-tag-cache.ts
+++ b/packages/cloudflare/src/api/overrides/tag-cache/do-sharded-tag-cache.ts
@@ -130,8 +130,9 @@ class ShardedDOTagCache implements NextModeTagCache {
 
 	public async getLastRevalidated(tags: string[]): Promise<number> {
 		const { isDisabled } = this.getConfig();
-		if (isDisabled) return 0;
-		if (tags.length === 0) return 0; // No tags to check
+		if (isDisabled || tags.length === 0) {
+			return 0;
+		}
 		const deduplicatedTags = Array.from(new Set(tags)); // We deduplicate the tags to avoid unnecessary requests
 		try {
 			const shardedTagGroups = this.groupTagsByDO({ tags: deduplicatedTags });
@@ -177,7 +178,9 @@ class ShardedDOTagCache implements NextModeTagCache {
 	 */
 	public async hasBeenRevalidated(tags: string[], lastModified?: number): Promise<boolean> {
 		const { isDisabled } = this.getConfig();
-		if (isDisabled) return false;
+		if (isDisabled || tags.length === 0) {
+			return false;
+		}
 		try {
 			const shardedTagGroups = this.groupTagsByDO({ tags });
 			const shardedTagRevalidationOutcomes = await Promise.all(

--- a/packages/cloudflare/src/api/overrides/tag-cache/kv-next-tag-cache.ts
+++ b/packages/cloudflare/src/api/overrides/tag-cache/kv-next-tag-cache.ts
@@ -26,7 +26,7 @@ export class KVNextModeTagCache implements NextModeTagCache {
 
 	async getLastRevalidated(tags: string[]): Promise<number> {
 		const kv = this.getKv();
-		if (!kv) {
+		if (!kv || tags.length === 0) {
 			return 0;
 		}
 


### PR DESCRIPTION
We were not handling the case were the tag list is empty, because we assume it would not happen...
But https://github.com/opennextjs/opennextjs-aws/pull/988

So this PR adds an explicit check - it should not be needed after the aws is merged but defensive programming is good when the perf impact is insignificant  