### PR TITLE
Bump Next

### DIFF
--- a/.changeset/free-items-grin.md
+++ b/.changeset/free-items-grin.md
@@ -1,0 +1,7 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+bump `@opennextjs/aws` to 3.9.4
+
+See details at <https://github.com/opennextjs/opennextjs-aws/releases/tag/v3.9.4>

--- a/.changeset/moody-oranges-joke.md
+++ b/.changeset/moody-oranges-joke.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+Bump Next

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -54,7 +54,7 @@
 	"dependencies": {
 		"@ast-grep/napi": "0.40.0",
 		"@dotenvx/dotenvx": "catalog:",
-		"@opennextjs/aws": "3.9.3",
+		"@opennextjs/aws": "3.9.4",
 		"cloudflare": "^4.4.1",
 		"enquirer": "^2.4.1",
 		"glob": "catalog:",
@@ -86,6 +86,6 @@
 	},
 	"peerDependencies": {
 		"wrangler": "catalog:",
-		"next": "14 - 14.2 || 14.3.0-canary.0 - 14.3.0-canary.76 || ~15.0.5 || ~15.1.9 || ~15.3.6 || ~15.4.8 || ~15.5.7 || ^16.0.7"
+		"next": "14 - 14.2 || 14.3.0-canary.0 - 14.3.0-canary.76 || ~15.0.5 || ~15.1.9 || ~15.2.6 || ~15.3.6 || ~15.4.8 || ~15.5.7 || ^16.0.7"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1081,8 +1081,8 @@ importers:
         specifier: 'catalog:'
         version: 1.31.0
       '@opennextjs/aws':
-        specifier: 3.9.3
-        version: 3.9.3(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
+        specifier: 3.9.4
+        version: 3.9.4(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       cloudflare:
         specifier: ^4.4.1
         version: 4.4.1
@@ -3974,11 +3974,11 @@ packages:
   '@octokit/types@13.10.0':
     resolution: {integrity: sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==}
 
-  '@opennextjs/aws@3.9.3':
-    resolution: {integrity: sha512-TtL8lg5IOgVUTvvxCauAU1Hwf5efoeNL1C4xT9Xn4Pji2W/LDG+nIt/XwA6eFgZvA+0MT3mKo0x/7t1xI0z1GA==}
+  '@opennextjs/aws@3.9.4':
+    resolution: {integrity: sha512-i5gWKSP7QQGz59z85ZjOGtIfXK1ZgRLEwbt7/dkmuujhTuMBWygQqrb2EGRf8vRZH1Xvp0fYENUZx7NjgvxsIg==}
     hasBin: true
     peerDependencies:
-      next: < 14.2 || ^14.2 || 14.3.0-canary.0 - 14.3.0-canary.76 || ~15.0.5 || ~15.1.9 || ~15.3.6 || ~15.4.8 || ~15.5.7 || ^16.0.7
+      next: < 14.2 || ^14.2 || 14.3.0-canary.0 - 14.3.0-canary.76 || ~15.0.5 || ~15.1.9 || ~15.2.6 || ~15.3.6 || ~15.4.8 || ~15.5.7 || ^16.0.7
 
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
@@ -13187,7 +13187,7 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 24.2.0
 
-  '@opennextjs/aws@3.9.3(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
+  '@opennextjs/aws@3.9.4(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
     dependencies:
       '@ast-grep/napi': 0.40.0
       '@aws-sdk/client-cloudfront': 3.398.0


### PR DESCRIPTION
15.2 was originally missing from https://vercel.com/changelog/cve-2025-55182