### PR TITLE
fix(patches): return empty object for unhandled manifests in loadManifest

### DIFF
--- a/.changeset/fix-load-manifest-graceful-fallback.md
+++ b/.changeset/fix-load-manifest-graceful-fallback.md
@@ -10,12 +10,17 @@ generated, so the patched function threw at runtime, crashing dynamic routes wit
 
 Instead of a blanket catch-all, handle only the specific optional manifests from Next.js
 `route-module.ts`:
-- `react-loadable-manifest.json` (Turbopack per-route, not all routes have dynamic imports)
-- `subresource-integrity-manifest.json` (only when `experimental.sri` configured)
-- `server-reference-manifest.json` (App Router only)
-- `dynamic-css-manifest.json` (Pages Router + Webpack only)
-- `fallback-build-manifest.json` (only for `/_error` page)
-- `_client-reference-manifest.js` (optional for static metadata routes)
+
+- `react-loadable-manifest` (Turbopack per-route, not all routes have dynamic imports)
+- `subresource-integrity-manifest` (only when `experimental.sri` configured)
+- `server-reference-manifest` (App Router only)
+- `dynamic-css-manifest` (Pages Router + Webpack only)
+- `fallback-build-manifest` (only for `/_error` page)
+- `prefetch-hints` (new in Next.js 16.2)
+- `_client-reference-manifest.js` (optional for static metadata routes, evalManifest)
+
+Manifest matching strips `.json` before comparison since some Next.js constants omit
+the extension (`SUBRESOURCE_INTEGRITY_MANIFEST`, `DYNAMIC_CSS_MANIFEST`, etc.).
 
 Unknown manifests still throw to surface genuine errors.
 

--- a/packages/cloudflare/src/cli/build/patches/plugins/load-manifest.ts
+++ b/packages/cloudflare/src/cli/build/patches/plugins/load-manifest.ts
@@ -69,12 +69,19 @@ function loadManifest($PATH, $$$ARGS) {
   // Known optional manifests \u2014 Next.js loads these with handleMissing: true
   // (see vercel/next.js packages/next/src/server/route-modules/route-module.ts).
   // Return {} to match Next.js behaviour instead of crashing the worker.
-  if ($PATH.endsWith("react-loadable-manifest.json") ||
-      $PATH.endsWith("subresource-integrity-manifest.json") ||
-      $PATH.endsWith("server-reference-manifest.json") ||
-      $PATH.endsWith("dynamic-css-manifest.json") ||
-      $PATH.endsWith("fallback-build-manifest.json")) {
-    return {};
+  // Note: Some manifest constants in Next.js omit the .json extension
+  // (e.g. SUBRESOURCE_INTEGRITY_MANIFEST, DYNAMIC_CSS_MANIFEST), so we
+  // strip .json before matching to handle both forms.
+  {
+    const p = $PATH.replace(/\\.json$/, "");
+    if (p.endsWith("react-loadable-manifest") ||
+        p.endsWith("subresource-integrity-manifest") ||
+        p.endsWith("server-reference-manifest") ||
+        p.endsWith("dynamic-css-manifest") ||
+        p.endsWith("fallback-build-manifest") ||
+        p.endsWith("prefetch-hints")) {
+      return {};
+    }
   }
   throw new Error(\`Unexpected loadManifest(\${$PATH}) call!\`);
 }`,


### PR DESCRIPTION
## Summary
- Return `{}` instead of throwing for manifest paths not found during the build-time glob scan in `loadManifest()` and `evalManifest()`
- Handles Next.js 16.2.0-canary.53+ which introduces new `loadManifest()` calls for optional/phase-dependent manifests

## Problem
Next.js canary adds `loadManifest()` calls for:
1. `subresource-integrity-manifest.json` - only generated when `experimental.sri` is configured, but loaded unconditionally
2. Per-route `react-loadable-manifest.json` - generated by Turbopack, possibly in a different build phase

The adapter's build-time glob scan doesn't find these files, so the patched function throws at runtime, crashing all dynamic routes with 500.

## Fix
Replace the `throw new Error('Unexpected loadManifest...')` fallback with `return {}`. This follows the same defensive pattern used by other adapter plugins (`instrumentation.ts`, `find-dir.ts`) that return safe defaults for missing files.

## Test plan
- [ ] Build a Next.js app with `next@canary` (16.2.0-canary.53+) using `@opennextjs/cloudflare`
- [ ] Verify dynamic/SSR routes no longer return 500
- [ ] Verify existing manifests still load correctly (app-manifest, build-manifest, etc.)
- [ ] Verify SRI works correctly when `experimental.sri` IS configured

Fixes #1141