### PR TITLE
.editorconfig: add YAML file formatting rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,3 +4,7 @@ root = true
 [*]
 indent_style = tab
 end_of_line = lf
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
```editorconfig
[*.{yml,yaml}]
indent_style = space
indent_size = 2
```

Because YAML does not allow tab indents.