### PR TITLE
fix: narrow peerDependencies next range to exclude 16.0.0–16.2.2

### DIFF
--- a/.changeset/fix-peerdeps-next-range.md
+++ b/.changeset/fix-peerdeps-next-range.md
@@ -1,0 +1,9 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+fix: exclude unsupported Next.js 16 releases from peer dependencies.
+
+The previous range allowed Next.js 16.0.0 through 16.2.2 without a peer dependency warning because `>=16.2.3` was already covered by `>=15.5.15`.
+
+The range now explicitly supports Next.js 15.5.15 and above in the 15.x line, and Next.js 16.2.3 and above in the 16.x line.

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -86,7 +86,7 @@
 		"vitest": "catalog:"
 	},
 	"peerDependencies": {
-		"next": ">=15.5.15 || >=16.2.3",
+		"next": ">=15.5.15 <16 || >=16.2.3",
 		"wrangler": "catalog:"
 	}
 }


### PR DESCRIPTION
The previous range allowed Next.js 16.0.0 through 16.2.2 without a peer dependency warning because `>=16.2.3` was already covered by `>=15.5.15`.

The range now explicitly supports Next.js 15.5.15 and above in the 15.x line, and Next.js 16.2.3 and above in the 16.x line.

Closes #1202
