### PR TITLE
bump the number of retries for r2 cache uploads

### DIFF
--- a/.changeset/poor-peaches-jump.md
+++ b/.changeset/poor-peaches-jump.md
@@ -3,3 +3,5 @@
 ---
 
 bump the number of retries for r2 cache uploads
+
+Increase the retry count from 5 to 15 with a capped exponential backoff to improve resilience against transient R2 write failures during cache population.

--- a/.changeset/poor-peaches-jump.md
+++ b/.changeset/poor-peaches-jump.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+bump the number of retries for r2 cache uploads

--- a/packages/cloudflare/src/cli/commands/populate-cache.spec.ts
+++ b/packages/cloudflare/src/cli/commands/populate-cache.spec.ts
@@ -10,7 +10,13 @@ import { unstable_startWorker } from "wrangler";
 import { defineCloudflareConfig } from "../../api/config.js";
 import r2IncrementalCache from "../../api/overrides/incremental-cache/r2-incremental-cache.js";
 import { ensureR2Bucket } from "../utils/ensure-r2-bucket.js";
-import { getCacheAssets, populateCache, PopulateCacheOptions } from "./populate-cache.js";
+import {
+	getCacheAssets,
+	MAX_REQUEST_RETRIES,
+	MAX_RETRY_DELAY_MS,
+	populateCache,
+	PopulateCacheOptions,
+} from "./populate-cache.js";
 import { WorkerEnvVar } from "./utils/helpers.js";
 
 describe("getCacheAssets", () => {
@@ -398,61 +404,54 @@ describe("populateCache", () => {
 			expect(mockWorkerDispose).toHaveBeenCalled();
 		});
 
-		test("exhausts all retries with exponential backoff for 5xx responses", async () => {
-			setupMockFileSystem();
-			vi.useFakeTimers();
+		test(
+			"exhausts all retries with exponential backoff for 5xx responses",
+			async () => {
+				setupMockFileSystem();
+				vi.useFakeTimers();
 
-			const mockWorkerDispose = vi.fn();
-			// @ts-expect-error - Mock unstable_startWorker to return a mock worker instance
-			vi.mocked(unstable_startWorker).mockResolvedValueOnce({
-				ready: Promise.resolve(),
-				url: Promise.resolve(new URL("http://localhost:12345")),
-				dispose: mockWorkerDispose,
-			});
+				const mockWorkerDispose = vi.fn();
+				// @ts-expect-error - Mock unstable_startWorker to return a mock worker instance
+				vi.mocked(unstable_startWorker).mockResolvedValueOnce({
+					ready: Promise.resolve(),
+					url: Promise.resolve(new URL("http://localhost:12345")),
+					dispose: mockWorkerDispose,
+				});
 
-			const fetchMock = vi.spyOn(global, "fetch").mockImplementation(async (_input, init) => {
-				if (init?.body instanceof ReadableStream) {
-					await init.body.cancel();
-				}
-
-				return new Response(
-					JSON.stringify({ success: false, error: "R2 storage error", code: "ERR_WRITE_FAILED" }),
-					{
-						status: 500,
-						headers: { "Content-Type": "application/json" },
+				const fetchMock = vi.spyOn(global, "fetch").mockImplementation(async (_input, init) => {
+					if (init?.body instanceof ReadableStream) {
+						await init.body.cancel();
 					}
+
+					return new Response(
+						JSON.stringify({ success: false, error: "R2 storage error", code: "ERR_WRITE_FAILED" }),
+						{
+							status: 500,
+							headers: { "Content-Type": "application/json" },
+						}
+					);
+				});
+
+				const result = populateCache(
+					buildOptions,
+					config,
+					wranglerConfig,
+					{ target: "local", shouldUsePreviewId: false },
+					envVars
 				);
-			});
 
-			const result = populateCache(
-				buildOptions,
-				config,
-				wranglerConfig,
-				{ target: "local", shouldUsePreviewId: false },
-				envVars
-			);
+				await vi.advanceTimersByTimeAsync(MAX_REQUEST_RETRIES * MAX_RETRY_DELAY_MS);
 
-			await vi.waitFor(() => {
-				expect(fetchMock).toHaveBeenCalledTimes(1);
-			});
+				await expect(result).rejects.toThrow(
+					new RegExp(
+						`Failed to populate the local R2 cache: Failed to write "incremental-cache\\/buildID\\/[A-Za-z0-9]+\\.cache" to R2 after ${MAX_REQUEST_RETRIES} attempts`
+					)
+				);
 
-			await vi.advanceTimersByTimeAsync(249);
-			expect(fetchMock).toHaveBeenCalledTimes(1);
-
-			await vi.advanceTimersByTimeAsync(1);
-
-			await vi.waitFor(() => {
-				expect(fetchMock).toHaveBeenCalledTimes(2);
-			});
-
-			await vi.advanceTimersByTimeAsync(500 + 1000 + 2000);
-
-			await expect(result).rejects.toThrow(
-				/Failed to populate the local R2 cache: Failed to write "incremental-cache\/buildID\/[A-Za-z0-9]+.cache" to R2 after 5 attempts/
-			);
-
-			expect(fetchMock).toHaveBeenCalledTimes(5);
-			expect(mockWorkerDispose).toHaveBeenCalled();
-		});
+				expect(fetchMock).toHaveBeenCalledTimes(MAX_REQUEST_RETRIES);
+				expect(mockWorkerDispose).toHaveBeenCalled();
+			},
+			/* timeout ms */ MAX_REQUEST_RETRIES * MAX_RETRY_DELAY_MS + 1_000
+		);
 	});
 });

--- a/packages/cloudflare/src/cli/commands/populate-cache.spec.ts
+++ b/packages/cloudflare/src/cli/commands/populate-cache.spec.ts
@@ -81,6 +81,19 @@ describe("getCacheAssets", () => {
 	});
 });
 
+// Mock `node:timers/promises` so that `setTimeout` delegates to `globalThis.setTimeout`,
+// which is correctly intercepted by `vi.useFakeTimers()`. Without this, the destructured
+// import in the source code holds a reference to the original native `setTimeout`, making
+// `vi.advanceTimersByTimeAsync()` ineffective and causing tests to wait real wall-clock time.
+vi.mock("node:timers/promises", async (importOriginal) => {
+	const original = await importOriginal<typeof import("node:timers/promises")>();
+	return {
+		...original,
+		setTimeout: (ms: number, value?: unknown) =>
+			new Promise((resolve) => globalThis.setTimeout(() => resolve(value), ms)),
+	};
+});
+
 vi.mock("./utils/run-wrangler.js", () => ({
 	runWrangler: vi.fn(() => ({ success: true, stdout: "", stderr: "" })),
 }));
@@ -404,54 +417,51 @@ describe("populateCache", () => {
 			expect(mockWorkerDispose).toHaveBeenCalled();
 		});
 
-		test(
-			"exhausts all retries with exponential backoff for 5xx responses",
-			async () => {
-				setupMockFileSystem();
-				vi.useFakeTimers();
+		test("exhausts all retries with exponential backoff for 5xx responses", async () => {
+			setupMockFileSystem();
+			vi.useFakeTimers();
 
-				const mockWorkerDispose = vi.fn();
-				// @ts-expect-error - Mock unstable_startWorker to return a mock worker instance
-				vi.mocked(unstable_startWorker).mockResolvedValueOnce({
-					ready: Promise.resolve(),
-					url: Promise.resolve(new URL("http://localhost:12345")),
-					dispose: mockWorkerDispose,
-				});
+			const mockWorkerDispose = vi.fn();
+			// @ts-expect-error - Mock unstable_startWorker to return a mock worker instance
+			vi.mocked(unstable_startWorker).mockResolvedValueOnce({
+				ready: Promise.resolve(),
+				url: Promise.resolve(new URL("http://localhost:12345")),
+				dispose: mockWorkerDispose,
+			});
 
-				const fetchMock = vi.spyOn(global, "fetch").mockImplementation(async (_input, init) => {
-					if (init?.body instanceof ReadableStream) {
-						await init.body.cancel();
+			const fetchMock = vi.spyOn(global, "fetch").mockImplementation(async (_input, init) => {
+				if (init?.body instanceof ReadableStream) {
+					await init.body.cancel();
+				}
+
+				return new Response(
+					JSON.stringify({ success: false, error: "R2 storage error", code: "ERR_WRITE_FAILED" }),
+					{
+						status: 500,
+						headers: { "Content-Type": "application/json" },
 					}
-
-					return new Response(
-						JSON.stringify({ success: false, error: "R2 storage error", code: "ERR_WRITE_FAILED" }),
-						{
-							status: 500,
-							headers: { "Content-Type": "application/json" },
-						}
-					);
-				});
-
-				const result = populateCache(
-					buildOptions,
-					config,
-					wranglerConfig,
-					{ target: "local", shouldUsePreviewId: false },
-					envVars
 				);
+			});
 
-				await vi.advanceTimersByTimeAsync(MAX_REQUEST_RETRIES * MAX_RETRY_DELAY_MS);
+			const result = populateCache(
+				buildOptions,
+				config,
+				wranglerConfig,
+				{ target: "local", shouldUsePreviewId: false },
+				envVars
+			);
 
-				await expect(result).rejects.toThrow(
-					new RegExp(
-						`Failed to populate the local R2 cache: Failed to write "incremental-cache\\/buildID\\/[A-Za-z0-9]+\\.cache" to R2 after ${MAX_REQUEST_RETRIES} attempts`
-					)
-				);
+			const resultExpectation = expect(result).rejects.toThrow(
+				new RegExp(
+					`Failed to populate the local R2 cache: Failed to write "incremental-cache\\/buildID\\/[A-Za-z0-9]+\\.cache" to R2 after ${MAX_REQUEST_RETRIES} attempts`
+				)
+			);
 
-				expect(fetchMock).toHaveBeenCalledTimes(MAX_REQUEST_RETRIES);
-				expect(mockWorkerDispose).toHaveBeenCalled();
-			},
-			/* timeout ms */ MAX_REQUEST_RETRIES * MAX_RETRY_DELAY_MS + 1_000
-		);
+			await vi.advanceTimersByTimeAsync(MAX_REQUEST_RETRIES * MAX_RETRY_DELAY_MS);
+			await resultExpectation;
+
+			expect(fetchMock).toHaveBeenCalledTimes(MAX_REQUEST_RETRIES);
+			expect(mockWorkerDispose).toHaveBeenCalled();
+		});
 	});
 });

--- a/packages/cloudflare/src/cli/commands/populate-cache.ts
+++ b/packages/cloudflare/src/cli/commands/populate-cache.ts
@@ -56,6 +56,15 @@ import {
 	withWranglerPassthroughArgs,
 } from "./utils/utils.js";
 
+// Maximum number of attempts to send the request
+export const MAX_REQUEST_RETRIES = 15;
+// Base delay for retries
+export const BASE_RETRY_DELAY_MS = 250;
+// Maximum delay for retries, used to calculate the backoff factor
+export const MAX_RETRY_DELAY_MS = 10_000;
+// Backoff factor for retries, calculated to ensure that the delay grows exponentially up to the maximum delay
+export const BACKOFF_FACTOR = (MAX_RETRY_DELAY_MS / BASE_RETRY_DELAY_MS) ** (1 / (MAX_REQUEST_RETRIES - 1));
+
 /**
  * Implementation of the `opennextjs-cloudflare populateCache` command.
  *
@@ -324,14 +333,11 @@ async function populateR2IncrementalCache(
 /**
  * Sends cache entries to the R2 worker, one entry per request.
  *
- * Up to `concurrency` requests are in-flight at any given time.
- * Retry logic for transient R2 write failures is handled by the worker.
- *
  * @param options
  * @param options.workerUrl - The URL of the local R2 worker's `/populate` endpoint.
  * @param options.assets - The cache assets to write, as collected by {@link getCacheAssets}.
  * @param options.prefix - Optional prefix prepended to each R2 key.
- * @param options.concurrency - Maximum number of concurrent in-flight requests.
+ * @param options.maxConcurrency - Maximum number of concurrent in-flight requests.
  * @returns Resolves when all entries have been written successfully.
  * @throws {Error} If any entry fails after all retries or encounters a non-retryable error.
  */
@@ -343,41 +349,26 @@ async function sendEntriesToR2Worker(options: {
 }): Promise<void> {
 	const { workerUrl, assets, prefix, maxConcurrency } = options;
 
-	// Build the list of entries to send (key + filename).
-	// File contents are read lazily in sendEntryToR2Worker to avoid
-	// loading all cache values into memory at once.
-	const entries = assets.map(({ fullPath, key, buildId, isFetch }) => ({
-		key: computeCacheKey(key, {
-			prefix,
-			buildId,
-			cacheType: isFetch ? "fetch" : "cache",
-		}),
-		filename: fullPath,
-	}));
-
-	// Use a concurrency-limited loop with a progress bar.
-	// `pending` tracks in-flight promises so we can cap concurrency.
 	const pending = new Set<Promise<void>>();
 
-	let concurrency = 1;
+	for (const asset of tqdm(assets)) {
+		const { fullPath, key, buildId, isFetch } = asset;
 
-	for (const entry of tqdm(entries)) {
 		const task = sendEntryToR2Worker({
 			workerUrl,
-			key: entry.key,
-			filename: entry.filename,
+			key: computeCacheKey(key, {
+				prefix,
+				buildId,
+				cacheType: isFetch ? "fetch" : "cache",
+			}),
+			filename: fullPath,
 		}).finally(() => pending.delete(task));
 
 		pending.add(task);
 
 		// If we've reached the concurrency limit, wait for one to finish.
-		if (pending.size >= concurrency) {
+		if (pending.size >= maxConcurrency) {
 			await Promise.race(pending);
-			// Increase concurrency gradually to avoid overwhelming the worker
-			// with too many requests at once.
-			if (concurrency < maxConcurrency) {
-				concurrency++;
-			}
 		}
 	}
 
@@ -404,10 +395,7 @@ async function sendEntryToR2Worker(options: {
 }): Promise<void> {
 	const { workerUrl, key, filename } = options;
 
-	const CLIENT_RETRY_ATTEMPTS = 5;
-	const CLIENT_RETRY_BASE_DELAY_MS = 250;
-
-	for (let attempt = 0; attempt < CLIENT_RETRY_ATTEMPTS; attempt++) {
+	for (let attempt = 0; attempt < MAX_REQUEST_RETRIES; attempt++) {
 		try {
 			let response: Response;
 
@@ -426,9 +414,7 @@ async function sendEntryToR2Worker(options: {
 			} catch (e) {
 				throw new RetryableWorkerError(
 					`Failed to send request to R2 worker: ${e instanceof Error ? e.message : String(e)}`,
-					{
-						cause: e,
-					}
+					{ cause: e }
 				);
 			}
 
@@ -438,6 +424,7 @@ async function sendEntryToR2Worker(options: {
 			try {
 				result = JSON.parse(body) as R2Response;
 			} catch (e) {
+				// https://developers.cloudflare.com/support/troubleshooting/http-status-codes/cloudflare-1xxx-errors/error-1102
 				if (body.includes("Worker exceeded resource limits")) {
 					throw new RetryableWorkerError("Worker exceeded resource limits", { cause: e });
 				}
@@ -454,25 +441,23 @@ async function sendEntryToR2Worker(options: {
 				});
 			}
 
-			if (!result.success && response.status >= 500) {
-				throw new RetryableWorkerError(result.error);
-			}
-
 			if (!result.success) {
-				throw new Error(`Failed to write "${key}" to R2: ${result.error}`);
+				throw response.status >= 500
+					? new RetryableWorkerError(result.error)
+					: new Error(`Failed to write "${key}" to R2: ${result.error}`);
 			}
 
 			return;
 		} catch (e) {
-			if (e instanceof RetryableWorkerError && attempt < CLIENT_RETRY_ATTEMPTS - 1) {
+			if (e instanceof RetryableWorkerError && attempt < MAX_REQUEST_RETRIES - 1) {
 				logger.error(
 					`Attempt ${attempt + 1} to write "${key}" failed with a retryable error: ${e.message}. Retrying...`
 				);
-				await setTimeout(CLIENT_RETRY_BASE_DELAY_MS * Math.pow(2, attempt));
+				await setTimeout(BASE_RETRY_DELAY_MS * Math.pow(BACKOFF_FACTOR, attempt));
 				continue;
 			}
 
-			throw new Error(`Failed to write "${key}" to R2 after ${CLIENT_RETRY_ATTEMPTS} attempts`, {
+			throw new Error(`Failed to write "${key}" to R2 after ${MAX_REQUEST_RETRIES} attempts`, {
 				cause: e,
 			});
 		}


### PR DESCRIPTION
- Bump the max number of retries for R2 upload from 5 to 15
- Start at full speed - I couldn't reproduce any failure with the increase of the concurrency over time. It simplifies the code.

Note that the `BACKOFF_FACTOR` is now compute to respect a `MAX_RETRY_DELAY_MS`.

Also misc minor cleanup.

I think that https://github.com/opennextjs/opennextjs-cloudflare/issues/1173 and #1175 will no more be needed after this is merged.

Validated by uploading 100k assets to R2 (took about 20min from my local computer)

<!-- devin-review-badge-begin -->



---

<a href="https://app.devin.ai/review/opennextjs/opennextjs-cloudflare/pull/1252" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->