### PR TITLE
refactor: do not create a wrangler config when a custom one is passed

### DIFF
--- a/.changeset/thick-seas-walk.md
+++ b/.changeset/thick-seas-walk.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+refactor: do not create a wrangler config when a custom one is passed

--- a/packages/cloudflare/src/cli/build/build.ts
+++ b/packages/cloudflare/src/cli/build/build.ts
@@ -17,7 +17,6 @@ import { compileInit } from "./open-next/compile-init.js";
 import { compileSkewProtection } from "./open-next/compile-skew-protection.js";
 import { compileDurableObjects } from "./open-next/compileDurableObjects.js";
 import { createServerBundle } from "./open-next/createServerBundle.js";
-import { createWranglerConfigIfNotExistent } from "./utils/index.js";
 import { getVersion } from "./utils/version.js";
 
 /**
@@ -86,10 +85,6 @@ export async function build(
 	await compileDurableObjects(options);
 
 	await bundleServer(options, projectOpts);
-
-	if (!projectOpts.skipWranglerConfigCheck) {
-		await createWranglerConfigIfNotExistent(projectOpts);
-	}
 
 	logger.info("OpenNext build complete.");
 }


### PR DESCRIPTION
Only ask whether to create a config file when no custom one is specified via `--config`.

Also the check is moved at the beginning of the build at the build aborts when the reply is No.

Both cases (no config, custom config) tested locally.