### PR TITLE
fix: add missing git ignored files for the migrate command

### DIFF
--- a/.changeset/stupid-gifts-stick.md
+++ b/.changeset/stupid-gifts-stick.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+fix: add missing git ignored files for the migrate command

--- a/packages/cloudflare/src/cli/commands/migrate.ts
+++ b/packages/cloudflare/src/cli/commands/migrate.ts
@@ -136,11 +136,9 @@ async function migrateCommand(args: { forceInstall: boolean }): Promise<void> {
 	} catch (error) {
 		logger.error("Failed to update package.json", (error as Error).message);
 		logger.warn(
-			"\nPlease ensure that your package.json contains the following scripts:\n" +
-				logger.warn(
-					[...Object.entries(openNextScripts)].map(([key, value]) => ` - ${key}: ${value}`).join("\n")
-				) +
-				"\n"
+			`Please ensure that your package.json contains the following scripts:
+				${[...Object.entries(openNextScripts)].map(([k, v]) => ` - ${k}: ${v}`).join("\n")}
+`
 		);
 	}
 

--- a/packages/cloudflare/src/cli/commands/migrate.ts
+++ b/packages/cloudflare/src/cli/commands/migrate.ts
@@ -154,6 +154,7 @@ async function migrateCommand(args: { forceInstall: boolean }): Promise<void> {
 # wrangler files
 .wrangler
 .dev.vars*
+!.dev.vars.example
 `,
 		{
 			appendIf: (content) => !content.includes(".open-next"),

--- a/packages/cloudflare/src/cli/commands/migrate.ts
+++ b/packages/cloudflare/src/cli/commands/migrate.ts
@@ -137,7 +137,7 @@ async function migrateCommand(args: { forceInstall: boolean }): Promise<void> {
 		logger.error("Failed to update package.json", (error as Error).message);
 		logger.warn(
 			`Please ensure that your package.json contains the following scripts:
-				${[...Object.entries(openNextScripts)].map(([k, v]) => ` - ${k}: ${v}`).join("\n")}
+${[...Object.entries(openNextScripts)].map(([k, v]) => ` - ${k}: ${v}`).join("\n")}
 `
 		);
 	}

--- a/packages/cloudflare/src/cli/commands/migrate.ts
+++ b/packages/cloudflare/src/cli/commands/migrate.ts
@@ -146,10 +146,20 @@ async function migrateCommand(args: { forceInstall: boolean }): Promise<void> {
 
 	const gitIgnoreExists = fs.existsSync(".gitignore");
 	printStepTitle(`${gitIgnoreExists ? "Updating" : "Creating"} .gitignore file`);
-	conditionalAppendFileSync(".gitignore", "# OpenNext\n.open-next\n", {
-		appendIf: (content) => !content.includes(".open-next"),
-		appendPrefix: "\n",
-	});
+	conditionalAppendFileSync(
+		".gitignore",
+		`# OpenNext
+.open-next
+
+# wrangler files
+.wrangler
+.dev.vars*
+`,
+		{
+			appendIf: (content) => !content.includes(".open-next"),
+			appendPrefix: "\n",
+		}
+	);
 
 	const nextConfig = findNextConfig({ appPath: projectDir });
 

--- a/packages/cloudflare/src/cli/commands/migrate.ts
+++ b/packages/cloudflare/src/cli/commands/migrate.ts
@@ -137,7 +137,7 @@ async function migrateCommand(args: { forceInstall: boolean }): Promise<void> {
 		logger.error("Failed to update package.json", (error as Error).message);
 		logger.warn(
 			"\nPlease ensure that your package.json contains the following scripts:\n" +
-				console.log(
+				logger.warn(
 					[...Object.entries(openNextScripts)].map(([key, value]) => ` - ${key}: ${value}`).join("\n")
 				) +
 				"\n"


### PR DESCRIPTION
We should also ignore `.wrangler` and `.dev.vars*` after a migration.

Edit: tested with the pre-relase, WAI:

<img width="333" height="278" alt="image" src="https://github.com/user-attachments/assets/bdf1e679-d746-4818-875d-5c4b7753cb67" />


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opennextjs/opennextjs-cloudflare/pull/1240" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
