### PR TITLE
Use the c3 <COMPATIBILITY_DATE> placeholder in the template

### DIFF
--- a/create-cloudflare/next/wrangler.jsonc
+++ b/create-cloudflare/next/wrangler.jsonc
@@ -6,7 +6,7 @@
 	"$schema": "node_modules/wrangler/config-schema.json",
 	"name": "<WORKER_NAME>",
 	"main": ".open-next/worker.js",
-	"compatibility_date": "2025-12-01",
+	"compatibility_date": "<COMPATIBILITY_DATE>",
 	"compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
 	"assets": {
 		"binding": "ASSETS",


### PR DESCRIPTION
Support was added in c3 in [this PR](https://github.com/cloudflare/workers-sdk/pull/11520).

It will make things consistent with:
- other placeholders in the same file
- placeholders in `packages/cloudflare/templates/wrangler.jsonc`

Tested on a local build of c3 pointing to this branch