### PR TITLE
refactor: vitetest config

### DIFF
--- a/packages/cloudflare/vitest.config.ts
+++ b/packages/cloudflare/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		/**
+		 * Explicitly set root to current directory for this package.
+		 *
+		 * In monorepo setups, this vitest.config.ts takes priority over any parent
+		 * vite.config.js files, preventing Vitest from using unrelated configurations
+		 * from parent directories that may reference dependencies not installed in
+		 * this package.
+		 *
+		 * This is the recommended approach for monorepo packages to ensure isolated
+		 * test configuration.
+		 *
+		 * See: https://vitest.dev/config/
+		 */
+		root: ".",
+	},
+});


### PR DESCRIPTION
`pnpm test` was failing for me earlier this morning because it was looking at a generated file:

```
Scope: 24 of 25 workspace projects
packages/cloudflare test$ vitest --run
│ failed to load config from /Users/vberchet/code/work/vite.config.js
│ ⎯⎯⎯⎯⎯⎯⎯ Startup Error ⎯⎯⎯⎯⎯⎯⎯⎯
│ Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'vite' imported from /Users/vberchet/code/work/vite.config.js.timestamp-1770023965105-d1c08c2780d9b.mjs
│ Did you mean to import "vite/index.cjs"?
...
```

Claude thinks it's a reasonable fix, let's try that unless someone has a better idea?