### PR TITLE
switch back to `<TBD>` in the `package.json` of the c3 template

### DIFF
--- a/create-cloudflare/next/package.json
+++ b/create-cloudflare/next/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "<PACKAGE_NAME>",
+	"name": "<TBD>",
 	"version": "0.1.0",
 	"private": true,
 	"scripts": {


### PR DESCRIPTION
`<PACKAGE_NAME>` is not supported with the current c3 and then not replaced