### PR TITLE
Reuse sharded tag data on regional cache fill

### DIFF
--- a/.changeset/green-zebras-know.md
+++ b/.changeset/green-zebras-know.md
@@ -1,0 +1,7 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+fix: reuse sharded tag data when filling the regional cache.
+
+The sharded tag cache miss path already reads tag data from the Durable Object before answering the request. Reuse that fetched data when populating the regional cache so a shard miss does not immediately trigger a second identical Durable Object read.

--- a/packages/cloudflare/src/api/overrides/tag-cache/do-sharded-tag-cache.spec.ts
+++ b/packages/cloudflare/src/api/overrides/tag-cache/do-sharded-tag-cache.spec.ts
@@ -269,6 +269,29 @@ describe("DOShardedTagCache", () => {
 			expect(cache.putToRegionalCache).toHaveBeenCalled();
 		});
 
+		it("should only read tag data once on a regional-cache miss", async () => {
+			const putMock = vi.fn();
+			// @ts-expect-error - Defined on cloudfare context
+			globalThis.caches = {
+				open: vi.fn().mockResolvedValue({
+					match: vi.fn().mockResolvedValue(null),
+					put: putMock,
+				}),
+			};
+			const cache = shardedDOTagCache({ baseShardSize: 4, regionalCache: true });
+			cache.getFromRegionalCache = vi.fn().mockResolvedValueOnce([]);
+			getTagDataMock.mockResolvedValueOnce({});
+
+			const result = await cache.hasBeenRevalidated(["tag1"], 123456);
+
+			expect(result).toBe(false);
+			expect(getTagDataMock).toHaveBeenCalledTimes(1);
+			expect(getTagDataMock).toHaveBeenCalledWith(["tag1"]);
+			expect(putMock).not.toHaveBeenCalled();
+			// @ts-expect-error - Defined on cloudfare context
+			globalThis.caches = undefined;
+		});
+
 		it("should call all the durable object instances", async () => {
 			const cache = shardedDOTagCache();
 			cache.getFromRegionalCache = vi.fn().mockResolvedValue([]);

--- a/packages/cloudflare/src/api/overrides/tag-cache/do-sharded-tag-cache.spec.ts
+++ b/packages/cloudflare/src/api/overrides/tag-cache/do-sharded-tag-cache.spec.ts
@@ -280,14 +280,20 @@ describe("DOShardedTagCache", () => {
 			};
 			const cache = shardedDOTagCache({ baseShardSize: 4, regionalCache: true });
 			cache.getFromRegionalCache = vi.fn().mockResolvedValueOnce([]);
-			getTagDataMock.mockResolvedValueOnce({});
+			getTagDataMock.mockResolvedValueOnce({
+				tag1: { revalidatedAt: 123455, stale: null, expire: null },
+			});
 
 			const result = await cache.hasBeenRevalidated(["tag1"], 123456);
 
 			expect(result).toBe(false);
 			expect(getTagDataMock).toHaveBeenCalledTimes(1);
 			expect(getTagDataMock).toHaveBeenCalledWith(["tag1"]);
-			expect(putMock).not.toHaveBeenCalled();
+			expect(putMock).toHaveBeenCalledTimes(1);
+			expect(putMock).toHaveBeenCalledWith(
+				"http://local.cache/shard/tag-hard;shard-1?tag=tag1",
+				expect.any(Response)
+			);
 			// @ts-expect-error - Defined on cloudfare context
 			globalThis.caches = undefined;
 		});

--- a/packages/cloudflare/src/api/overrides/tag-cache/do-sharded-tag-cache.ts
+++ b/packages/cloudflare/src/api/overrides/tag-cache/do-sharded-tag-cache.ts
@@ -322,12 +322,16 @@ class ShardedDOTagCache implements NextModeTagCache {
 		}
 	}
 
-	public async putToRegionalCache(optsKey: CacheTagKeyOptions, stub: DurableObjectStub<DOShardedTagCache>) {
+	public async putToRegionalCache(
+		optsKey: CacheTagKeyOptions,
+		stub: DurableObjectStub<DOShardedTagCache>,
+		prefetchedTagData?: Record<string, TagData>
+	) {
 		if (!this.opts.regionalCache) return;
 		const cache = await this.getCacheInstance();
 		if (!cache) return;
 		const tags = optsKey.tags;
-		const tagData = await stub.getTagData(tags);
+		const tagData = prefetchedTagData ?? (await stub.getTagData(tags));
 		await Promise.all(
 			tags.map(async (tag) => {
 				let data = tagData[tag];
@@ -451,7 +455,9 @@ class ShardedDOTagCache implements NextModeTagCache {
 					result.set(tag, tagData[tag] ?? null);
 				}
 
-				getCloudflareContext().ctx.waitUntil(this.putToRegionalCache({ doId, tags: remainingTags }, stub));
+				getCloudflareContext().ctx.waitUntil(
+					this.putToRegionalCache({ doId, tags: remainingTags }, stub, tagData)
+				);
 			})
 		);
 


### PR DESCRIPTION
## Summary
- reuse tag data already fetched on sharded tag-cache regional-cache misses instead of reading the Durable Object twice
- add a regression test that proves a shard miss only performs one `getTagData` read

## Verification
- `pnpm --filter cloudflare test -- packages/cloudflare/src/api/overrides/tag-cache/do-sharded-tag-cache.spec.ts`
- `pnpm --filter cloudflare ts:check`
