### PR TITLE
Remove R2 from the templates used when creating `wrangler.jsonc` and `open-next.config.ts` files

### DIFF
--- a/.changeset/rotten-foxes-nail.md
+++ b/.changeset/rotten-foxes-nail.md
@@ -1,0 +1,9 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+Remove R2 caching from the `wrangler.jsonc` and `open-next.config.ts` files created by the `migrate` command
+
+The `migrate` command no longer sets up the R2 caching in the `wrangler.jsonc` and `open-next.config.ts` files it creates, this allows newly migrated applications to be deployed right away without forcing the user to enable R2 nor set an R2 bucket.
+
+Ideally applications should use caching for optimal results, so a warning is now also presented at the end of the migration recommending users to set up caching.

--- a/.changeset/slimy-roses-shop.md
+++ b/.changeset/slimy-roses-shop.md
@@ -1,0 +1,9 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+Remove R2 caching from the `wrangler.jsonc` the `build` command might create
+
+The `build` command run in a project without a `wrangler.jsonc` file creates such file. Previously the file would contain an R2 binding for caching, this might be incorrect since the user is likely not to have an R2 bucket with the name hardcoded in the created `wrangler.jsonc` (they also might not have R2 enabled in their account). In such case attempting a deployment would fail.
+
+So as a safer alternative that enables users to deploy their application immediately, the created `wrangler.jsonc` will now not include any binding. The user is always able to add them later when appropriate (for example after they created the appropriate R2 bucket).

--- a/packages/cloudflare/src/cli/commands/migrate.ts
+++ b/packages/cloudflare/src/cli/commands/migrate.ts
@@ -197,7 +197,10 @@ async function migrateCommand(args: { forceInstall: boolean }): Promise<void> {
 		"🎉 OpenNext Cloudflare adapter complete!\n" +
 			"\nNext steps:\n" +
 			`- Run: "${packageManager.run} preview" to build and preview your Cloudflare application locally\n` +
-			`- Run: "${packageManager.run} deploy" to deploy your application to Cloudflare Workers\n`
+			`- Run: "${packageManager.run} deploy" to deploy your application to Cloudflare Workers\n` +
+			`\n\n` +
+			`⚠️ Note: This setup doesn't include caching, for best results please enable caching by following\n` +
+			` the instructions in: https://opennext.js.org/cloudflare/caching\n`
 	);
 }
 

--- a/packages/cloudflare/templates/open-next.config.ts
+++ b/packages/cloudflare/templates/open-next.config.ts
@@ -1,7 +1,6 @@
 // default open-next.config.ts file created by @opennextjs/cloudflare
 import { defineCloudflareConfig } from "@opennextjs/cloudflare/config";
-import r2IncrementalCache from "@opennextjs/cloudflare/overrides/incremental-cache/r2-incremental-cache";
 
 export default defineCloudflareConfig({
-	incrementalCache: r2IncrementalCache,
+	// To enable caching set here an `incrementalCache` solution as described in https://opennext.js.org/cloudflare/caching
 });

--- a/packages/cloudflare/templates/wrangler.jsonc
+++ b/packages/cloudflare/templates/wrangler.jsonc
@@ -16,17 +16,8 @@
 			"service": "<WORKER_NAME>"
 		}
 	],
-	"r2_buckets": [
-		// Use R2 incremental cache
-		// See https://opennext.js.org/cloudflare/caching
-		{
-			"binding": "NEXT_INC_CACHE_R2_BUCKET",
-			// Create the bucket before deploying
-			// You can change the bucket name if you want
-			// See https://developers.cloudflare.com/workers/wrangler/commands/#r2-bucket-create
-			"bucket_name": "cache"
-		}
-	],
+	// To enable caching an R2 bucket (or a KV namespace) can be configured here and configured as
+	// described in https://opennext.js.org/cloudflare/caching
 	"images": {
 		// Enable image optimization
 		// see https://opennext.js.org/cloudflare/howtos/image


### PR DESCRIPTION
Fixes https://jira.cfdata.org/browse/DEVX-2491

This PR removes R2 from the templates used when creating `wrangler.jsonc` and `open-next.config.ts` files since this generally results on an application that can't actually be deployed.

For more details please see the included changesets.