### PR TITLE
Allow populating R2 when the domain is protected by Cloudflare Access

### DIFF
--- a/.changeset/public-poems-heal.md
+++ b/.changeset/public-poems-heal.md
@@ -1,0 +1,11 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+Allow populating R2 when the domain is protected by Cloudflare Access
+
+You need to:
+
+- create a "Service Auth" policy for "open-next-cache-populate.<account>.workers.dev"
+- add an "Include" rule for "Any Access Service Token" or for a given service token ("Service Token")
+- populate the env variables CLOUDFLARE_ACCESS_CLIENT_ID and CLOUDFLARE_ACCESS_CLIENT_SECRET

--- a/packages/cloudflare/src/cli/commands/populate-cache.ts
+++ b/packages/cloudflare/src/cli/commands/populate-cache.ts
@@ -414,7 +414,7 @@ async function sendEntryToR2Worker(options: {
 						...(process.env.CLOUDFLARE_ACCESS_CLIENT_ID && process.env.CLOUDFLARE_ACCESS_CLIENT_SECRET
 							? {
 									"CF-Access-Client-Id": process.env.CLOUDFLARE_ACCESS_CLIENT_ID,
-									"CF-Access-Client-Secret": process.env.v,
+									"CF-Access-Client-Secret": process.env.CLOUDFLARE_ACCESS_CLIENT_SECRET,
 								}
 							: {}),
 					},

--- a/packages/cloudflare/src/cli/commands/populate-cache.ts
+++ b/packages/cloudflare/src/cli/commands/populate-cache.ts
@@ -405,6 +405,18 @@ async function sendEntryToR2Worker(options: {
 					headers: {
 						"x-opennext-cache-key": key,
 						"content-length": fs.statSync(filename).size.toString(),
+						// Include Access Client ID and Secret if they are set in the environment,
+						// to allow the worker to authenticate with the Cloudflare API when writing to R2.
+						//
+						// The Application at "open-next-cache-populate.<account>.workers.dev" should have a policy with:
+						// - "Action" set to "Service Auth"
+						// - "Any Access Service Token" or "Service Token" + a specific service token
+						...(process.env.CLOUDFLARE_ACCESS_CLIENT_ID && process.env.CLOUDFLARE_ACCESS_CLIENT_SECRET
+							? {
+									"CF-Access-Client-Id": process.env.CLOUDFLARE_ACCESS_CLIENT_ID,
+									"CF-Access-Client-Secret": process.env.v,
+								}
+							: {}),
 					},
 					body: Readable.toWeb(fs.createReadStream(filename)) as unknown as ReadableStream,
 					signal: AbortSignal.timeout(60_000),


### PR DESCRIPTION
fixes #1171

You need to:

- create a "Service Auth" policy for "open-next-cache-populate.\<account\>.workers.dev"
- add an "Include" rule for "Any Access Service Token" or for a given service token ("Service Token")
- populate the env variables CLOUDFLARE_ACCESS_CLIENT_ID and CLOUDFLARE_ACCESS_CLIENT_SECRET
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opennextjs/opennextjs-cloudflare/pull/1261" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->