### PR TITLE
feat(cloudflare): add --rcloneBatch flag for faster R2 cache uploads using rclone

### DIFF
--- a/.changeset/rclone-batch-upload.md
+++ b/.changeset/rclone-batch-upload.md
@@ -1,0 +1,34 @@
+---
+"@opennextjs/cloudflare": minor
+---
+
+feature: add --rcloneBatch flag for faster R2 cache uploads
+
+This adds a new optional `--rcloneBatch` flag that enables batch uploading to R2 using rclone instead of individual wrangler uploads. This significantly improves upload performance for large caches.
+
+**Supported commands:**
+
+- `populateCache` - Explicit cache population
+- `deploy` - Deploy with cache population
+- `upload` - Upload version with cache population
+- `preview` - Preview with cache population
+
+**Performance improvements:**
+
+- Creates staging directory with all cache files organized by R2 keys
+- Uses rclone's parallel transfer capabilities (32 transfers, 16 checkers)
+- Reduces API calls to Cloudflare
+
+**Usage:**
+
+```bash
+opennextjs-cloudflare deploy --rcloneBatch
+opennextjs-cloudflare populateCache remote --rcloneBatch
+```
+
+**Requirements:**
+
+- The `rclone.js` package (included as dependency) provides the binary
+- An rclone config file at `~/.config/rclone/rclone.conf` with R2 credentials (see README for setup instructions)
+
+The original wrangler-based upload remains the default behavior for backward compatibility.

--- a/packages/cloudflare/README.md
+++ b/packages/cloudflare/README.md
@@ -55,3 +55,54 @@ Deploy your application to production with the following:
   # or
   bun opennextjs-cloudflare build && bun opennextjs-cloudflare deploy
   ```
+
+## CLI Options
+
+### Batch Cache Population (rclone)
+
+The `--rcloneBatch` flag enables faster R2 cache uploads using rclone batch mode. This flag is supported by the following commands:
+
+- `populateCache` - Explicitly populate cache
+- `deploy` - Deploy and populate cache
+- `upload` - Upload version and populate cache
+- `preview` - Preview and populate cache
+
+**Usage:**
+
+```bash
+# Standalone cache population
+npx opennextjs-cloudflare populateCache local --rcloneBatch
+npx opennextjs-cloudflare populateCache remote --rcloneBatch
+
+# During deployment
+npx opennextjs-cloudflare deploy --rcloneBatch
+
+# During upload
+npx opennextjs-cloudflare upload --rcloneBatch
+
+# During preview
+npx opennextjs-cloudflare preview --rcloneBatch
+```
+
+**Requirements:**
+
+1. The `rclone.js` package (included as a dependency) provides the rclone binary automatically
+2. An rclone configuration file is required at `~/.config/rclone/rclone.conf` with your R2 credentials
+
+**rclone Configuration:**
+
+Create or update `~/.config/rclone/rclone.conf` with your R2 bucket configuration:
+
+```ini
+[r2]
+type = s3
+provider = Cloudflare
+access_key_id = YOUR_ACCESS_KEY_ID
+secret_access_key = YOUR_SECRET_ACCESS_KEY
+endpoint = https://YOUR_ACCOUNT_ID.r2.cloudflarestorage.com
+acl = private
+```
+
+See [Cloudflare's rclone documentation](https://developers.cloudflare.com/r2/examples/rclone/) for more details.
+
+**Default:** `false` (uses standard wrangler-based uploads)

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -57,6 +57,7 @@
 		"cloudflare": "^4.4.1",
 		"enquirer": "^2.4.1",
 		"glob": "catalog:",
+		"rclone.js": "^0.6.6",
 		"ts-tqdm": "^0.8.6",
 		"yargs": "catalog:"
 	},

--- a/packages/cloudflare/src/cli/commands/deploy.ts
+++ b/packages/cloudflare/src/cli/commands/deploy.ts
@@ -19,7 +19,9 @@ import {
  *
  * @param args
  */
-export async function deployCommand(args: WithWranglerArgs<{ cacheChunkSize?: number }>): Promise<void> {
+export async function deployCommand(
+	args: WithWranglerArgs<{ cacheChunkSize?: number; rcloneBatch?: boolean }>
+): Promise<void> {
 	printHeaders("deploy");
 
 	const { config } = await retrieveCompiledConfig();
@@ -40,6 +42,7 @@ export async function deployCommand(args: WithWranglerArgs<{ cacheChunkSize?: nu
 		wranglerConfigPath: args.wranglerConfigPath,
 		cacheChunkSize: args.cacheChunkSize,
 		shouldUsePreviewId: false,
+		rcloneBatch: args.rcloneBatch,
 	});
 
 	runWrangler(

--- a/packages/cloudflare/src/cli/commands/populate-cache.spec.ts
+++ b/packages/cloudflare/src/cli/commands/populate-cache.spec.ts
@@ -5,7 +5,7 @@ import type { BuildOptions } from "@opennextjs/aws/build/helper.js";
 import mockFs from "mock-fs";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 
-import { getCacheAssets } from "./populate-cache.js";
+import { getCacheAssets, withPopulateCacheOptions } from "./populate-cache.js";
 
 describe("getCacheAssets", () => {
 	beforeAll(() => {
@@ -66,5 +66,25 @@ describe("getCacheAssets", () => {
         },
       ]
     `);
+	});
+});
+
+describe("withPopulateCacheOptions", () => {
+	test("includes rcloneBatch option with correct defaults", () => {
+		interface MockYargs {
+			options: (name: string, config: Record<string, unknown>) => MockYargs;
+		}
+
+		const mockYargs: MockYargs = {
+			options: (name: string, config: Record<string, unknown>) => {
+				expect(name).toBeDefined();
+				expect(config).toBeDefined();
+				return mockYargs;
+			},
+		};
+
+		const result = withPopulateCacheOptions(mockYargs as never);
+
+		expect(result).toBe(mockYargs);
 	});
 });

--- a/packages/cloudflare/src/cli/commands/preview.ts
+++ b/packages/cloudflare/src/cli/commands/preview.ts
@@ -17,7 +17,7 @@ import {
  * @param args
  */
 export async function previewCommand(
-	args: WithWranglerArgs<{ cacheChunkSize?: number; remote: boolean }>
+	args: WithWranglerArgs<{ cacheChunkSize?: number; rcloneBatch?: boolean; remote: boolean }>
 ): Promise<void> {
 	printHeaders("preview");
 
@@ -32,6 +32,7 @@ export async function previewCommand(
 		wranglerConfigPath: args.wranglerConfigPath,
 		cacheChunkSize: args.cacheChunkSize,
 		shouldUsePreviewId: args.remote,
+		rcloneBatch: args.rcloneBatch,
 	});
 
 	runWrangler(options, ["dev", ...args.wranglerArgs], { logging: "all" });

--- a/packages/cloudflare/src/cli/commands/upload.ts
+++ b/packages/cloudflare/src/cli/commands/upload.ts
@@ -19,7 +19,9 @@ import {
  *
  * @param args
  */
-export async function uploadCommand(args: WithWranglerArgs<{ cacheChunkSize?: number }>): Promise<void> {
+export async function uploadCommand(
+	args: WithWranglerArgs<{ cacheChunkSize?: number; rcloneBatch?: boolean }>
+): Promise<void> {
 	printHeaders("upload");
 
 	const { config } = await retrieveCompiledConfig();
@@ -40,6 +42,7 @@ export async function uploadCommand(args: WithWranglerArgs<{ cacheChunkSize?: nu
 		wranglerConfigPath: args.wranglerConfigPath,
 		cacheChunkSize: args.cacheChunkSize,
 		shouldUsePreviewId: false,
+		rcloneBatch: args.rcloneBatch,
 	});
 
 	runWrangler(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1086,6 +1086,9 @@ importers:
       glob:
         specifier: 'catalog:'
         version: 11.0.0
+      rclone.js:
+        specifier: ^0.6.6
+        version: 0.6.6
       ts-tqdm:
         specifier: ^0.8.6
         version: 0.8.6
@@ -5030,6 +5033,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  adm-zip@0.5.16:
+    resolution: {integrity: sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==}
+    engines: {node: '>=12.0'}
+
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
@@ -8425,6 +8432,13 @@ packages:
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
+
+  rclone.js@0.6.6:
+    resolution: {integrity: sha512-Dxh34cab/fNjFq5SSm0fYLNkGzG2cQSBy782UW9WwxJCEiVO4cGXkvaXcNlgv817dK8K8PuQ+NHUqSAMMhWujQ==}
+    engines: {node: '>=12'}
+    cpu: [arm, arm64, mips, mipsel, x32, x64]
+    os: [darwin, freebsd, linux, openbsd, sunos, win32]
     hasBin: true
 
   react-dom@18.3.1:
@@ -14763,6 +14777,8 @@ snapshots:
 
   acorn@8.15.0: {}
 
+  adm-zip@0.5.16: {}
+
   agent-base@6.0.2:
     dependencies:
       debug: 4.4.0
@@ -19101,6 +19117,11 @@ snapshots:
       ini: 1.3.8
       minimist: 1.2.8
       strip-json-comments: 2.0.1
+
+  rclone.js@0.6.6:
+    dependencies:
+      adm-zip: 0.5.16
+      mri: 1.2.0
 
   react-dom@18.3.1(react@18.3.1):
     dependencies:


### PR DESCRIPTION
# Batch upload R2 cahce using rclone

This PR proposes adding support for optional batch uploading R2 cache using rclone.
Based on the solution discussed in [Issue #866](https://github.com/opennextjs/opennextjs-cloudflare/issues/866)

## Details

The `--rcloneBatch` flag enables faster R2 cache uploads using rclone batch mode. 
This flag is supported by the following commands:
- `populateCache` - Explicitly populate cache
- `deploy` - Deploy and populate cache
- `upload` - Upload version and populate cache
- `preview` - Preview and populate cache
