### PR TITLE
Fix r2 bulk put - respect bucket jurisdiction

### DIFF
--- a/packages/cloudflare/src/cli/commands/populate-cache.ts
+++ b/packages/cloudflare/src/cli/commands/populate-cache.ts
@@ -245,10 +245,11 @@ async function populateR2IncrementalCache(
 	fs.writeFileSync(listFile, JSON.stringify(objectList));
 
 	const concurrency = Math.max(1, populateCacheOptions.cacheChunkSize ?? 50);
+	const jurisdiction = binding.jurisdiction ? `--jurisdiction ${binding.jurisdiction}` : '';
 
 	runWrangler(
 		buildOpts,
-		["r2 bulk put", bucket, `--filename ${quoteShellMeta(listFile)}`, `--concurrency ${concurrency}`],
+		["r2 bulk put", bucket, `--filename ${quoteShellMeta(listFile)}`, `--concurrency ${concurrency}`, jurisdiction],
 		{
 			target: populateCacheOptions.target,
 			configPath: populateCacheOptions.wranglerConfigPath,


### PR DESCRIPTION
There is issue when you try to deploy to R2 bucket NEXT_INC_CACHE_R2_BUCKET with specified jurisdiction. This PR fixes this.