### PR TITLE
fix(cloudflare): stop bundling @vercel/og when it is unused

### DIFF
--- a/.changeset/drop-unused-vercel-og.md
+++ b/.changeset/drop-unused-vercel-og.md
@@ -1,0 +1,9 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+Stop bundling `@vercel/og` (and its ~1.4 MiB `resvg.wasm`) when the app does not use it.
+
+Next.js's `externalImport` helper keeps a dynamic `import("next/dist/compiled/@vercel/og/index.edge.js")` in the emitted handler even for apps that never use `ImageResponse` / `opengraph-image`. Previously this module was marked as `external` when `useOg` was `false`, which left Wrangler to resolve and bundle it — pulling in ~800 KiB of JS plus `resvg.wasm` and pushing many Workers over the Cloudflare free-tier 3 MiB gzip limit.
+
+When `useOg` is `false`, the edge entry is now aliased to the existing `throw.js` shim, so the unreachable dynamic import resolves to a tiny module and the real `@vercel/og` library is no longer pulled into the Worker bundle.

--- a/packages/cloudflare/src/cli/build/bundle-server.ts
+++ b/packages/cloudflare/src/cli/build/bundle-server.ts
@@ -113,12 +113,20 @@ export async function bundleServer(buildOpts: BuildOptions, projectOpts: Project
 			// Apply updater updates, must be the last plugin
 			updater.plugin,
 		] as Plugin[],
-		external: [
-			"./middleware/handler.mjs",
-			// Do not bundle og when it is not used
-			...(useOg ? [] : ["next/dist/compiled/@vercel/og/index.edge.js"]),
-		],
+		external: ["./middleware/handler.mjs"],
 		alias: {
+			// When @vercel/og is not used, alias the edge entry to a throwing shim so the
+			// dynamic `import("next/dist/compiled/@vercel/og/index.edge.js")` call site
+			// emitted by Next.js does not drag the library (~800 KiB) and its
+			// `resvg.wasm` (~1.4 MiB) into the Worker bundle.
+			...(useOg
+				? {}
+				: {
+						"next/dist/compiled/@vercel/og/index.edge.js": path.join(
+							buildOpts.outputDir,
+							"cloudflare-templates/shims/throw.js"
+						),
+					}),
 			// Workers have `fetch` so the `node-fetch` polyfill is not needed
 			"next/dist/compiled/node-fetch": path.join(buildOpts.outputDir, "cloudflare-templates/shims/fetch.js"),
 			// Workers have builtin Web Sockets


### PR DESCRIPTION
Fixes #1220 (and the original #1211).

## Problem

Next.js's internal `externalImport` helper emits a dynamic

```js
import("next/dist/compiled/@vercel/og/index.edge.js")
```

into the app handler even for apps that never use `next/og` (`ImageResponse`, `opengraph-image`, `twitter-image`, …). Today, when `patchVercelOgLibrary` decides `useOg === false`, `bundle-server.ts` marks that module as `external`:

```ts
external: [
  "./middleware/handler.mjs",
  // Do not bundle og when it is not used
  ...(useOg ? [] : ["next/dist/compiled/@vercel/og/index.edge.js"]),
],
```

esbuild honors `external` and leaves the `import("…@vercel/og/index.edge.js")` call site intact. Wrangler then resolves that external module against `node_modules` and bundles:

- `@vercel/og` edge bundle (~800 KiB uncompressed / ~260 KiB gzip)
- `resvg.wasm` (~1.4 MiB)

…even though the code path is unreachable. For CSR-heavy apps that never use OG images this single dynamic import pushes the Worker over the **3 MiB** free-tier gzip limit.

Reproduced on a real Next 16 app with `@opennextjs/cloudflare@1.19.1` and `1.19.2`:

| build                              | `wrangler deploy --dry-run` |
|------------------------------------|-----------------------------|
| unpatched (`useOg=false`, external)| `14098.57 KiB / gzip 3119.42 KiB` ❌ |
| after this PR                      | `11875.51 KiB / gzip 2415.74 KiB` ✅ |

(The same savings were previously achievable only via a post-build regex script that rewrote the emitted handler.)

## Fix

When `useOg === false`, alias the edge entry to the existing `throw.js` shim instead of marking it external:

```ts
external: ["./middleware/handler.mjs"],
alias: {
  ...(useOg
    ? {}
    : {
        "next/dist/compiled/@vercel/og/index.edge.js": path.join(
          buildOpts.outputDir,
          "cloudflare-templates/shims/throw.js"
        ),
      }),
  // …
},
```

The unreachable dynamic import now resolves to a tiny `throw "OpenNext shim"` module, and Wrangler no longer drags the real `@vercel/og` library + `resvg.wasm` into the Worker bundle. If the dynamic import is ever executed at runtime (which would indicate a bug in `patchVercelOgLibrary`'s `useOg` detection), the shim throws immediately — the same failure mode users already get from `@ampproject/toolbox-optimizer` and other shimmed modules, rather than a silent runtime mismatch.

When `useOg === true` the behavior is unchanged: the real edge build is copied and patched by `patchVercelOgLibrary` as before.

## Why not a config flag?

The original issue proposed an opt-in flag (`cloudflare: { disableVercelOg: true }`), but the adapter already computes the exact signal it needs (`useOg`), so this can be done safely with no new config surface.

## Validation

- `pnpm --filter cloudflare test` — 31 files / 317 tests pass.
- `pnpm code:checks` (prettier + eslint + tsc) — clean.
- End-to-end: built a real app (Next 16.2.4, `app/` router, no `next/og`) against this fork, confirmed `handler.mjs` no longer contains `next/dist/compiled/@vercel/og/index.edge.js` and `wrangler deploy --dry-run` size dropped as shown above.

## Changeset

Included as a `patch` bump under `.changeset/drop-unused-vercel-og.md`.
