### PR TITLE
chore: update c3 template to Next 16

### DIFF
--- a/create-cloudflare/next/package.json
+++ b/create-cloudflare/next/package.json
@@ -13,7 +13,7 @@
 		"cf-typegen": "wrangler types --env-interface CloudflareEnv ./cloudflare-env.d.ts"
 	},
 	"dependencies": {
-		"@opennextjs/cloudflare": "^1.15.0",
+		"@opennextjs/cloudflare": "^1.15.1",
 		"next": "16.1.4",
 		"react": "19.1.4",
 		"react-dom": "19.1.4"

--- a/create-cloudflare/next/tsconfig.json
+++ b/create-cloudflare/next/tsconfig.json
@@ -11,7 +11,7 @@
 		"moduleResolution": "bundler",
 		"resolveJsonModule": true,
 		"isolatedModules": true,
-		"jsx": "preserve",
+		"jsx": "react-jsx",
 		"incremental": true,
 		"plugins": [
 			{
@@ -20,8 +20,9 @@
 		],
 		"paths": {
 			"@/*": ["./src/*"]
-		}
+		},
+		"types": ["./cloudflare-env.d.ts", "node"]
 	},
-	"include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+	"include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", ".next/dev/types/**/*.ts"],
 	"exclude": ["node_modules"]
 }


### PR DESCRIPTION
Validated, helped catch a bug in 1.15.0 (1.15.1 has been released to fix that)