### PR TITLE
refactor: only test prisma v7 with turbopack

### DIFF
--- a/examples/common/config-e2e.ts
+++ b/examples/common/config-e2e.ts
@@ -14,7 +14,7 @@ export function configurePlaywright(
 		multipleBrowsers = false,
 		// Whether to run tests in single file in parallel
 		parallel = true,
-		// Use the turbopack runtime
+		// Use the turbopack runtime (execute the `build:worker-turbopack` script instead of `build:worker`)
 		useTurbopack = false,
 	} = {}
 ) {

--- a/examples/prisma-7/e2e/playwright.turbopack.config.ts
+++ b/examples/prisma-7/e2e/playwright.turbopack.config.ts
@@ -1,3 +1,0 @@
-import { configurePlaywright } from "../../common/config-e2e";
-
-export default configurePlaywright("prisma-7", { useTurbopack: true });

--- a/examples/prisma-7/open-next.turbopack.config.ts
+++ b/examples/prisma-7/open-next.turbopack.config.ts
@@ -1,7 +1,0 @@
-import config from "./open-next.config.js";
-
-export default {
-	...config,
-	// Override the build command to use Turbopack
-	buildCommand: "next build --turbopack",
-};

--- a/examples/prisma-7/package.json
+++ b/examples/prisma-7/package.json
@@ -10,11 +10,9 @@
 		"lint": "next lint",
 		"prepare:db": "npx prisma generate && wrangler d1 execute db --file populate.sql",
 		"build:worker": "pnpm prepare:db && pnpm opennextjs-cloudflare build",
-		"build:worker-turbopack": "pnpm prepare:db && pnpm opennextjs-cloudflare build --openNextConfigPath open-next.turbopack.config.ts",
 		"preview:worker": "pnpm opennextjs-cloudflare preview",
 		"preview": "pnpm build:worker && pnpm preview:worker",
 		"e2e": "playwright test -c e2e/playwright.config.ts",
-		"e2e-turbopack": "playwright test -c e2e/playwright.turbopack.config.ts",
 		"e2e:dev": "playwright test -c e2e/playwright.dev.config.ts",
 		"cf-typegen": "wrangler types --env-interface CloudflareEnv"
 	},

--- a/examples/prisma-7/package.json
+++ b/examples/prisma-7/package.json
@@ -5,7 +5,7 @@
 	"type": "module",
 	"scripts": {
 		"dev": "next dev --turbopack",
-		"build": "next build",
+		"build": "next build --turbopack",
 		"start": "next start",
 		"lint": "next lint",
 		"prepare:db": "npx prisma generate && wrangler d1 execute db --file populate.sql",


### PR DESCRIPTION
The supposedly webpack e2e is actually also testing turbopack (it is the default when using `next build` without further option in Next 16).

This PR:
- makes it explicit that we use turbopack by using `next build --turbopack` (unchanged behavior)
- remove the "webpack" test that was actually testing turbopack
- cleanup unneeded files

/cc @tahmid-23 
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opennextjs/opennextjs-cloudflare/pull/1247" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->