### PR TITLE
Add a profile to revalidateTag calls to avoid deprecation warnings

### DIFF
--- a/examples/overrides/d1-tag-next/app/action.ts
+++ b/examples/overrides/d1-tag-next/app/action.ts
@@ -3,7 +3,7 @@
 import { revalidatePath, revalidateTag } from "next/cache";
 
 export async function revalidateTagAction() {
-	revalidateTag("date", "max");
+	revalidateTag("date", { expire: 0 });
 }
 
 export async function revalidatePathAction() {

--- a/examples/overrides/kv-tag-next/app/action.ts
+++ b/examples/overrides/kv-tag-next/app/action.ts
@@ -3,7 +3,7 @@
 import { revalidatePath, revalidateTag } from "next/cache";
 
 export async function revalidateTagAction() {
-	revalidateTag("date", "max");
+	revalidateTag("date", { expire: 0 });
 }
 
 export async function revalidatePathAction() {

--- a/examples/overrides/static-assets-incremental-cache/app/action.ts
+++ b/examples/overrides/static-assets-incremental-cache/app/action.ts
@@ -3,7 +3,7 @@
 import { revalidatePath, revalidateTag } from "next/cache";
 
 export async function revalidateTagAction() {
-	revalidateTag("date", "max");
+	revalidateTag("date", { expire: 0 });
 }
 
 export async function revalidatePathAction() {


### PR DESCRIPTION
See https://nextjs.org/docs/app/api-reference/functions/revalidateTag#parameters:~:text=%7D-,Good%20to%20know,-%3A%20The%20single%2Dargument