### PR TITLE
feat: add DO proxy layer for supporting DO operations through service binding

### DIFF
--- a/.changeset/spotty-chefs-float.md
+++ b/.changeset/spotty-chefs-float.md
@@ -1,0 +1,10 @@
+---
+"@opennextjs/cloudflare": minor
+---
+
+feature: add Durable Object proxy for service binding approach
+
+Adds DO proxy utilities under `do-proxy/` that route Durable Object namespace
+operations through a service binding to a separate DO worker via HTTP. This
+enables using Durable Objects while keeping preview URLs (skew protection)
+enabled on the main worker.

--- a/packages/cloudflare/src/api/cloudflare-context.ts
+++ b/packages/cloudflare/src/api/cloudflare-context.ts
@@ -73,6 +73,13 @@ declare global {
 		// The API token to use for the cache purge. It should have the `Cache Purge` permission
 		CACHE_PURGE_API_TOKEN?: string;
 
+		// Service binding to an external DO worker.
+		// When set, proxy DO namespaces are automatically injected for
+		// NEXT_TAG_CACHE_DO_SHARDED, NEXT_CACHE_DO_QUEUE, and NEXT_CACHE_DO_PURGE
+		// if those bindings are not directly available.
+		// This enables using DOs with preview URLs / skew protection.
+		OPENNEXT_DO_WORKER?: Service;
+
 		// The following variables must be provided when skew protection is enabled
 		// The name of the worker (as defined in the wrangler configuration)
 		// When a specific wrangler environment is used, it should be appended at the end:

--- a/packages/cloudflare/src/api/do-proxy/constants.ts
+++ b/packages/cloudflare/src/api/do-proxy/constants.ts
@@ -1,0 +1,14 @@
+/** URL path prefix for DO proxy RPC requests. */
+export const DO_RPC_PREFIX = "/do-rpc";
+
+/**
+ * DO namespace binding names used by OpenNext.
+ * Shared between the proxy client (proxy-namespace) and handler (proxy-handler).
+ */
+export const NAMESPACE_BINDINGS = [
+	"NEXT_TAG_CACHE_DO_SHARDED",
+	"NEXT_CACHE_DO_QUEUE",
+	"NEXT_CACHE_DO_PURGE",
+] as const;
+
+export type NamespaceBindingName = (typeof NAMESPACE_BINDINGS)[number];

--- a/packages/cloudflare/src/api/do-proxy/index.spec.ts
+++ b/packages/cloudflare/src/api/do-proxy/index.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { withDOProxy } from "./index.js";
+
+describe("withDOProxy", () => {
+	test("wraps handler and injects DO proxy bindings before fetch", async () => {
+		const mockFetch = vi.fn().mockResolvedValue(new Response("ok"));
+		const handler: ExportedHandler<CloudflareEnv> = { fetch: mockFetch };
+		const env = { OPENNEXT_DO_WORKER: { fetch: vi.fn() } } as unknown as CloudflareEnv;
+
+		const wrapped = withDOProxy(handler);
+		await wrapped.fetch!(new Request("https://example.com"), env, {} as ExecutionContext);
+
+		// Original fetch should have been called
+		expect(mockFetch).toHaveBeenCalledTimes(1);
+
+		// DO proxy bindings should have been injected into env
+		const record = env as unknown as Record<string, unknown>;
+		expect(record["NEXT_TAG_CACHE_DO_SHARDED"]).toBeDefined();
+		expect(record["NEXT_CACHE_DO_QUEUE"]).toBeDefined();
+		expect(record["NEXT_CACHE_DO_PURGE"]).toBeDefined();
+	});
+
+	test("throws if handler has no fetch method", () => {
+		const handler = {} as ExportedHandler<CloudflareEnv>;
+
+		expect(() => withDOProxy(handler)).toThrow("handler must define a fetch method");
+	});
+
+	test("preserves other handler properties", () => {
+		const scheduled = vi.fn();
+		const handler: ExportedHandler<CloudflareEnv> = {
+			fetch: vi.fn(),
+			scheduled,
+		};
+
+		const wrapped = withDOProxy(handler);
+
+		expect(wrapped.scheduled).toBe(scheduled);
+	});
+});

--- a/packages/cloudflare/src/api/do-proxy/index.ts
+++ b/packages/cloudflare/src/api/do-proxy/index.ts
@@ -1,0 +1,34 @@
+import { injectDOProxyBindings } from "./proxy-namespace.js";
+
+export { createDOProxyHandler } from "./proxy-handler.js";
+export {
+	createProxyDurableObjectNamespace,
+	injectDOProxyBindings,
+	ProxyDurableObjectId,
+} from "./proxy-namespace.js";
+
+/**
+ * Wraps an ExportedHandler to inject DO proxy namespaces into env
+ * before each request, enabling DO usage without direct DO bindings.
+ *
+ * Usage:
+ * ```ts
+ * import { withDOProxy } from "@opennextjs/cloudflare/do-proxy/index";
+ * import openNextHandler from "./.open-next/worker.js";
+ *
+ * export default withDOProxy(openNextHandler);
+ * ```
+ */
+export function withDOProxy(handler: ExportedHandler<CloudflareEnv>): ExportedHandler<CloudflareEnv> {
+	const originalFetch = handler.fetch;
+	if (!originalFetch) {
+		throw new Error("withDOProxy: handler must define a fetch method");
+	}
+	return {
+		...handler,
+		fetch(request, env, ctx) {
+			injectDOProxyBindings(env);
+			return originalFetch(request, env, ctx);
+		},
+	};
+}

--- a/packages/cloudflare/src/api/do-proxy/proxy-handler.spec.ts
+++ b/packages/cloudflare/src/api/do-proxy/proxy-handler.spec.ts
@@ -1,0 +1,161 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { createDOProxyHandler } from "./proxy-handler.js";
+
+function createMockEnv(overrides: Record<string, unknown> = {}): CloudflareEnv {
+	const mockStub = {
+		getLastRevalidated: vi.fn().mockResolvedValue(123),
+		writeTags: vi.fn().mockResolvedValue(undefined),
+		failingMethod: vi.fn().mockRejectedValue(new Error("DO error")),
+	};
+
+	const mockNamespace = {
+		idFromName: vi.fn().mockReturnValue({ toString: () => "mock-id" }),
+		get: vi.fn().mockReturnValue(mockStub),
+	};
+
+	return {
+		NEXT_TAG_CACHE_DO_SHARDED: mockNamespace,
+		NEXT_CACHE_DO_QUEUE: mockNamespace,
+		NEXT_CACHE_DO_PURGE: mockNamespace,
+		...overrides,
+	} as unknown as CloudflareEnv;
+}
+
+function createRequest(
+	path: string,
+	options: { method?: string; body?: unknown; headers?: Record<string, string> } = {}
+): Request {
+	return new Request(`https://do-proxy${path}`, {
+		method: options.method ?? "POST",
+		headers: { "Content-Type": "application/json", ...options.headers },
+		body: options.body !== undefined ? JSON.stringify(options.body) : JSON.stringify([]),
+	});
+}
+
+describe("createDOProxyHandler", () => {
+	const handler = createDOProxyHandler();
+
+	test("routes valid RPC call and returns JSON result", async () => {
+		const env = createMockEnv();
+		const request = createRequest("/do-rpc/NEXT_TAG_CACHE_DO_SHARDED/my-shard/getLastRevalidated", {
+			body: [["tag1", "tag2"]],
+		});
+
+		const response = await handler.fetch!(request, env, {} as ExecutionContext);
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("Content-Type")).toBe("application/json");
+		expect(await response.json()).toBe(123);
+	});
+
+	test("returns 204 for void methods", async () => {
+		const env = createMockEnv();
+		const request = createRequest("/do-rpc/NEXT_TAG_CACHE_DO_SHARDED/my-shard/writeTags", {
+			body: [["tag1"], 1000],
+		});
+
+		const response = await handler.fetch!(request, env, {} as ExecutionContext);
+
+		expect(response.status).toBe(204);
+	});
+
+	test("returns 404 for non-RPC paths", async () => {
+		const env = createMockEnv();
+		const request = createRequest("/some-other-path");
+
+		const response = await handler.fetch!(request, env, {} as ExecutionContext);
+
+		expect(response.status).toBe(404);
+	});
+
+	test("returns 405 for non-POST requests", async () => {
+		const env = createMockEnv();
+		const request = new Request("https://do-proxy/do-rpc/NEXT_TAG_CACHE_DO_SHARDED/id/method", {
+			method: "GET",
+		});
+
+		const response = await handler.fetch!(request, env, {} as ExecutionContext);
+
+		expect(response.status).toBe(405);
+	});
+
+	test("returns 400 for malformed paths", async () => {
+		const env = createMockEnv();
+		const request = createRequest("/do-rpc/only-two-parts");
+
+		const response = await handler.fetch!(request, env, {} as ExecutionContext);
+
+		expect(response.status).toBe(400);
+	});
+
+	test("returns 404 for unknown namespace", async () => {
+		const env = createMockEnv();
+		const request = createRequest("/do-rpc/UNKNOWN_NAMESPACE/id/method");
+
+		const response = await handler.fetch!(request, env, {} as ExecutionContext);
+
+		expect(response.status).toBe(404);
+		expect(await response.text()).toContain("Unknown DO namespace");
+	});
+
+	test("returns 500 when namespace binding is missing from env", async () => {
+		const env = createMockEnv({ NEXT_TAG_CACHE_DO_SHARDED: undefined });
+		const request = createRequest("/do-rpc/NEXT_TAG_CACHE_DO_SHARDED/id/method");
+
+		const response = await handler.fetch!(request, env, {} as ExecutionContext);
+
+		expect(response.status).toBe(500);
+		expect(await response.text()).toContain("not bound");
+	});
+
+	test("returns 404 when method does not exist on stub", async () => {
+		const env = createMockEnv();
+		const request = createRequest("/do-rpc/NEXT_TAG_CACHE_DO_SHARDED/id/nonExistentMethod");
+
+		const response = await handler.fetch!(request, env, {} as ExecutionContext);
+
+		expect(response.status).toBe(404);
+		expect(await response.text()).toContain("not found");
+	});
+
+	test("returns 500 when method throws", async () => {
+		const env = createMockEnv();
+		const request = createRequest("/do-rpc/NEXT_TAG_CACHE_DO_SHARDED/id/failingMethod");
+
+		const response = await handler.fetch!(request, env, {} as ExecutionContext);
+
+		expect(response.status).toBe(500);
+		expect(await response.text()).toContain("DO error");
+	});
+
+	test("passes location hint header to namespace.get", async () => {
+		const env = createMockEnv();
+		const request = createRequest("/do-rpc/NEXT_TAG_CACHE_DO_SHARDED/my-shard/getLastRevalidated", {
+			body: [["tag1"]],
+			headers: { "X-DO-Location-Hint": "enam" },
+		});
+
+		await handler.fetch!(request, env, {} as ExecutionContext);
+
+		const ns = (env as Record<string, unknown>)["NEXT_TAG_CACHE_DO_SHARDED"] as {
+			get: ReturnType<typeof vi.fn>;
+		};
+		expect(ns.get).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ locationHint: "enam" }));
+	});
+
+	test("decodes URI-encoded path components", async () => {
+		const env = createMockEnv();
+		const encodedName = encodeURIComponent("shard/with/slashes");
+		const request = createRequest(`/do-rpc/NEXT_TAG_CACHE_DO_SHARDED/${encodedName}/getLastRevalidated`, {
+			body: [["tag1"]],
+		});
+
+		await handler.fetch!(request, env, {} as ExecutionContext);
+
+		const ns = (env as Record<string, unknown>)["NEXT_TAG_CACHE_DO_SHARDED"] as {
+			idFromName: ReturnType<typeof vi.fn>;
+		};
+		expect(ns.idFromName).toHaveBeenCalledWith("shard/with/slashes");
+	});
+});

--- a/packages/cloudflare/src/api/do-proxy/proxy-handler.ts
+++ b/packages/cloudflare/src/api/do-proxy/proxy-handler.ts
@@ -1,0 +1,110 @@
+/**
+ * Fetch handler for the DO worker that routes proxy RPC requests
+ * from the main worker to the appropriate Durable Object stubs.
+ *
+ * Usage in do-worker.ts:
+ * ```ts
+ * import { createDOProxyHandler } from "@opennextjs/cloudflare/do-proxy/index";
+ * export { DOQueueHandler } from "./.open-next/worker.js";
+ * export { DOShardedTagCache } from "./.open-next/worker.js";
+ * export { BucketCachePurge } from "./.open-next/worker.js";
+ * export default createDOProxyHandler();
+ * ```
+ */
+
+import { DO_RPC_PREFIX, NAMESPACE_BINDINGS } from "./constants.js";
+
+/**
+ * Creates a fetch handler that routes DO proxy RPC requests to local DO stubs.
+ *
+ * The handler expects requests in the format:
+ *   POST /do-rpc/{namespaceName}/{doIdName}/{method}
+ *   Body: JSON array of arguments
+ *   Headers: X-DO-Location-Hint (optional)
+ *
+ * Returns:
+ *   - 200 with JSON body for methods that return a value
+ *   - 204 for void methods
+ *   - 400/404/500 for errors
+ */
+export function createDOProxyHandler(): ExportedHandler<CloudflareEnv> {
+	return {
+		async fetch(request: Request, env: CloudflareEnv): Promise<Response> {
+			const url = new URL(request.url);
+
+			// Only handle DO RPC requests
+			if (!url.pathname.startsWith(DO_RPC_PREFIX)) {
+				return new Response("Not Found", { status: 404 });
+			}
+
+			if (request.method !== "POST") {
+				return new Response("Method Not Allowed", { status: 405 });
+			}
+
+			// Parse the path: /do-rpc/{namespace}/{doIdName}/{method}
+			const pathParts = url.pathname
+				.slice(DO_RPC_PREFIX.length + 1)
+				.split("/")
+				.map(decodeURIComponent);
+
+			if (pathParts.length !== 3) {
+				return new Response(
+					`Invalid RPC path. Expected /do-rpc/{namespace}/{doIdName}/{method}, got ${url.pathname}`,
+					{ status: 400 }
+				);
+			}
+
+			const namespaceName = pathParts[0]!;
+			const doIdName = pathParts[1]!;
+			const method = pathParts[2]!;
+
+			// Validate namespace
+			if (!(NAMESPACE_BINDINGS as readonly string[]).includes(namespaceName)) {
+				return new Response(`Unknown DO namespace: ${namespaceName}`, { status: 404 });
+			}
+
+			// Get the DO namespace from env
+			const namespace = (env as Record<string, unknown>)[namespaceName as string] as
+				| DurableObjectNamespace
+				| undefined;
+
+			if (!namespace) {
+				return new Response(`DO namespace ${namespaceName} not bound in DO worker env`, { status: 500 });
+			}
+
+			try {
+				// Create the DO stub
+				const id = namespace.idFromName(doIdName);
+				const locationHint = request.headers.get("X-DO-Location-Hint");
+				const stub = locationHint
+					? namespace.get(id, { locationHint } as DurableObjectNamespaceGetDurableObjectOptions)
+					: namespace.get(id);
+
+				// Parse arguments
+				const args = (await request.json()) as unknown[];
+
+				// Call the method on the stub
+				// biome-ignore lint: dynamic dispatch is intentional for RPC proxy
+				const fn = (stub as unknown as Record<string, (...a: unknown[]) => unknown>)[method];
+				if (typeof fn !== "function") {
+					return new Response(`Method ${method} not found on DO stub`, { status: 404 });
+				}
+				const result = await fn(...args);
+
+				// Return the result
+				if (result === undefined || result === null) {
+					return new Response(null, { status: 204 });
+				}
+
+				return new Response(JSON.stringify(result), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				console.error(`DO proxy handler error: ${namespaceName}.${doIdName}.${method}():`, err);
+				return new Response(message, { status: 500 });
+			}
+		},
+	};
+}

--- a/packages/cloudflare/src/api/do-proxy/proxy-namespace.spec.ts
+++ b/packages/cloudflare/src/api/do-proxy/proxy-namespace.spec.ts
@@ -1,0 +1,236 @@
+import { describe, expect, test, vi } from "vitest";
+
+import {
+	createProxyDurableObjectNamespace,
+	injectDOProxyBindings,
+	ProxyDurableObjectId,
+} from "./proxy-namespace.js";
+
+function createMockService(
+	responseFactory: (url: string, init: RequestInit) => Response = () =>
+		new Response(JSON.stringify(42), {
+			status: 200,
+			headers: { "Content-Type": "application/json" },
+		})
+): Service {
+	return {
+		fetch: vi.fn().mockImplementation((input: RequestInfo, init?: RequestInit) => {
+			const url = typeof input === "string" ? input : input.url;
+			return Promise.resolve(responseFactory(url, init ?? {}));
+		}),
+	} as unknown as Service;
+}
+
+describe("ProxyDurableObjectId", () => {
+	test("stores the name", () => {
+		const id = new ProxyDurableObjectId("my-shard");
+		expect(id.name).toBe("my-shard");
+	});
+
+	test("toString returns proxy prefix", () => {
+		const id = new ProxyDurableObjectId("my-shard");
+		expect(id.toString()).toBe("proxy:my-shard");
+	});
+
+	test("equals returns true for same name", () => {
+		const a = new ProxyDurableObjectId("shard");
+		const b = new ProxyDurableObjectId("shard");
+		expect(a.equals(b)).toBe(true);
+	});
+
+	test("equals returns false for different name", () => {
+		const a = new ProxyDurableObjectId("shard-a");
+		const b = new ProxyDurableObjectId("shard-b");
+		expect(a.equals(b)).toBe(false);
+	});
+});
+
+describe("createProxyDurableObjectNamespace", () => {
+	test("idFromName returns a ProxyDurableObjectId", () => {
+		const service = createMockService();
+		const ns = createProxyDurableObjectNamespace(service, "TEST_NS");
+
+		const id = ns.idFromName("my-shard");
+
+		expect(id).toBeInstanceOf(ProxyDurableObjectId);
+		expect((id as ProxyDurableObjectId).name).toBe("my-shard");
+	});
+
+	test("get with valid ProxyDurableObjectId returns a stub", () => {
+		const service = createMockService();
+		const ns = createProxyDurableObjectNamespace(service, "TEST_NS");
+		const id = ns.idFromName("my-shard");
+
+		const stub = ns.get(id);
+
+		expect(stub).toBeDefined();
+	});
+
+	test("get with non-proxy DurableObjectId throws", () => {
+		const service = createMockService();
+		const ns = createProxyDurableObjectNamespace(service, "TEST_NS");
+		const fakeId = { toString: () => "fake" } as DurableObjectId;
+
+		expect(() => ns.get(fakeId)).toThrow("non-proxy DurableObjectId");
+	});
+
+	test("newUniqueId throws", () => {
+		const service = createMockService();
+		const ns = createProxyDurableObjectNamespace(service, "TEST_NS");
+
+		expect(() => ns.newUniqueId()).toThrow("newUniqueId is not supported");
+	});
+
+	test("jurisdiction returns self", () => {
+		const service = createMockService();
+		const ns = createProxyDurableObjectNamespace(service, "TEST_NS");
+
+		const result = ns.jurisdiction("eu" as DurableObjectJurisdiction);
+
+		expect(result).toBe(ns);
+	});
+});
+
+describe("proxy stub", () => {
+	test("method call serializes as POST with JSON body", async () => {
+		const service = createMockService();
+		const ns = createProxyDurableObjectNamespace(service, "MY_NS");
+		const stub = ns.get(ns.idFromName("shard-1"));
+
+		await (stub as unknown as Record<string, (...args: unknown[]) => Promise<unknown>>).someMethod(
+			"arg1",
+			42
+		);
+
+		const fetchMock = service.fetch as ReturnType<typeof vi.fn>;
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+
+		const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+		expect(url).toContain("/do-rpc/MY_NS/shard-1/someMethod");
+		expect(init.method).toBe("POST");
+		expect(JSON.parse(init.body as string)).toEqual(["arg1", 42]);
+	});
+
+	test("returns parsed JSON for 200 response", async () => {
+		const service = createMockService(
+			() =>
+				new Response(JSON.stringify({ key: "value" }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				})
+		);
+		const ns = createProxyDurableObjectNamespace(service, "NS");
+		const stub = ns.get(ns.idFromName("id"));
+
+		const result = await (stub as unknown as Record<string, () => Promise<unknown>>).myMethod();
+
+		expect(result).toEqual({ key: "value" });
+	});
+
+	test("returns undefined for 204 response", async () => {
+		const service = createMockService(() => new Response(null, { status: 204 }));
+		const ns = createProxyDurableObjectNamespace(service, "NS");
+		const stub = ns.get(ns.idFromName("id"));
+
+		const result = await (stub as unknown as Record<string, () => Promise<unknown>>).voidMethod();
+
+		expect(result).toBeUndefined();
+	});
+
+	test("throws on non-ok response", async () => {
+		const service = createMockService(() => new Response("Internal Server Error", { status: 500 }));
+		const ns = createProxyDurableObjectNamespace(service, "NS");
+		const stub = ns.get(ns.idFromName("id"));
+
+		await expect((stub as unknown as Record<string, () => Promise<unknown>>).badMethod()).rejects.toThrow(
+			"DO proxy RPC failed"
+		);
+	});
+
+	test(".then returns undefined (no spurious RPC)", () => {
+		const service = createMockService();
+		const ns = createProxyDurableObjectNamespace(service, "NS");
+		const stub = ns.get(ns.idFromName("id"));
+
+		// Accessing .then should not trigger an RPC call
+		expect((stub as unknown as Record<string, unknown>).then).toBeUndefined();
+		expect(service.fetch as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+	});
+
+	test(".toJSON returns undefined (no spurious RPC)", () => {
+		const service = createMockService();
+		const ns = createProxyDurableObjectNamespace(service, "NS");
+		const stub = ns.get(ns.idFromName("id"));
+
+		expect((stub as unknown as Record<string, unknown>).toJSON).toBeUndefined();
+		expect(service.fetch as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+	});
+
+	test(".id returns a ProxyDurableObjectId", () => {
+		const service = createMockService();
+		const ns = createProxyDurableObjectNamespace(service, "NS");
+		const stub = ns.get(ns.idFromName("my-id"));
+
+		expect(stub.id).toBeInstanceOf(ProxyDurableObjectId);
+		expect((stub.id as unknown as ProxyDurableObjectId).name).toBe("my-id");
+	});
+
+	test(".name returns the DO id name", () => {
+		const service = createMockService();
+		const ns = createProxyDurableObjectNamespace(service, "NS");
+		const stub = ns.get(ns.idFromName("my-id"));
+
+		expect(stub.name).toBe("my-id");
+	});
+
+	test("passes location hint as header", async () => {
+		const service = createMockService();
+		const ns = createProxyDurableObjectNamespace(service, "NS");
+		const id = ns.idFromName("id");
+		const stub = ns.get(id, { locationHint: "enam" } as DurableObjectNamespaceGetDurableObjectOptions);
+
+		await (stub as unknown as Record<string, () => Promise<unknown>>).someMethod();
+
+		const fetchMock = service.fetch as ReturnType<typeof vi.fn>;
+		const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+		expect((init.headers as Record<string, string>)["X-DO-Location-Hint"]).toBe("enam");
+	});
+});
+
+describe("injectDOProxyBindings", () => {
+	test("injects proxy namespaces when OPENNEXT_DO_WORKER is present", () => {
+		const env = {
+			OPENNEXT_DO_WORKER: createMockService(),
+		} as unknown as CloudflareEnv;
+
+		injectDOProxyBindings(env);
+
+		const record = env as unknown as Record<string, unknown>;
+		expect(record["NEXT_TAG_CACHE_DO_SHARDED"]).toBeDefined();
+		expect(record["NEXT_CACHE_DO_QUEUE"]).toBeDefined();
+		expect(record["NEXT_CACHE_DO_PURGE"]).toBeDefined();
+	});
+
+	test("does not overwrite existing DO bindings", () => {
+		const existingNamespace = { idFromName: vi.fn() };
+		const env = {
+			OPENNEXT_DO_WORKER: createMockService(),
+			NEXT_TAG_CACHE_DO_SHARDED: existingNamespace,
+		} as unknown as CloudflareEnv;
+
+		injectDOProxyBindings(env);
+
+		expect((env as unknown as Record<string, unknown>)["NEXT_TAG_CACHE_DO_SHARDED"]).toBe(existingNamespace);
+	});
+
+	test("does nothing when OPENNEXT_DO_WORKER is absent", () => {
+		const env = {} as unknown as CloudflareEnv;
+
+		injectDOProxyBindings(env);
+
+		const record = env as unknown as Record<string, unknown>;
+		expect(record["NEXT_TAG_CACHE_DO_SHARDED"]).toBeUndefined();
+		expect(record["NEXT_CACHE_DO_QUEUE"]).toBeUndefined();
+		expect(record["NEXT_CACHE_DO_PURGE"]).toBeUndefined();
+	});
+});

--- a/packages/cloudflare/src/api/do-proxy/proxy-namespace.ts
+++ b/packages/cloudflare/src/api/do-proxy/proxy-namespace.ts
@@ -1,0 +1,155 @@
+/**
+ * Proxy implementation of DurableObjectNamespace that routes RPC calls
+ * through a service binding to an external DO worker via HTTP.
+ *
+ * This enables the main worker to use DOs without having `durable_objects`
+ * in its wrangler config, which is required for preview URLs (skew protection).
+ */
+
+import { DO_RPC_PREFIX, NAMESPACE_BINDINGS } from "./constants.js";
+
+/**
+ * Properties that should NOT be intercepted by the proxy stub.
+ * Accessing these must return `undefined` to avoid spurious RPC calls,
+ * e.g. when the stub is accidentally `await`ed (which checks `.then`).
+ */
+const NON_RPC_PROPERTIES = new Set(["then", "toJSON", "valueOf", "toString", "constructor"]);
+
+/**
+ * A proxy DurableObjectId that carries the name used to create it.
+ */
+export class ProxyDurableObjectId {
+	readonly name: string;
+
+	constructor(name: string) {
+		this.name = name;
+	}
+
+	toString(): string {
+		return `proxy:${this.name}`;
+	}
+
+	equals(other: DurableObjectId): boolean {
+		return other instanceof ProxyDurableObjectId && other.name === this.name;
+	}
+}
+
+/**
+ * A proxy DurableObjectStub that serializes method calls as HTTP requests
+ * to the DO worker's fetch handler.
+ */
+function createProxyStub(
+	service: Service,
+	namespaceName: string,
+	doIdName: string,
+	locationHint?: string
+): DurableObjectStub {
+	// Use a Proxy to intercept any method call on the stub
+	return new Proxy({} as DurableObjectStub, {
+		get(_target, method: string | symbol) {
+			// Skip symbol properties
+			if (typeof method === "symbol") return undefined;
+			// Skip known non-RPC properties to prevent spurious calls
+			if (NON_RPC_PROPERTIES.has(method)) return undefined;
+			// Return the id
+			if (method === "id") return new ProxyDurableObjectId(doIdName);
+			// Return the name
+			if (method === "name") return doIdName;
+
+			// For any method call, serialize it as an HTTP request
+			return async (...args: unknown[]) => {
+				const url = `https://do-proxy${DO_RPC_PREFIX}/${encodeURIComponent(namespaceName)}/${encodeURIComponent(doIdName)}/${encodeURIComponent(method)}`;
+
+				const headers: Record<string, string> = {
+					"Content-Type": "application/json",
+				};
+				if (locationHint) {
+					headers["X-DO-Location-Hint"] = locationHint;
+				}
+
+				const response = await service.fetch(url, {
+					method: "POST",
+					headers,
+					body: JSON.stringify(args),
+				});
+
+				if (!response.ok) {
+					const errorText = await response.text();
+					throw new Error(
+						`DO proxy RPC failed: ${namespaceName}.${doIdName}.${method}() -> ${response.status}: ${errorText}`
+					);
+				}
+
+				const contentType = response.headers.get("Content-Type");
+				if (contentType?.includes("application/json")) {
+					return response.json();
+				}
+				// void methods return 204
+				return undefined;
+			};
+		},
+	});
+}
+
+/**
+ * Creates a proxy DurableObjectNamespace that routes all DO operations
+ * through a service binding to an external DO worker.
+ *
+ * The proxy implements `idFromName()` and `get()` to match the
+ * DurableObjectNamespace interface used by OpenNext overrides.
+ */
+export function createProxyDurableObjectNamespace(
+	service: Service,
+	namespaceName: string
+): DurableObjectNamespace {
+	return {
+		idFromName(name: string): DurableObjectId {
+			return new ProxyDurableObjectId(name);
+		},
+
+		get(id: DurableObjectId, options?: DurableObjectNamespaceGetDurableObjectOptions): DurableObjectStub {
+			if (!(id instanceof ProxyDurableObjectId)) {
+				throw new Error(
+					"DO proxy: get() received a non-proxy DurableObjectId. Use idFromName() from this namespace."
+				);
+			}
+			return createProxyStub(service, namespaceName, id.name, options?.locationHint);
+		},
+
+		// Jurisdiction is not commonly used, but provide a basic implementation
+		jurisdiction(): DurableObjectNamespace {
+			return this;
+		},
+
+		newUniqueId(): DurableObjectId {
+			throw new Error("newUniqueId is not supported via DO proxy. Use idFromName instead.");
+		},
+
+		idFromString(): DurableObjectId {
+			throw new Error("idFromString is not supported via DO proxy. Use idFromName instead.");
+		},
+
+		getByName(): DurableObjectStub {
+			throw new Error("getByName is not supported via DO proxy. Use idFromName + get instead.");
+		},
+	} as DurableObjectNamespace;
+}
+
+/**
+ * Patches the CloudflareEnv object to inject proxy DO namespaces
+ * when the `OPENNEXT_DO_WORKER` service binding exists but direct
+ * DO bindings are missing.
+ *
+ * This should be called before the env is stored in the Cloudflare context.
+ */
+export function injectDOProxyBindings(env: CloudflareEnv): void {
+	const doWorkerService = (env as Record<string, unknown>)["OPENNEXT_DO_WORKER"] as Service | undefined;
+
+	if (!doWorkerService) return;
+
+	for (const name of NAMESPACE_BINDINGS) {
+		if (!env[name as keyof CloudflareEnv]) {
+			(env as Record<string, unknown>)[name] = createProxyDurableObjectNamespace(doWorkerService, name);
+		}
+	}
+}


### PR DESCRIPTION
Follow-up to https://github.com/opennextjs/opennextjs-cloudflare/issues/783 and https://github.com/opennextjs/opennextjs-cloudflare/issues/834

@vicb It seemed that your suggested approach of using a separate worker does not work out of the box, see my comment in #834. I had Claude attempt a possible solution by adding a DO proxy layer for using service binding between the "main" and the "do worker". I tested it in our setup and the DO RPC traffic flowed correctly and skew protection also still worked for the main worker.

Looking forward to your feedback.

## Summary

Adds a DO proxy layer under `src/api/do-proxy/` that routes Durable Object
operations through a service binding to a separate DO worker via HTTP.

This is one of way solving the current limitation where workers with `durable_objects` config
cannot use preview URLs, which is requiref for skew protection. By splitting DOs into a
separate worker and proxying via service binding, the main worker retains preview
URL support.

## Usage

**Main worker** (`worker.ts`):
```ts
import { withDOProxy } from "@opennextjs/cloudflare/do-proxy/index";
import handler from "./.open-next/worker.js";
export default withDOProxy(handler);
DO worker (do-worker.ts):


import { createDOProxyHandler } from "@opennextjs/cloudflare/do-proxy/index";
export { DOQueueHandler, DOShardedTagCache, BucketCachePurge } from "./.open-next/worker.js";
export default createDOProxyHandler();
```

**Main worker wrangler config** (`wrangler.jsonc`):
```jsonc
{
  "name": "my-app",
  // No durable_objects block — this enables preview URLs / skew protection
  "services": [
    {
      "binding": "OPENNEXT_DO_WORKER",
      "service": "my-app-do"
    }
  ]
}
```

DO worker wrangler config (wrangler-do.jsonc):
```jsonc
{
  "name": "my-app-do",
  "main": "do-worker.ts",
  "durable_objects": {
    "bindings": [
      { "name": "NEXT_TAG_CACHE_DO_SHARDED", "class_name": "DOShardedTagCache" },
      { "name": "NEXT_CACHE_DO_QUEUE", "class_name": "DOQueueHandler" },
      { "name": "NEXT_CACHE_DO_PURGE", "class_name": "BucketCachePurge" }
    ]
  },
  "migrations": [
    { "tag": "v1", "new_sqlite_classes": ["DOShardedTagCache", "DOQueueHandler", "BucketCachePurge"] }
  ]
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)