### PR TITLE
remove `process.version` override now that unenv#493 is merged

### DIFF
--- a/.changeset/every-animals-poke.md
+++ b/.changeset/every-animals-poke.md
@@ -1,0 +1,7 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+fix: remove process.version workaround
+
+Remove process.version / process.versions.node workaround now that [unjs/unenv#493](https://github.com/unjs/unenv/pull/493) is merged and shipped in [unenv@2.0.0-rc.16](https://github.com/unjs/unenv/releases/tag/v2.0.0-rc.16) (project uses 2.0.0-rc.24)

--- a/.changeset/every-animals-poke.md
+++ b/.changeset/every-animals-poke.md
@@ -2,6 +2,6 @@
 "@opennextjs/cloudflare": patch
 ---
 
-fix: remove process.version workaround
+remove `process.version` override
 
-Remove process.version / process.versions.node workaround now that [unjs/unenv#493](https://github.com/unjs/unenv/pull/493) is merged and shipped in [unenv@2.0.0-rc.16](https://github.com/unjs/unenv/releases/tag/v2.0.0-rc.16) (project uses 2.0.0-rc.24)
+Remove process.version / process.versions.node overrides now that [unjs/unenv#493](https://github.com/unjs/unenv/pull/493) is merged and shipped in [unenv@2.0.0-rc.16](https://github.com/unjs/unenv/releases/tag/v2.0.0-rc.16) (project uses 2.0.0-rc.24)

--- a/packages/cloudflare/src/cli/templates/init.ts
+++ b/packages/cloudflare/src/cli/templates/init.ts
@@ -53,12 +53,6 @@ function init(request: Request, env: CloudflareEnv) {
 }
 
 function initRuntime() {
-	// Some packages rely on `process.version` and `process.versions.node` (i.e. Jose@4)
-	// TODO: Remove when https://github.com/unjs/unenv/pull/493 is merged
-	Object.assign(process, { version: process.version || "v22.14.0" });
-	// @ts-expect-error Node type does not match workerd
-	Object.assign(process.versions, { node: "22.14.0", ...process.versions });
-
 	globalThis.__dirname ??= "";
 	globalThis.__filename ??= "";
 	// Some packages rely on `import.meta.url` but it is undefined in workerd


### PR DESCRIPTION
Remove process.version / process.versions.node workaround now that [unjs/unenv#493](https://github.com/unjs/unenv/pull/493) is merged and shipped in [unenv@2.0.0-rc.16](https://github.com/unjs/unenv/releases/tag/v2.0.0-rc.16) (project uses 2.0.0-rc.24)