### PR TITLE
fix: Compiled config is now imported using pathToFileURL to avoid crashes on Windows

### DIFF
--- a/.changeset/clean-lions-tan.md
+++ b/.changeset/clean-lions-tan.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+fix: Compiled config is now imported using `pathToFileURL` to avoid crashes on Windows.

--- a/packages/cloudflare/src/cli/commands/utils.ts
+++ b/packages/cloudflare/src/cli/commands/utils.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
+import url from "node:url";
 
 import { compileOpenNextConfig } from "@opennextjs/aws/build/compileConfig.js";
 import { normalizeOptions } from "@opennextjs/aws/build/helper.js";
@@ -71,7 +72,7 @@ export async function retrieveCompiledConfig() {
 		process.exit(1);
 	}
 
-	const config = await import(configPath).then((mod) => mod.default);
+	const config = await import(url.pathToFileURL(configPath).href).then((mod) => mod.default);
 	ensureCloudflareConfig(config);
 
 	return { config };


### PR DESCRIPTION
For the moment, this is the only bug preventing me from building and deploying with opennext to cloudflare. With this fix, build and publish passes without issues. 

The solution was described in #826 - after testing, I decided to file a PR for it. 

Feel free to suggest fixes if I missed anything. If there are other fixes needed that require windows testing, ping me, I might be able to test and fix other issues as well.