### PR TITLE
fix: detect object-valued conditions

### DIFF
--- a/.changeset/stupid-ways-rush.md
+++ b/.changeset/stupid-ways-rush.md
@@ -1,0 +1,14 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+fix: detect object-valued conditions
+
+The pre-existing build condition transform logic had subtle errors:
+
+- failed to recognize object conditions
+  (e.g. "workerd": { "import": ..., "require": ... })
+- sibling pruning only applied to strings, not objects
+
+Now, we fully support object conditions. Furthermore, we prune siblings,
+unless its subtree also contains the build condition.

--- a/packages/cloudflare/src/cli/build/utils/workerd.spec.ts
+++ b/packages/cloudflare/src/cli/build/utils/workerd.spec.ts
@@ -191,6 +191,38 @@ describe("transformPackageJson", () => {
 		expect(hasBuildCondition).toBe(true);
 	});
 
+	// https://github.com/opennextjs/opennextjs-cloudflare/issues/1153
+	// Matches the exports field of pg-cloudflare@1.3.0.
+	test("exports with object-valued workerd condition (pg-cloudflare)", () => {
+		const json = {
+			name: "pg-cloudflare",
+			exports: {
+				".": {
+					workerd: {
+						import: "./esm/index.mjs",
+						require: "./dist/index.js",
+					},
+					default: "./dist/empty.js",
+				},
+				"./package.json": "./package.json",
+			},
+		};
+		const { transformed, hasBuildCondition } = transformPackageJson(json);
+		expect(transformed).toEqual({
+			name: "pg-cloudflare",
+			exports: {
+				".": {
+					workerd: {
+						import: "./esm/index.mjs",
+						require: "./dist/index.js",
+					},
+				},
+				"./package.json": "./package.json",
+			},
+		});
+		expect(hasBuildCondition).toBe(true);
+	});
+
 	test("exports and imports with workerd condition both nested and top level", () => {
 		const json = {
 			name: "test",

--- a/packages/cloudflare/src/cli/build/utils/workerd.spec.ts
+++ b/packages/cloudflare/src/cli/build/utils/workerd.spec.ts
@@ -59,10 +59,6 @@ describe("transformBuildCondition", () => {
 		expect(defaultExport.transformedExports).toEqual({
 			".": "/path/to/index.js",
 			"./server": {
-				"react-server": {
-					workerd: "./server.edge.js",
-					other: "./server.js",
-				},
 				default: "./server.js",
 			},
 		});
@@ -80,7 +76,7 @@ describe("transformBuildCondition", () => {
 		});
 	});
 
-	test("only consider leaves", () => {
+	test("object-valued condition", () => {
 		const exports = {
 			".": "/path/to/index.js",
 			"./server": {
@@ -92,7 +88,7 @@ describe("transformBuildCondition", () => {
 
 		const workerd = transformBuildCondition(exports, "workerd");
 
-		expect(workerd.hasBuildCondition).toBe(false);
+		expect(workerd.hasBuildCondition).toBe(true);
 		expect(workerd.transformedExports).toEqual({
 			".": "/path/to/index.js",
 			"./server": {
@@ -100,6 +96,25 @@ describe("transformBuildCondition", () => {
 					default: "./server.edge.js",
 				},
 			},
+		});
+	});
+
+	test("preserve sibling subtree that nests the condition", () => {
+		const exports = {
+			"react-server": {
+				workerd: "./rsc.edge.js",
+			},
+			workerd: "./top.edge.js",
+		};
+
+		const workerd = transformBuildCondition(exports, "workerd");
+
+		expect(workerd.hasBuildCondition).toBe(true);
+		expect(workerd.transformedExports).toEqual({
+			"react-server": {
+				workerd: "./rsc.edge.js",
+			},
+			workerd: "./top.edge.js",
 		});
 	});
 });

--- a/packages/cloudflare/src/cli/build/utils/workerd.ts
+++ b/packages/cloudflare/src/cli/build/utils/workerd.ts
@@ -23,9 +23,7 @@ export function transformBuildCondition(
 	hasBuildCondition: boolean;
 } {
 	const transformed: { [key: string]: unknown } = {};
-	const hasTopLevelBuildCondition = Object.keys(conditionMap).some(
-		(key) => key === condition && typeof conditionMap[key] === "string"
-	);
+	const hasTopLevelBuildCondition = condition in conditionMap && conditionMap[condition] != null;
 	let hasBuildCondition = hasTopLevelBuildCondition;
 	for (const [key, value] of Object.entries(conditionMap)) {
 		if (typeof value === "object" && value != null) {
@@ -33,17 +31,19 @@ export function transformBuildCondition(
 				value as { [key: string]: unknown },
 				condition
 			);
+
+			// If a build condition is present at this level but a sibling
+			// subtree doesn't contain the build condition, we can drop it entirely.
+			if (hasTopLevelBuildCondition && key !== condition && !innerBuildCondition) {
+				continue;
+			}
+
 			transformed[key] = transformedExports;
 			hasBuildCondition ||= innerBuildCondition;
-		} else {
-			// If it doesn't have the build condition, we need to keep everything as is
-			// If it has the build condition, we need to keep only the build condition
-			// and remove everything else
-			if (!hasTopLevelBuildCondition) {
-				transformed[key] = value;
-			} else if (key === condition) {
-				transformed[key] = value;
-			}
+		} else if (!hasTopLevelBuildCondition || key === condition) {
+			// If there is no build condition at this level or this is a non-object build condition,
+			// we need to keep the child condition as is.
+			transformed[key] = value;
 		}
 	}
 	return { transformedExports: transformed, hasBuildCondition };


### PR DESCRIPTION
The pre-existing build condition transform logic had subtle errors:

- failed to recognize object conditions (e.g. "workerd": { "import": ..., "require": ... })
- sibling pruning only applied to strings, not objects

Now, we fully support object conditions. Furthermore, we prune siblings, unless its subtree also contains the build condition.


This has an impact on the "nested" test. Now, when we prune for "default", we see that "react-server" has no "default" condition. Hence, we prune "react-server" entirely. (I think this is correct? but I'm not an expert).

This also flips the "only consider leaves" test.

The newly added test checks multiple conditions, where one subtree only contains the build condition at a deeper level.


This fixes #1153. Note pg-cloudflare's package.json:
```json
"exports": {
  ".": {
    "workerd": {
      "import": "./esm/index.mjs",
      "require": "./dist/index.js"
    },
    "default": "./dist/empty.js"
  },
  "./package.json": "./package.json"
},
```

The workerd condition is an object, not a string, which surfaces the issue. Now, it should copy the relevant workerd modules into the bundle.

I verified by applying (a slightly simplified version of) this patch to fix the error for myself. I also asked Claude to verify that the relevant workerd files were previously not copied, but now are successfully copied with this patch in the reproduction repo.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opennextjs/opennextjs-cloudflare/pull/1243" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
