### PR TITLE
fix: do not log expected expected D1 errors

### DIFF
--- a/.changeset/eleven-parents-send.md
+++ b/.changeset/eleven-parents-send.md
@@ -6,4 +6,4 @@ fix: do not log expected expected D1 errors
 
 The `populateCache` command adds columns to the D1 tag cache for SWR support.
 This is required for older deployments made before those column were added.
-SQLite errors when the columns exist and we should not lof those errors.
+SQLite errors when the columns exist and we should not log those errors.

--- a/.changeset/eleven-parents-send.md
+++ b/.changeset/eleven-parents-send.md
@@ -1,0 +1,9 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+fix: do not log expected expected D1 errors
+
+The `populateCache` command adds columns to the D1 tag cache for SWR support.
+This is required for older deployments made before those column were added.
+SQLite errors when the columns exist and we should not lof those errors.

--- a/packages/cloudflare/src/cli/commands/populate-cache.ts
+++ b/packages/cloudflare/src/cli/commands/populate-cache.ts
@@ -607,7 +607,8 @@ function populateD1TagCache(
 			target: populateCacheOptions.target,
 			environment: populateCacheOptions.environment,
 			configPath: populateCacheOptions.wranglerConfigPath,
-			logging: "error",
+			// Do not log errors since the ALTER TABLE command will fail if the columns already exist.
+			logging: "none",
 		}
 	);
 


### PR DESCRIPTION
A user reported this error on Discord:

```plain
Populating remote R2 incremental cache...
 ⛅️ wrangler 4.87.0
───────────────────
✘ [ERROR] You are logged in with an API Token. Unset the CLOUDFLARE_API_TOKEN in the environment to log in via OAuth.
🪵  Logs were written to "/root/.config/.wrangler/logs/wrangler-2026-05-02_02-38-22_506.log"
(node:2118) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
(Use `node --trace-deprecation ...` to show where the warning was created)
 25%|███████████                                  | 1/4 [00:00:<00:00:, 0.00it/s] 50%|██████████████████████                       | 2/4 [00:02:<00:02:, 0.99it/s] 75%|█████████████████████████████████            | 3/4 [00:02:<00:00:, 1.49it/s]100%|█████████████████████████████████████████████| 4/4 [00:02:<00:00:, 1.70it/s]
Successfully populated cache with 4 entries
Creating D1 table if necessary...
✘ [ERROR] A request to the Cloudflare API (/accounts/6b222270f00e0e9c6707c0016bb1c80c/d1/database/f5de6e68-6866-4615-a33a-86ddfa5aba14/query) failed.
  duplicate column name: stale: SQLITE_ERROR [code: 7500]
  
  If you think this is a bug, please open an issue at: https://github.com/cloudflare/workers-sdk/issues/new/choose
🪵  Logs were written to "/root/.config/.wrangler/logs/wrangler-2026-05-02_02-38-31_763.log"
 ⛅️ wrangler 4.87.0
───────────────────
Resource location: remote 
🌀 Executing on remote database NEXT_TAG_CACHE_D1 (f5de6e68-6866-4615-a33a-86ddfa5aba14):
🌀 To execute on your local development database, remove the --remote flag from your wrangler command.
Successfully created D1 table
```

As explained in the changelog, the error is expected when the column exists.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opennextjs/opennextjs-cloudflare/pull/1246" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->