### PR TITLE
remove `.dev.vars.example` from the c3 template

### DIFF
--- a/create-cloudflare/next/.dev.vars.example
+++ b/create-cloudflare/next/.dev.vars.example
@@ -1,2 +1,0 @@
-# Load .env.development* files when running `wrangler dev`
-NEXTJS_ENV=development

--- a/create-cloudflare/next/.gitignore
+++ b/create-cloudflare/next/.gitignore
@@ -47,4 +47,4 @@ next-env.d.ts
 # wrangler files
 .wrangler
 .dev.vars*
-!.dev.vars.example
+


### PR DESCRIPTION
`.dev.vars` was added to the template (ignored in `.gitignore`) so we don't need the `.dev.vars.example` as well.