### PR TITLE
fix(tag-cache): forward `isStale()` in `withFilter`

### DIFF
--- a/.changeset/major-actors-make.md
+++ b/.changeset/major-actors-make.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+fix(tag-cache): forward `isStale()` in `withFilter`

--- a/packages/cloudflare/src/api/overrides/tag-cache/tag-cache-filter.spec.ts
+++ b/packages/cloudflare/src/api/overrides/tag-cache/tag-cache-filter.spec.ts
@@ -10,6 +10,7 @@ const mockedTagCache = {
 	getPathsByTags: vi.fn(),
 	hasBeenRevalidated: vi.fn(),
 	writeTags: vi.fn(),
+	isStale: vi.fn(),
 } satisfies NextModeTagCache;
 
 const filterFn = (tag: string) => tag.startsWith("valid_");
@@ -106,6 +107,42 @@ describe("withFilter", () => {
 		});
 
 		expect(tagCache.getPathsByTags).toBeUndefined();
+	});
+
+	it("should filter out tags based on isStale", async () => {
+		const tagCache = withFilter({
+			tagCache: mockedTagCache,
+			filterFn,
+		});
+
+		const tags = ["valid_tag", "invalid_tag"];
+		const lastModified = Date.now();
+
+		await tagCache.isStale?.(tags, lastModified);
+		expect(mockedTagCache.isStale).toHaveBeenCalledWith(["valid_tag"], lastModified);
+	});
+
+	it("should not call isStale if no tags are valid", async () => {
+		const tagCache = withFilter({
+			tagCache: mockedTagCache,
+			filterFn,
+		});
+		const tags = ["invalid_tag"];
+		const lastModified = Date.now();
+		await tagCache.isStale?.(tags, lastModified);
+		expect(mockedTagCache.isStale).not.toHaveBeenCalled();
+	});
+
+	it("should not create a function if isStale is not defined", async () => {
+		const tagCache = withFilter({
+			tagCache: {
+				...mockedTagCache,
+				isStale: undefined,
+			},
+			filterFn,
+		});
+
+		expect(tagCache.isStale).toBeUndefined();
 	});
 
 	it("should filter soft tags", () => {

--- a/packages/cloudflare/src/api/overrides/tag-cache/tag-cache-filter.ts
+++ b/packages/cloudflare/src/api/overrides/tag-cache/tag-cache-filter.ts
@@ -52,6 +52,15 @@ export function withFilter({ tagCache, filterFn }: WithFilterOptions): NextModeT
 			}
 			return tagCache.writeTags(filteredTags);
 		},
+		isStale: tagCache.isStale
+			? async (tags, lastModified) => {
+					const filteredTags = tags.filter(filterFn);
+					if (filteredTags.length === 0) {
+						return false;
+					}
+					return tagCache.isStale!(filteredTags, lastModified);
+				}
+			: undefined,
 	};
 }
 


### PR DESCRIPTION
## Summary

The `withFilter` utility does not forward the optional `isStale()` method from the underlying tag cache implementation. This breaks SWR (stale-while-revalidate) support added in v1.19.0.

When using `withFilter`, `globalThis.tagCache.isStale?.()` always returns `undefined` → `false`, causing every revalidated entry to be treated as expired (immediate re-fetch) instead of stale (serve stale, revalidate in background).

## Changes

- Forward `isStale()` in `withFilter`, following the same conditional pattern used for `getPathsByTags` (only create the wrapper when the underlying tag cache provides it)
- Add tests for `isStale` filtering, empty tag short-circuit, and undefined forwarding

## How it was found

After upgrading to v1.19.0 and using `withFilter` + `softTagFilter` with `doShardedTagCache`, we observed that SWR never triggered. Tracing through the code revealed that `withFilter`'s return object omits `isStale`, so the optional chain in `@opennextjs/aws/utils/cache.js` always falls back to `false`.

Closes #1187