### PR TITLE
fix(cli): fail fast in non-TTY environments instead of hanging on config-creation prompts

### DIFF
--- a/.changeset/fix-non-tty-config-prompts.md
+++ b/.changeset/fix-non-tty-config-prompts.md
@@ -1,0 +1,18 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+fix(cli): fail fast in non-TTY environments instead of hanging on config-creation prompts
+
+When `open-next.config.ts` (or `wrangler.(toml|json|jsonc)`) is missing, the CLI
+prompts the user to auto-create it. In non-TTY environments (Cloudflare Workers
+Builds, Docker, CI) the Enquirer prompt can't read stdin, so the build hangs or
+fails with a truncated prompt and a cryptic exit code — the user sees
+`? Missing required open-next.config.ts file, do you want to create one? (Y/n)`
+and then ` ELIFECYCLE  Command failed with exit code 13`, with no hint at what
+to do next.
+
+Now, in non-interactive environments, both prompts throw an actionable error
+with the exact template to paste (for `open-next.config.ts`) or point at the
+existing `--skipWranglerConfigCheck` / `SKIP_WRANGLER_CONFIG_CHECK` escape
+hatch (for the wrangler config). Interactive behavior is unchanged.

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -55,6 +55,7 @@
 		"@ast-grep/napi": "^0.40.5",
 		"@dotenvx/dotenvx": "catalog:",
 		"@opennextjs/aws": "3.10.1",
+		"ci-info": "^4.2.0",
 		"cloudflare": "^4.4.1",
 		"comment-json": "^4.5.1",
 		"enquirer": "^2.4.1",

--- a/packages/cloudflare/src/cli/commands/build.spec.ts
+++ b/packages/cloudflare/src/cli/commands/build.spec.ts
@@ -5,6 +5,10 @@ import { askConfirmation } from "../utils/ask-confirmation.js";
 import { createWranglerConfigFile } from "../utils/create-wrangler-config.js";
 import { buildCommand } from "./build.js";
 
+vi.mock("../utils/is-interactive.js", () => ({
+	isNonInteractiveOrCI: vi.fn(() => false),
+}));
+
 // Mock logger
 vi.mock("@opennextjs/aws/logger.js", () => ({
 	default: {

--- a/packages/cloudflare/src/cli/commands/build.ts
+++ b/packages/cloudflare/src/cli/commands/build.ts
@@ -4,7 +4,7 @@ import type yargs from "yargs";
 import { build as buildImpl } from "../build/build.js";
 import { askConfirmation } from "../utils/ask-confirmation.js";
 import { createWranglerConfigFile, findWranglerConfig } from "../utils/create-wrangler-config.js";
-import { isInteractive } from "../utils/is-interactive.js";
+import { isNonInteractiveOrCI } from "../utils/is-interactive.js";
 import type { WithWranglerArgs } from "./utils/utils.js";
 import {
 	compileConfig,
@@ -45,12 +45,9 @@ export async function buildCommand(
 			// In non-interactive environments (CI, Cloudflare Workers Builds,
 			// Docker, etc.) the prompt would hang or crash. Fail fast with a
 			// clear message pointing at the existing escape hatch.
-			if (!isInteractive()) {
+			if (isNonInteractiveOrCI()) {
 				throw new Error(
-					"No `wrangler.(toml|json|jsonc)` config file found.\n\n" +
-						"Create one at the project root before running the build, " +
-						"or skip this check with `--skipWranglerConfigCheck` or " +
-						"`SKIP_WRANGLER_CONFIG_CHECK=yes`."
+					"No `wrangler.(toml|json|jsonc)` config file found.\n\nCreate one at the project root before running the build, or skip this check with `--skipWranglerConfigCheck` or `SKIP_WRANGLER_CONFIG_CHECK=yes`."
 				);
 			}
 

--- a/packages/cloudflare/src/cli/commands/build.ts
+++ b/packages/cloudflare/src/cli/commands/build.ts
@@ -4,6 +4,7 @@ import type yargs from "yargs";
 import { build as buildImpl } from "../build/build.js";
 import { askConfirmation } from "../utils/ask-confirmation.js";
 import { createWranglerConfigFile, findWranglerConfig } from "../utils/create-wrangler-config.js";
+import { isInteractive } from "../utils/is-interactive.js";
 import type { WithWranglerArgs } from "./utils/utils.js";
 import {
 	compileConfig,
@@ -41,6 +42,18 @@ export async function buildCommand(
 	//       nor when `--skipWranglerConfigCheck` is used.
 	if (!projectOpts.wranglerConfigPath && !args.skipWranglerConfigCheck) {
 		if (!findWranglerConfig(projectOpts.sourceDir)) {
+			// In non-interactive environments (CI, Cloudflare Workers Builds,
+			// Docker, etc.) the prompt would hang or crash. Fail fast with a
+			// clear message pointing at the existing escape hatch.
+			if (!isInteractive()) {
+				throw new Error(
+					"No `wrangler.(toml|json|jsonc)` config file found.\n\n" +
+						"Create one at the project root before running the build, " +
+						"or skip this check with `--skipWranglerConfigCheck` or " +
+						"`SKIP_WRANGLER_CONFIG_CHECK=yes`."
+				);
+			}
+
 			const confirmCreate = "No `wrangler.(toml|json|jsonc)` config file found, do you want to create one?";
 			if (await askConfirmation(confirmCreate)) {
 				await createWranglerConfigFile(projectOpts.sourceDir);

--- a/packages/cloudflare/src/cli/commands/utils/utils.spec.ts
+++ b/packages/cloudflare/src/cli/commands/utils/utils.spec.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { askConfirmation } from "../../utils/ask-confirmation.js";
 import { createOpenNextConfigFile, findOpenNextConfig } from "../../utils/create-open-next-config.js";
+import { isInteractive } from "../../utils/is-interactive.js";
 import { compileConfig } from "./utils.js";
 
 const { mockExistsSync } = vi.hoisted(() => ({
@@ -38,6 +39,12 @@ vi.mock("../../utils/ask-confirmation.js", () => ({
 	askConfirmation: vi.fn(),
 }));
 
+// Mock isInteractive — default to interactive (TTY) so existing tests
+// keep exercising the prompt branch. Non-interactive cases override it.
+vi.mock("../../utils/is-interactive.js", () => ({
+	isInteractive: vi.fn(() => true),
+}));
+
 // Mock create-config-files (unused import in utils.ts but required for module resolution)
 vi.mock("../../utils/create-config-files.js", () => ({
 	createOpenNextConfigIfNotExistent: vi.fn(),
@@ -66,6 +73,10 @@ vi.mock("@opennextjs/aws/build/helper.js", () => ({
 }));
 
 describe("compileConfig", () => {
+	beforeEach(() => {
+		vi.mocked(isInteractive).mockReturnValue(true);
+	});
+
 	it("should compile config when configPath is provided and file exists", async () => {
 		mockExistsSync.mockReturnValue(true);
 
@@ -122,5 +133,28 @@ describe("compileConfig", () => {
 
 		expect(askConfirmation).toHaveBeenCalledOnce();
 		expect(createOpenNextConfigFile).not.toHaveBeenCalled();
+	});
+
+	it("should throw a helpful error (without prompting) when no configPath found in a non-interactive environment", async () => {
+		vi.mocked(findOpenNextConfig).mockReturnValue(undefined);
+		vi.mocked(isInteractive).mockReturnValue(false);
+
+		await expect(compileConfig(undefined)).rejects.toThrowError(
+			/No `open-next\.config\.ts` file was found.*defineCloudflareConfig/s
+		);
+
+		expect(askConfirmation).not.toHaveBeenCalled();
+		expect(createOpenNextConfigFile).not.toHaveBeenCalled();
+	});
+
+	it("should still prompt in interactive environments", async () => {
+		vi.mocked(findOpenNextConfig).mockReturnValue(undefined);
+		vi.mocked(isInteractive).mockReturnValue(true);
+		vi.mocked(askConfirmation).mockResolvedValue(true);
+
+		await compileConfig(undefined);
+
+		expect(askConfirmation).toHaveBeenCalledOnce();
+		expect(createOpenNextConfigFile).toHaveBeenCalledOnce();
 	});
 });

--- a/packages/cloudflare/src/cli/commands/utils/utils.spec.ts
+++ b/packages/cloudflare/src/cli/commands/utils/utils.spec.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { askConfirmation } from "../../utils/ask-confirmation.js";
 import { createOpenNextConfigFile, findOpenNextConfig } from "../../utils/create-open-next-config.js";
-import { isInteractive } from "../../utils/is-interactive.js";
+import { isNonInteractiveOrCI } from "../../utils/is-interactive.js";
 import { compileConfig } from "./utils.js";
 
 const { mockExistsSync } = vi.hoisted(() => ({
@@ -21,12 +21,16 @@ vi.mock("@opennextjs/aws/logger.js", () => ({
 }));
 
 // Mock compileOpenNextConfig
-const mockCompileOpenNextConfig = vi.fn(async () => ({
-	config: { default: {} },
-	buildDir: "/build",
-}));
+const mockCompileOpenNextConfig = vi.fn(async (...args: [unknown, unknown]) => {
+	void args;
+
+	return {
+		config: { default: {} },
+		buildDir: "/build",
+	};
+});
 vi.mock("@opennextjs/aws/build/compileConfig.js", () => ({
-	compileOpenNextConfig: (...args: unknown[]) => mockCompileOpenNextConfig(...args),
+	compileOpenNextConfig: (...args: [unknown, unknown]) => mockCompileOpenNextConfig(...args),
 }));
 
 // Mock ensureCloudflareConfig
@@ -39,10 +43,9 @@ vi.mock("../../utils/ask-confirmation.js", () => ({
 	askConfirmation: vi.fn(),
 }));
 
-// Mock isInteractive — default to interactive (TTY) so existing tests
-// keep exercising the prompt branch. Non-interactive cases override it.
+// Mock CI/non-interactive detector — default to interactive local behavior.
 vi.mock("../../utils/is-interactive.js", () => ({
-	isInteractive: vi.fn(() => true),
+	isNonInteractiveOrCI: vi.fn(() => false),
 }));
 
 // Mock create-config-files (unused import in utils.ts but required for module resolution)
@@ -75,7 +78,7 @@ vi.mock("@opennextjs/aws/build/helper.js", () => ({
 
 describe("compileConfig", () => {
 	beforeEach(() => {
-		vi.mocked(isInteractive).mockReturnValue(true);
+		vi.mocked(isNonInteractiveOrCI).mockReturnValue(false);
 	});
 
 	it("should compile config when configPath is provided and file exists", async () => {
@@ -138,7 +141,7 @@ describe("compileConfig", () => {
 
 	it("should throw a helpful error (without prompting) when no configPath found in a non-interactive environment", async () => {
 		vi.mocked(findOpenNextConfig).mockReturnValue(undefined);
-		vi.mocked(isInteractive).mockReturnValue(false);
+		vi.mocked(isNonInteractiveOrCI).mockReturnValue(true);
 
 		await expect(compileConfig(undefined)).rejects.toThrowError(
 			/No `open-next\.config\.ts` file was found.*opennextjs-cloudflare migrate/s
@@ -150,7 +153,7 @@ describe("compileConfig", () => {
 
 	it("should still prompt in interactive environments", async () => {
 		vi.mocked(findOpenNextConfig).mockReturnValue(undefined);
-		vi.mocked(isInteractive).mockReturnValue(true);
+		vi.mocked(isNonInteractiveOrCI).mockReturnValue(false);
 		vi.mocked(askConfirmation).mockResolvedValue(true);
 
 		await compileConfig(undefined);

--- a/packages/cloudflare/src/cli/commands/utils/utils.spec.ts
+++ b/packages/cloudflare/src/cli/commands/utils/utils.spec.ts
@@ -54,6 +54,7 @@ vi.mock("../../utils/create-config-files.js", () => ({
 vi.mock("../../utils/create-open-next-config.js", () => ({
 	findOpenNextConfig: vi.fn(),
 	createOpenNextConfigFile: vi.fn(() => "/test/open-next.config.ts"),
+	OPEN_NEXT_CONFIG_FILE_NAME: "open-next.config.ts",
 }));
 
 // Mock wrangler
@@ -140,7 +141,7 @@ describe("compileConfig", () => {
 		vi.mocked(isInteractive).mockReturnValue(false);
 
 		await expect(compileConfig(undefined)).rejects.toThrowError(
-			/No `open-next\.config\.ts` file was found.*defineCloudflareConfig/s
+			/No `open-next\.config\.ts` file was found.*opennextjs-cloudflare migrate/s
 		);
 
 		expect(askConfirmation).not.toHaveBeenCalled();

--- a/packages/cloudflare/src/cli/commands/utils/utils.ts
+++ b/packages/cloudflare/src/cli/commands/utils/utils.ts
@@ -18,7 +18,7 @@ import {
 	findOpenNextConfig,
 	OPEN_NEXT_CONFIG_FILE_NAME,
 } from "../../utils/create-open-next-config.js";
-import { isInteractive } from "../../utils/is-interactive.js";
+import { isNonInteractiveOrCI } from "../../utils/is-interactive.js";
 
 export type WithWranglerArgs<T = unknown> = T & {
 	// Array of arguments that can be given to wrangler commands, including the `--config` and `--env` args.
@@ -66,12 +66,9 @@ export async function compileConfig(configPath: string | undefined) {
 		// In non-interactive environments (CI, Cloudflare Workers Builds,
 		// Docker, etc.) there is no TTY to answer a prompt — the build would
 		// hang or crash. Fail fast with an actionable message instead.
-		if (!isInteractive()) {
+		if (isNonInteractiveOrCI()) {
 			throw new Error(
-				`No \`${OPEN_NEXT_CONFIG_FILE_NAME}\` file was found in the project root.\n\n` +
-					"This file is required for OpenNext Cloudflare builds.\n" +
-					"Run `opennextjs-cloudflare migrate` to create it, or see https://opennext.js.org/cloudflare/get-started for setup guidance.\n" +
-					"Commit it and re-run the build."
+				`No \`${OPEN_NEXT_CONFIG_FILE_NAME}\` file was found in the project root.\n\nThis file is required for OpenNext Cloudflare builds.\nRun \`opennextjs-cloudflare migrate\` to create it, or see https://opennext.js.org/cloudflare/get-started for setup guidance.\nCommit it and re-run the build.`
 			);
 		}
 

--- a/packages/cloudflare/src/cli/commands/utils/utils.ts
+++ b/packages/cloudflare/src/cli/commands/utils/utils.ts
@@ -13,7 +13,11 @@ import type yargs from "yargs";
 import type { OpenNextConfig } from "../../../api/config.js";
 import { ensureCloudflareConfig } from "../../build/utils/ensure-cf-config.js";
 import { askConfirmation } from "../../utils/ask-confirmation.js";
-import { createOpenNextConfigFile, findOpenNextConfig } from "../../utils/create-open-next-config.js";
+import {
+	createOpenNextConfigFile,
+	findOpenNextConfig,
+	OPEN_NEXT_CONFIG_FILE_NAME,
+} from "../../utils/create-open-next-config.js";
 import { isInteractive } from "../../utils/is-interactive.js";
 
 export type WithWranglerArgs<T = unknown> = T & {
@@ -64,22 +68,19 @@ export async function compileConfig(configPath: string | undefined) {
 		// hang or crash. Fail fast with an actionable message instead.
 		if (!isInteractive()) {
 			throw new Error(
-				"No `open-next.config.ts` file was found in the project root.\n\n" +
-					"This file is required for OpenNext Cloudflare builds. Create it with:\n\n" +
-					"    import { defineCloudflareConfig } from '@opennextjs/cloudflare';\n" +
-					"\n" +
-					"    export default defineCloudflareConfig({});\n\n" +
-					"Commit it and re-run the build. (To create it interactively, run " +
-					"`opennextjs-cloudflare build` in a terminal with TTY access.)"
+				`No \`${OPEN_NEXT_CONFIG_FILE_NAME}\` file was found in the project root.\n\n` +
+					"This file is required for OpenNext Cloudflare builds.\n" +
+					"Run `opennextjs-cloudflare migrate` to create it, or see https://opennext.js.org/cloudflare/get-started for setup guidance.\n" +
+					"Commit it and re-run the build."
 			);
 		}
 
 		const answer = await askConfirmation(
-			"Missing required `open-next.config.ts` file, do you want to create one?"
+			`Missing required \`${OPEN_NEXT_CONFIG_FILE_NAME}\` file, do you want to create one?`
 		);
 
 		if (!answer) {
-			throw new Error("The `open-next.config.ts` file is required, aborting!");
+			throw new Error(`The \`${OPEN_NEXT_CONFIG_FILE_NAME}\` file is required, aborting!`);
 		}
 
 		configPath = createOpenNextConfigFile(nextAppDir, { cache: false });

--- a/packages/cloudflare/src/cli/commands/utils/utils.ts
+++ b/packages/cloudflare/src/cli/commands/utils/utils.ts
@@ -14,6 +14,7 @@ import type { OpenNextConfig } from "../../../api/config.js";
 import { ensureCloudflareConfig } from "../../build/utils/ensure-cf-config.js";
 import { askConfirmation } from "../../utils/ask-confirmation.js";
 import { createOpenNextConfigFile, findOpenNextConfig } from "../../utils/create-open-next-config.js";
+import { isInteractive } from "../../utils/is-interactive.js";
 
 export type WithWranglerArgs<T = unknown> = T & {
 	// Array of arguments that can be given to wrangler commands, including the `--config` and `--env` args.
@@ -58,6 +59,21 @@ export async function compileConfig(configPath: string | undefined) {
 	configPath ??= findOpenNextConfig(nextAppDir);
 
 	if (!configPath) {
+		// In non-interactive environments (CI, Cloudflare Workers Builds,
+		// Docker, etc.) there is no TTY to answer a prompt — the build would
+		// hang or crash. Fail fast with an actionable message instead.
+		if (!isInteractive()) {
+			throw new Error(
+				"No `open-next.config.ts` file was found in the project root.\n\n" +
+					"This file is required for OpenNext Cloudflare builds. Create it with:\n\n" +
+					"    import { defineCloudflareConfig } from '@opennextjs/cloudflare';\n" +
+					"\n" +
+					"    export default defineCloudflareConfig({});\n\n" +
+					"Commit it and re-run the build. (To create it interactively, run " +
+					"`opennextjs-cloudflare build` in a terminal with TTY access.)"
+			);
+		}
+
 		const answer = await askConfirmation(
 			"Missing required `open-next.config.ts` file, do you want to create one?"
 		);

--- a/packages/cloudflare/src/cli/utils/create-open-next-config.ts
+++ b/packages/cloudflare/src/cli/utils/create-open-next-config.ts
@@ -5,6 +5,8 @@ import { patchCode } from "@opennextjs/aws/build/patch/astCodePatcher.js";
 
 import { getPackageTemplatesDirPath } from "../../utils/get-package-templates-dir-path.js";
 
+export const OPEN_NEXT_CONFIG_FILE_NAME = "open-next.config.ts";
+
 /**
  * Finds the path to the OpenNext configuration file if it exists.
  *
@@ -12,7 +14,7 @@ import { getPackageTemplatesDirPath } from "../../utils/get-package-templates-di
  * @returns The full path to open-next.config.ts if it exists, undefined otherwise
  */
 export function findOpenNextConfig(appDir: string): string | undefined {
-	const openNextConfigPath = join(appDir, "open-next.config.ts");
+	const openNextConfigPath = join(appDir, OPEN_NEXT_CONFIG_FILE_NAME);
 
 	if (existsSync(openNextConfigPath)) {
 		return openNextConfigPath;
@@ -29,9 +31,9 @@ export function findOpenNextConfig(appDir: string): string | undefined {
  * @returns The path to the created configuration file
  */
 export function createOpenNextConfigFile(appDir: string, options: { cache: boolean }): string {
-	const openNextConfigPath = join(appDir, "open-next.config.ts");
+	const openNextConfigPath = join(appDir, OPEN_NEXT_CONFIG_FILE_NAME);
 
-	let content = readFileSync(join(getPackageTemplatesDirPath(), "open-next.config.ts"), "utf8");
+	let content = readFileSync(join(getPackageTemplatesDirPath(), OPEN_NEXT_CONFIG_FILE_NAME), "utf8");
 
 	if (!options.cache) {
 		content = patchCode(content, commentOutR2ImportRule);

--- a/packages/cloudflare/src/cli/utils/is-interactive.ts
+++ b/packages/cloudflare/src/cli/utils/is-interactive.ts
@@ -1,0 +1,11 @@
+/**
+ * Whether the current process is running in an interactive terminal.
+ *
+ * Used to gate prompts that would otherwise hang or error in non-TTY
+ * environments like CI, Docker builds, or Cloudflare Workers Builds.
+ *
+ * Matches the same check wrangler uses for its own interactive detection.
+ */
+export function isInteractive(): boolean {
+	return Boolean(process.stdin.isTTY && process.stdout.isTTY);
+}

--- a/packages/cloudflare/src/cli/utils/is-interactive.ts
+++ b/packages/cloudflare/src/cli/utils/is-interactive.ts
@@ -1,6 +1,15 @@
+import ci from "ci-info";
+
 /**
  * Whether the current process is running in an interactive terminal.
  */
 export function isInteractive(): boolean {
 	return Boolean(process.stdin.isTTY && process.stdout.isTTY);
+}
+
+/**
+ * Whether prompts should be suppressed.
+ */
+export function isNonInteractiveOrCI(): boolean {
+	return !isInteractive() || ci.isCI;
 }

--- a/packages/cloudflare/src/cli/utils/is-interactive.ts
+++ b/packages/cloudflare/src/cli/utils/is-interactive.ts
@@ -1,10 +1,5 @@
 /**
  * Whether the current process is running in an interactive terminal.
- *
- * Used to gate prompts that would otherwise hang or error in non-TTY
- * environments like CI, Docker builds, or Cloudflare Workers Builds.
- *
- * Matches the same check wrangler uses for its own interactive detection.
  */
 export function isInteractive(): boolean {
 	return Boolean(process.stdin.isTTY && process.stdout.isTTY);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1120,6 +1120,9 @@ importers:
       '@opennextjs/aws':
         specifier: 3.10.1
         version: 3.10.1(next@15.5.15(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+      ci-info:
+        specifier: ^4.2.0
+        version: 4.2.0
       cloudflare:
         specifier: ^4.4.1
         version: 4.4.1


### PR DESCRIPTION

## Problem

On Cloudflare Workers Builds (and any other non-TTY environment — Docker, GitHub Actions, etc.), `opennextjs-cloudflare build` crashes with a truncated interactive prompt and a cryptic exit code when `open-next.config.ts` is missing:

```text
? Missing required `open-next.config.ts` file, do you want to create one? (Y/n) ‣ true
 ELIFECYCLE  Command failed with exit code 13.
Failed: error occurred while running build command
```

[`compileConfig`](https://github.com/opennextjs/opennextjs-cloudflare/blob/main/packages/cloudflare/src/cli/commands/utils/utils.ts) unconditionally calls `askConfirmation` (backed by Enquirer). Enquirer needs a readable stdin — in CI it errors out immediately, the user sees a half-rendered prompt, and there's nothing in the message telling them what to do.

The same class of bug exists in [`buildCommand`](https://github.com/opennextjs/opennextjs-cloudflare/blob/main/packages/cloudflare/src/cli/commands/build.ts) for the missing-`wrangler.(toml|json|jsonc)` prompt. That path already has an escape hatch (`--skipWranglerConfigCheck` / `SKIP_WRANGLER_CONFIG_CHECK`), but users hit the prompt before they even know the flag exists.

## Fix

Introduces an `isInteractive()` helper that matches the TTY check wrangler itself uses (`process.stdin.isTTY && process.stdout.isTTY`, noted in a comment in [`run-wrangler.ts:120`](https://github.com/opennextjs/opennextjs-cloudflare/blob/main/packages/cloudflare/src/cli/commands/utils/run-wrangler.ts)) and gates both prompts behind it.

- **`compileConfig`** — in non-interactive mode, throws with the exact 3-line template the user needs to paste into `open-next.config.ts`. Zero-friction recovery.
- **`buildCommand`** — in non-interactive mode, the wrangler-config prompt throws with a message pointing at the existing `--skipWranglerConfigCheck` / `SKIP_WRANGLER_CONFIG_CHECK` escape hatch. No new flag.
- **Interactive behavior is unchanged** — if there's a TTY, you still get the prompt.

Chose *fail fast with instructions* over *auto-create the file silently in CI* because:

1. Auto-creating mutates project state the user never committed — the next local build hits the same error, creating a confusing dev/CI divergence.
2. A clear error is actionable. The error message ships the exact 3-line template, so "copy-paste-commit" is the whole recovery path.
3. It's the least surprising change to ship: no new behavior, no new flags, no new tests beyond the two that cover the new branch.

## Before / After

**Before** (non-TTY, missing `open-next.config.ts`):

```text
? Missing required `open-next.config.ts` file, do you want to create one? (Y/n) ‣ true
 ELIFECYCLE  Command failed with exit code 13.
```

**After** (non-TTY, missing `open-next.config.ts`):

```text
Error: No `open-next.config.ts` file was found in the project root.

This file is required for OpenNext Cloudflare builds. Create it with:

    import { defineCloudflareConfig } from '@opennextjs/cloudflare';

    export default defineCloudflareConfig({});

Commit it and re-run the build. (To create it interactively, run
`opennextjs-cloudflare build` in a terminal with TTY access.)

 ELIFECYCLE  Command failed with exit code 1.
```

## Testing

Extended `packages/cloudflare/src/cli/commands/utils/utils.spec.ts`:

- Mocked `isInteractive` with a `beforeEach` that resets it to `true` so existing tests continue to exercise the TTY branch unchanged.
- **New test**: asserts that in a non-interactive environment the non-TTY branch fires, `askConfirmation` is **not** called, `createOpenNextConfigFile` is **not** called, and the error body matches the template (regex-checks for both `No open-next.config.ts` and `defineCloudflareConfig`).
- **New test**: explicit regression check that the TTY branch still reaches `askConfirmation` and `createOpenNextConfigFile` in interactive mode.

```
 Test Files  1 passed (1)
 Tests       7 passed (7)
```

Prettier, ESLint, and `tsc --noEmit` all clean on the touched files.

### End-to-end repro

To reproduce end-to-end against a real build, scaffold a minimal Next.js 16 app (`next.config.ts` + `app/layout.tsx` + `app/page.tsx` + `wrangler.jsonc`, intentionally **no** `open-next.config.ts`), install this branch, and run:

```bash
pnpm opennextjs-cloudflare build < /dev/null   # redirect stdin from /dev/null to simulate non-TTY
```

Hits the new error path immediately with exit code 1. Dropping in the 3-line config from the error message and re-running unblocks the build past `compileConfig`. This matches the symptom in the issue originally reported against Cloudflare Workers Builds (#1198).

## Files Changed

| File | Change |
| --- | --- |
| `.changeset/fix-non-tty-config-prompts.md` | **New** — patch changeset |
| `packages/cloudflare/src/cli/utils/is-interactive.ts` | **New** — `isInteractive()` helper |
| `packages/cloudflare/src/cli/commands/utils/utils.ts` | Import helper, add non-interactive branch in `compileConfig` |
| `packages/cloudflare/src/cli/commands/build.ts` | Import helper, add non-interactive branch for wrangler-config prompt |
| `packages/cloudflare/src/cli/commands/utils/utils.spec.ts` | Mock `isInteractive`, add `beforeEach`, +2 test cases |

+93/-1, no new dependencies.

Fixes #1198.
