### PR TITLE
allow using a regional cache with KV

### DIFF
--- a/.changeset/tidy-symbols-wonder.md
+++ b/.changeset/tidy-symbols-wonder.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+allow using a regional cache with KV


### PR DESCRIPTION
I think the name "regional cache" is misleading (for historical reason).

When it was first introduced, the idea was to add a regional cache to R2.
We would not allow it for KV at it already has a built-in regional cache.

But:

- R2 also has a builtin regional cache
- The regional cache handles lazy updates, purge, ... that could help even if the store already has a cache.

A longer term fix would be to rename the concept.

ref: https://github.com/opennextjs/opennextjs-cloudflare/issues/1103
/cc @rickyfang

