### PR TITLE
fix: new Request(request, init) crashing in route handlers on workerd          

### DIFF
--- a/.changeset/fix-custom-request-constructor.md
+++ b/.changeset/fix-custom-request-constructor.md
@@ -1,0 +1,7 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+fix: handle plain Request-like objects in `CustomRequest` constructor
+
+workerd's `Request` constructor coerces plain objects to `"[object Object]"` instead of reading `.url`, causing `TypeError: Invalid URL`. The fix extracts `.url` and merges method/headers/body from plain objects before passing to `super()`.

--- a/packages/cloudflare/src/cli/templates/init.ts
+++ b/packages/cloudflare/src/cli/templates/init.ts
@@ -77,7 +77,10 @@ function initRuntime() {
 		return __original_fetch(input, init);
 	};
 
-	const CustomRequest = class extends globalThis.Request {
+	// workerd calls toString() on plain objects instead of reading .url,
+	// so capture the native constructor for instanceof checks.
+	const OriginalRequest = globalThis.Request;
+	const CustomRequest = class extends OriginalRequest {
 		constructor(input: RequestInfo | URL, init?: RequestInit) {
 			if (init) {
 				delete (init as { cache: unknown }).cache;
@@ -88,7 +91,21 @@ function initRuntime() {
 					value: init.body instanceof stream.Readable ? ReadableStream.from(init.body) : init.body,
 				});
 			}
-			super(input, init);
+			if (typeof input === "string" || input instanceof URL || input instanceof OriginalRequest) {
+				super(input, init);
+			} else {
+				// Plain Request like object from third-party middleware or edge adapters
+				// extract .url and merge properties so they aren't lost.
+				const req = input as unknown as Request;
+				const merged = {
+					method: req.method,
+					headers: req.headers,
+					body: req.body,
+					...(req.body ? { duplex: "half" as const } : {}),
+					...init,
+				};
+				super(req.url, merged as RequestInit);
+			}
 		}
 	};
 


### PR DESCRIPTION
## Summary

Fixes #1144. Likely also fixes #1037.

`new Request(request, { headers })` in route handlers crashes with `TypeError: Invalid URL: [object Request]` because the `request` object isn't recognized as a native `Request` by workerd's constructor.

The fix captures `OriginalRequest` before overwriting `globalThis.Request`, adds an `instanceof` guard, and extracts `.url` with merged properties for non-native objects.

### What changed

`packages/cloudflare/src/cli/templates/init.ts`

- Capture `OriginalRequest` before replacement for reliable `instanceof` checks
- String, URL, and `OriginalRequest` instances pass through to `super()` directly
- Non-native objects: extract `.url`, merge `method`/`headers`/`body` into init, set `duplex: "half"` when body is present

## Test plan

- [ ] String and URL inputs still work
- [ ] `new Request(request, { headers })` works in route handlers (the bug)
- [ ] Method, headers, and body are preserved through the non-native path
- [ ] `stream.Readable` body conversion still works (existing behavior)
