### PR TITLE
fix for setImmediate/clearImmediate

### DIFF
--- a/.changeset/modern-symbols-send.md
+++ b/.changeset/modern-symbols-send.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+Do not inject setImmediate/clearImmediate in the global scope

--- a/packages/cloudflare/src/cli/build/bundle-server.ts
+++ b/packages/cloudflare/src/cli/build/bundle-server.ts
@@ -152,7 +152,7 @@ export async function bundleServer(buildOpts: BuildOptions, projectOpts: Project
 		banner: {
 			// We need to import them here, assigning them to `globalThis` does not work because node:timers use `globalThis` and thus create an infinite loop
 			// See https://github.com/cloudflare/workerd/blob/d6a764c/src/node/internal/internal_timers.ts#L56-L70
-			js: `import {setInterval, clearInterval, setTimeout, clearTimeout, setImmediate, clearImmediate} from "node:timers"`,
+			js: `import {setInterval, clearInterval, setTimeout, clearTimeout} from "node:timers"`,
 		},
 		platform: "node",
 	});


### PR DESCRIPTION
The global version of `setImmediate`/`clearImmediate` do not need to be injected in the global scope of the bundle - it causes troubles with Next 16.1.

Fixes for `setInterval` and `setTimeout` will be available via the [`enable_nodejs_global_timers`](https://github.com/cloudflare/workerd/blob/main/src/workerd/io/compatibility-date.capnp#L1310) flag shortly.

fixes #1049 