### PR TITLE
Add Next.js 16.2.x compatibility patches (perf_hooks shim, fast-set-immediate shim, Turbopack handler delegation)

### DIFF
--- a/.changeset/next-16-2-compat.md
+++ b/.changeset/next-16-2-compat.md
@@ -1,0 +1,11 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+Add Next.js 16.2.x compatibility patches
+
+- **`perf_hooks` shim**: Next 16.2.x's `gc-observer` and `@vercel/otel` import `PerformanceObserver` / `performance` from `node:perf_hooks`, which Cloudflare Workers does not expose. A new shim re-exports `globalThis.performance` and provides a no-op `PerformanceObserver`, resolved via a new `shimNodeModules` onResolve plugin.
+- **`fast-set-immediate` shim**: Next 16.2's app-render scheduler imports `next/dist/server/node-environment-extensions/fast-set-immediate.external`, whose `install()` mutates the frozen `node:timers` module on load and throws "Cannot assign to read only property 'setImmediate'". A shim replaces the module with no-op control functions; the scheduler optimization is not needed in Workers. The bundle banner also exposes `AsyncLocalStorage` on `globalThis` so Next's check picks up the real implementation rather than the throwing fallback.
+- **`patchPageExports` plugin**: Next 16.2.x Turbopack templates set `handler` on a child module via `esmExport(bindings, childId)` then re-call `esmExport` for the entry id. Each page chunk's `module.exports = R.m(<entryId>).exports` then lacks `handler`, causing "ComponentMod.handler is not a function" on every app route. A new build-time plugin scans the SSR template chunks to discover entry→child mappings and rewrites each page.js / route.js terminator to merge the child's own-property descriptors over the entry's, exposing `handler` without touching the Turbopack runtime.
+
+Related: #1258

--- a/packages/cloudflare/src/cli/build/bundle-server.ts
+++ b/packages/cloudflare/src/cli/build/bundle-server.ts
@@ -22,6 +22,7 @@ import { patchResolveCache, patchSetWorkingDirectory } from "./patches/plugins/o
 import { handleOptionalDependencies } from "./patches/plugins/optional-deps.js";
 import { patchPagesRouterContext } from "./patches/plugins/pages-router-context.js";
 import { patchDepdDeprecations } from "./patches/plugins/patch-depd-deprecations.js";
+import { patchPageExports } from "./patches/plugins/patch-page-exports.js";
 import { fixRequire } from "./patches/plugins/require.js";
 import { shimRequireHook } from "./patches/plugins/require-hook.js";
 import { patchRouteModules } from "./patches/plugins/route-module.js";
@@ -113,6 +114,7 @@ export async function bundleServer(buildOpts: BuildOptions, projectOpts: Project
 			inlineFindDir(updater, buildOpts),
 			inlineLoadManifest(updater, buildOpts),
 			patchNextServer(updater, buildOpts),
+			patchPageExports(updater, buildOpts),
 			patchRouteModules(updater, buildOpts),
 			patchDepdDeprecations(updater),
 			patchResolveCache(updater, buildOpts),

--- a/packages/cloudflare/src/cli/build/bundle-server.ts
+++ b/packages/cloudflare/src/cli/build/bundle-server.ts
@@ -25,6 +25,7 @@ import { patchDepdDeprecations } from "./patches/plugins/patch-depd-deprecations
 import { fixRequire } from "./patches/plugins/require.js";
 import { shimRequireHook } from "./patches/plugins/require-hook.js";
 import { patchRouteModules } from "./patches/plugins/route-module.js";
+import { shimNodeModules } from "./patches/plugins/shim-node-modules.js";
 import { shimReact } from "./patches/plugins/shim-react.js";
 import { setWranglerExternal } from "./patches/plugins/wrangler-external.js";
 import { copyPackageCliFiles } from "./utils/copy-package-cli-files.js";
@@ -100,6 +101,9 @@ export async function bundleServer(buildOpts: BuildOptions, projectOpts: Project
 			inlineDynamicRequires(updater, buildOpts),
 			setWranglerExternal(),
 			fixRequire(updater),
+			// Must run before handleOptionalDependencies so node:perf_hooks is redirected
+			// to the shim before esbuild's platform:"node" logic marks it as external.
+			shimNodeModules(path.join(buildOpts.outputDir, "cloudflare-templates/shims/perf-hooks.js")),
 			handleOptionalDependencies(optionalDependencies),
 			patchInstrumentation(updater, buildOpts),
 			patchPagesRouterContext(buildOpts),

--- a/packages/cloudflare/src/cli/build/bundle-server.ts
+++ b/packages/cloudflare/src/cli/build/bundle-server.ts
@@ -103,7 +103,10 @@ export async function bundleServer(buildOpts: BuildOptions, projectOpts: Project
 			fixRequire(updater),
 			// Must run before handleOptionalDependencies so node:perf_hooks is redirected
 			// to the shim before esbuild's platform:"node" logic marks it as external.
-			shimNodeModules(path.join(buildOpts.outputDir, "cloudflare-templates/shims/perf-hooks.js")),
+			shimNodeModules(
+				path.join(buildOpts.outputDir, "cloudflare-templates/shims/perf-hooks.js"),
+				path.join(buildOpts.outputDir, "cloudflare-templates/shims/fast-set-immediate.js")
+			),
 			handleOptionalDependencies(optionalDependencies),
 			patchInstrumentation(updater, buildOpts),
 			patchPagesRouterContext(buildOpts),
@@ -173,7 +176,15 @@ export async function bundleServer(buildOpts: BuildOptions, projectOpts: Project
 		banner: {
 			// We need to import them here, assigning them to `globalThis` does not work because node:timers use `globalThis` and thus create an infinite loop
 			// See https://github.com/cloudflare/workerd/blob/d6a764c/src/node/internal/internal_timers.ts#L56-L70
-			js: `import {setInterval, clearInterval, setTimeout, clearTimeout} from "node:timers"`,
+			// AsyncLocalStorage is exposed on globalThis so that Next.js's async-local-storage.js check
+			// `globalThis.AsyncLocalStorage` succeeds in Workers. Without this, createAsyncLocalStorage()
+			// returns a FakeAsyncLocalStorage that throws on .run()/.exit(), which cascades into a
+			// "Cannot read properties of undefined (reading 'require')" crash when loading
+			// app-page-turbo.runtime.prod.js as a Turbopack external in Next.js 16.2.x.
+			js: [
+				`import {setInterval, clearInterval, setTimeout, clearTimeout} from "node:timers";`,
+				`import {AsyncLocalStorage} from "node:async_hooks"; globalThis.AsyncLocalStorage = AsyncLocalStorage;`,
+			].join(""),
 		},
 		platform: "node",
 	});

--- a/packages/cloudflare/src/cli/build/patches/plugins/patch-page-exports.spec.ts
+++ b/packages/cloudflare/src/cli/build/patches/plugins/patch-page-exports.spec.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "vitest";
+
+import { parseEntryChildFromChunk, transformPageJs } from "./patch-page-exports.js";
+
+describe("parseEntryChildFromChunk", () => {
+	test("extracts entryId and childId from an app-page template chunk", () => {
+		// Realistic shape: a template chunk wraps the entry module factory and
+		// inside its body calls `a.s([...,"handler",...], <childId>)` to vendor
+		// the handler onto a child module before re-emitting bindings for the
+		// entry's own id.
+		const content = `
+"use strict";(()=>{
+  var a={};
+  module.exports=[77553,a=>{a.s([ClientPageRoot,Bar,...], 77553)}];
+  a.s(["handler","workAsyncStorage","workUnitAsyncStorage","serverHooks","patchFetch","tree","html","pages","routeModule"], 6473);
+})();
+`;
+
+		expect(parseEntryChildFromChunk(content)).toEqual({ entryId: "77553", childId: "6473" });
+	});
+
+	test("returns null when the entry module id is missing", () => {
+		const content = `a.s(["handler","tree"], 6473);`;
+		expect(parseEntryChildFromChunk(content)).toBeNull();
+	});
+
+	test("returns null when no handler delegation is present", () => {
+		const content = `module.exports=[77553,a=>{a.s([Foo], 77553)}];`;
+		expect(parseEntryChildFromChunk(content)).toBeNull();
+	});
+
+	test("returns null when the handler delegate id equals the entry id (no delegation)", () => {
+		const content = `
+module.exports=[77553,a=>{}];
+a.s(["handler","tree"], 77553);
+`;
+		expect(parseEntryChildFromChunk(content)).toBeNull();
+	});
+
+	test("does not match arrays that mention 'handler' as a substring of another name", () => {
+		// The regex requires "handler" as a whole quoted element, surrounded by
+		// commas or array boundaries. A name like "myhandlerFn" must not match.
+		const content = `
+module.exports=[77553,a=>{}];
+a.s(["myhandlerFn","tree"], 6473);
+`;
+		expect(parseEntryChildFromChunk(content)).toBeNull();
+	});
+});
+
+describe("transformPageJs", () => {
+	const entryChildMap = new Map([["27012", "58478"]]);
+
+	test("rewrites the standard page.js terminator into a merge expression", () => {
+		const contents = [
+			`var R=require("../../chunks/ssr/[turbopack]_runtime.js")("server/app/page.js")`,
+			`R.c("server/chunks/ssr/abc.js")`,
+			`R.m(27012)`,
+			`module.exports=R.m(27012).exports`,
+		].join("\n");
+
+		const out = transformPageJs(contents, entryChildMap);
+		expect(out).not.toBeNull();
+		// Both module ids appear in the rewritten merge
+		expect(out).toContain("R.m(27012).exports");
+		expect(out).toContain("R.m(58478).exports");
+		// Fast path: skip merge when the entry already exposes a handler
+		expect(out).toContain("if(typeof _s.handler==='function')return _s");
+		// Property-descriptor merge preserves lazy getters
+		expect(out).toContain("Object.getOwnPropertyDescriptor");
+		// And the original terminator is gone
+		expect(out).not.toMatch(/module\.exports\s*=\s*R\.m\(\d+\)\.exports\s*$/);
+	});
+
+	test("returns null when the file does not end with the standard terminator", () => {
+		const contents = `R.m(27012)\nmodule.exports = somethingElse`;
+		expect(transformPageJs(contents, entryChildMap)).toBeNull();
+	});
+
+	test("returns null when the entry id is not in the mapping", () => {
+		const contents = [`R.m(99999)`, `module.exports=R.m(99999).exports`].join("\n");
+		expect(transformPageJs(contents, entryChildMap)).toBeNull();
+	});
+
+	test("leaves all other content above the terminator untouched", () => {
+		const head = [
+			`var R=require("../../chunks/ssr/[turbopack]_runtime.js")("server/app/page.js")`,
+			`R.c("server/chunks/ssr/keep-me.js")`,
+			`R.c("server/chunks/ssr/and-me.js")`,
+		].join("\n");
+		const contents = `${head}\nR.m(27012)\nmodule.exports=R.m(27012).exports`;
+
+		const out = transformPageJs(contents, entryChildMap)!;
+		expect(out.startsWith(head)).toBe(true);
+	});
+});

--- a/packages/cloudflare/src/cli/build/patches/plugins/patch-page-exports.ts
+++ b/packages/cloudflare/src/cli/build/patches/plugins/patch-page-exports.ts
@@ -1,0 +1,136 @@
+/**
+ * Next.js 16.2.x Turbopack page templates set up exports on a CHILD module via
+ * `esmExport(bindings, childId)`, then re-call esmExport for the entry module's
+ * own id. The page entry point does `module.exports = R.m(entryId).exports`,
+ * which only has the second call's vendored bindings (no `handler`), causing
+ * "ComponentMod.handler is not a function" at request time.
+ *
+ * Fix: at build time, scan each app-page template chunk to find the
+ * `entryId -> childId` mapping (the child module is where `handler` lives).
+ * Then transform each `app/**\/page.js` and `app/**\/route.js` to merge the
+ * child module's exports into `module.exports`.
+ *
+ * This patch ONLY modifies page.js/route.js files - it does NOT touch the
+ * Turbopack runtime, esmExport, or instantiateModule. So it can't regress
+ * instrumentation hook loading or app-page-turbo external module loading.
+ */
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import { type BuildOptions, getPackagePath } from "@opennextjs/aws/build/helper.js";
+import type { ContentUpdater, Plugin } from "@opennextjs/aws/plugins/content-updater.js";
+
+/**
+ * Extracts the entry-module-id and handler-child-module-id from a single
+ * app-page template chunk. Returns null if either anchor is missing.
+ *
+ * Exported for testing.
+ */
+export function parseEntryChildFromChunk(content: string): { entryId: string; childId: string } | null {
+	// Entry module id: `module.exports=[<entryId>,a=>{...}]`
+	const entryMatch = content.match(/module\.exports\s*=\s*\[(\d+)/);
+	if (!entryMatch) return null;
+
+	// Child module id with handler: `a.s([...,"handler",...], <childId>)`
+	const handlerMatch = content.match(/a\.s\(\[[^\]]*"handler"[^\]]*\],\s*(\d+)\)/);
+	if (!handlerMatch) return null;
+
+	const entryId = entryMatch[1]!;
+	const childId = handlerMatch[1]!;
+
+	// Only record if child differs from entry (real delegation pattern)
+	if (entryId === childId) return null;
+
+	return { entryId, childId };
+}
+
+/**
+ * Scans all SSR app-page template chunks and builds a map of
+ * entry-module-id -> child-module-id (where the handler lives).
+ */
+function buildEntryChildMap(buildOpts: BuildOptions): Map<string, string> {
+	const mapping = new Map<string, string>();
+	const ssrChunksDir = path.join(
+		buildOpts.outputDir,
+		"server-functions/default",
+		getPackagePath(buildOpts),
+		".next/server/chunks/ssr"
+	);
+
+	if (!existsSync(ssrChunksDir)) {
+		return mapping;
+	}
+
+	const templateRegex = /^0-e9_next_dist_esm_build_templates_app-page_.+\.js$/;
+	for (const file of readdirSync(ssrChunksDir)) {
+		if (!templateRegex.test(file)) continue;
+		if (file.endsWith(".map")) continue;
+
+		const content = readFileSync(path.join(ssrChunksDir, file), "utf8");
+		const parsed = parseEntryChildFromChunk(content);
+		if (parsed) {
+			mapping.set(parsed.entryId, parsed.childId);
+		}
+	}
+
+	return mapping;
+}
+
+/**
+ * Transforms `module.exports=R.m(<entryId>).exports` to merge in the
+ * child module's exports (which has the handler).
+ *
+ * Exported for testing.
+ */
+export function transformPageJs(contents: string, entryChildMap: Map<string, string>): string | null {
+	// Match the standard page.js terminator: `module.exports=R.m(<entryId>).exports`
+	const match = contents.match(/^(R\.m\((\d+)\)\s*)module\.exports\s*=\s*R\.m\(\d+\)\.exports\s*$/m);
+	if (!match) return null;
+
+	const entryId = match[2]!;
+	const childId = entryChildMap.get(entryId);
+	if (!childId) return null;
+
+	// Replace with merge logic. R.m(entryId) populates moduleCache[childId] as a
+	// side effect of esmExport(bindings, childId). R.m(childId) then returns the
+	// child module that owns the `handler` export. We then merge the child's
+	// own-property descriptors over the entry's (without overriding entry-only
+	// properties), so the page module exposes both the entry's bindings and the
+	// child's handler.
+	const replacement = `R.m(${entryId})
+module.exports=(function(){
+  var _s=R.m(${entryId}).exports;
+  if(typeof _s.handler==='function')return _s;
+  var _c=R.m(${childId}).exports;
+  var _r={};
+  for(var _k of Object.getOwnPropertyNames(_s)){var _d=Object.getOwnPropertyDescriptor(_s,_k);if(_d)Object.defineProperty(_r,_k,_d);}
+  for(var _k of Object.getOwnPropertyNames(_c)){var _d=Object.getOwnPropertyDescriptor(_c,_k);if(_d&&!Object.getOwnPropertyDescriptor(_r,_k))Object.defineProperty(_r,_k,_d);}
+  return _r;
+})()`;
+
+	return contents.replace(match[0], replacement);
+}
+
+export function patchPageExports(_updater: ContentUpdater, buildOpts: BuildOptions): Plugin {
+	const entryChildMap = buildEntryChildMap(buildOpts);
+
+	if (entryChildMap.size === 0) {
+		return { name: "patch-page-exports", setup() {} };
+	}
+
+	return {
+		name: "patch-page-exports",
+		setup(build) {
+			build.onLoad({ filter: /\.next[\\/]server[\\/]app[\\/].*[\\/](page|route)\.js$/ }, async (args) => {
+				const contents = await readFile(args.path, "utf8");
+				const transformed = transformPageJs(contents, entryChildMap);
+				return {
+					contents: transformed ?? contents,
+					loader: "js",
+				};
+			});
+		},
+	};
+}

--- a/packages/cloudflare/src/cli/build/patches/plugins/shim-node-modules.ts
+++ b/packages/cloudflare/src/cli/build/patches/plugins/shim-node-modules.ts
@@ -1,0 +1,28 @@
+/**
+ * ESBuild plugin to shim Node.js built-in modules that are incompatible with
+ * Cloudflare Workers, even with the `nodejs_compat` compatibility flag.
+ *
+ * Unlike esbuild's `alias` config, an `onResolve` plugin intercepts resolution
+ * before esbuild's `platform: "node"` logic marks built-ins as external, so
+ * the shim is actually bundled into the worker.
+ */
+
+import type { PluginBuild } from "esbuild";
+
+/**
+ * Replaces imports of `perf_hooks` and `node:perf_hooks` with a Workers-compatible
+ * shim. Next.js 16.2.x's `gc-observer` and packages like `@vercel/otel` import
+ * `PerformanceObserver` / `performance` from this module; the shim re-exports
+ * `globalThis.performance` and provides a no-op `PerformanceObserver`.
+ */
+export function shimNodeModules(shimPerfHooksPath: string) {
+	return {
+		name: "shim-node-modules",
+
+		setup(build: PluginBuild) {
+			build.onResolve({ filter: /^(node:)?perf_hooks$/ }, () => ({
+				path: shimPerfHooksPath,
+			}));
+		},
+	};
+}

--- a/packages/cloudflare/src/cli/build/patches/plugins/shim-node-modules.ts
+++ b/packages/cloudflare/src/cli/build/patches/plugins/shim-node-modules.ts
@@ -1,6 +1,7 @@
 /**
- * ESBuild plugin to shim Node.js built-in modules that are incompatible with
- * Cloudflare Workers, even with the `nodejs_compat` compatibility flag.
+ * ESBuild plugin to shim Node.js built-in modules and Next.js internal modules
+ * that are incompatible with Cloudflare Workers, even with the `nodejs_compat`
+ * compatibility flag.
  *
  * Unlike esbuild's `alias` config, an `onResolve` plugin intercepts resolution
  * before esbuild's `platform: "node"` logic marks built-ins as external, so
@@ -10,18 +11,29 @@
 import type { PluginBuild } from "esbuild";
 
 /**
- * Replaces imports of `perf_hooks` and `node:perf_hooks` with a Workers-compatible
- * shim. Next.js 16.2.x's `gc-observer` and packages like `@vercel/otel` import
- * `PerformanceObserver` / `performance` from this module; the shim re-exports
- * `globalThis.performance` and provides a no-op `PerformanceObserver`.
+ * Replaces incompatible modules with Workers-compatible shims:
+ *
+ * - `perf_hooks` / `node:perf_hooks`: Next.js 16.2.x's `gc-observer` and
+ *   packages like `@vercel/otel` import `PerformanceObserver` / `performance`
+ *   from this module; the shim re-exports `globalThis.performance` and
+ *   provides a no-op `PerformanceObserver`.
+ *
+ * - `next/dist/server/node-environment-extensions/fast-set-immediate.external`:
+ *   Next 16.2's app-render scheduler mutates the frozen `node:timers` module
+ *   on import, which throws "Cannot assign to read only property 'setImmediate'
+ *   of object '[object Module]'" under nodejs_compat. The shim no-ops the
+ *   install() side effect; the scheduler optimization isn't needed in Workers.
  */
-export function shimNodeModules(shimPerfHooksPath: string) {
+export function shimNodeModules(shimPerfHooksPath: string, shimFastSetImmediatePath: string) {
 	return {
 		name: "shim-node-modules",
 
 		setup(build: PluginBuild) {
 			build.onResolve({ filter: /^(node:)?perf_hooks$/ }, () => ({
 				path: shimPerfHooksPath,
+			}));
+			build.onResolve({ filter: /fast-set-immediate\.external(\.js)?$/ }, () => ({
+				path: shimFastSetImmediatePath,
 			}));
 		},
 	};

--- a/packages/cloudflare/src/cli/templates/shims/fast-set-immediate.ts
+++ b/packages/cloudflare/src/cli/templates/shims/fast-set-immediate.ts
@@ -1,0 +1,25 @@
+// Stub for Next.js's `node-environment-extensions/fast-set-immediate.external.js`.
+//
+// The original module monkey-patches `setImmediate` / `clearImmediate` onto the
+// `node:timers` module to provide a custom scheduler used by Next's app-render
+// pipeline. In Cloudflare Workers, `node:timers` is a frozen ESM module
+// namespace under nodejs_compat, so `nodeTimers.setImmediate = ...` throws a
+// "Cannot assign to read only property" TypeError, crashing every request.
+//
+// The fast-immediate scheduler is an optimization, not a correctness
+// requirement: Next's rendering still works when the exported control
+// functions are no-ops and `setImmediate` keeps its native (Workers) behavior.
+
+// `DANGEROUSLY_runPendingImmediatesAfterCurrentTask` and
+// `expectNoPendingImmediates` are called from app-render. Without the patch
+// installed, there are no queued immediates to drain or assert against, so
+// both reduce to no-ops in Workers.
+export function DANGEROUSLY_runPendingImmediatesAfterCurrentTask(): void {}
+
+export function expectNoPendingImmediates(): void {}
+
+// Callers use this to access the native setImmediate before any patching.
+// In Workers, no patching ever happens, so the global setImmediate IS the
+// unpatched one.
+export const unpatchedSetImmediate = (globalThis as unknown as { setImmediate: typeof setImmediate })
+	.setImmediate;

--- a/packages/cloudflare/src/cli/templates/shims/perf-hooks.ts
+++ b/packages/cloudflare/src/cli/templates/shims/perf-hooks.ts
@@ -1,0 +1,19 @@
+// Stub for Node.js `perf_hooks` / `node:perf_hooks` in Cloudflare Workers.
+//
+// Workers expose `performance` natively via the Web Performance API.
+// GC observation via PerformanceObserver with entryTypes ['gc'] is Node.js-specific
+// and is a no-op in the Workers environment.
+
+// Workers expose performance via the Web API; cast because workers-types may not declare it on globalThis
+export const performance = (globalThis as unknown as { performance: unknown }).performance;
+
+export class PerformanceObserver {
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	constructor(_callback: unknown) {}
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	observe(_options?: unknown): void {}
+	disconnect(): void {}
+	takeRecords(): unknown[] {
+		return [];
+	}
+}


### PR DESCRIPTION
## What

Three build-time patches that make Next.js 16.2.x apps work on Cloudflare Workers. Without these, every app-router request crashes on cold start.

### 1. `perf_hooks` shim (`f61f7c4`)

Next 16.2.x bundles `gc-observer.js` (imports `PerformanceObserver` from `perf_hooks`) and `@vercel/otel` (uses `require("perf_hooks").performance`) into the instrumentation hook loading path. esbuild normalizes bare `perf_hooks` to `node:perf_hooks` on the node platform, and Workers does not expose this module even with `nodejs_compat`.

A new shim re-exports `globalThis.performance` and provides a no-op `PerformanceObserver`. Resolved via a new `shimNodeModules` `onResolve` plugin (not `alias`) so the shim is bundled instead of being externalized by `platform: "node"`.

### 2. `fast-set-immediate` shim (`b42ef6d`)

Next 16.2's app-render-scheduling imports `next/dist/server/node-environment-extensions/fast-set-immediate.external`, whose top-level `install()` runs:

```js
const nodeTimers = require('node:timers');
globalThis.setImmediate = nodeTimers.setImmediate = patchedSetImmediate;
```

Under `nodejs_compat` the `node:timers` namespace is a frozen ESM module, so `nodeTimers.setImmediate = ...` throws ``Cannot assign to read only property 'setImmediate' of object '[object Module]'`` on every request, before any user code runs.

The fast-immediate scheduler is an optimization, not a correctness requirement. A new shim exports the same names (`DANGEROUSLY_runPendingImmediatesAfterCurrentTask`, `expectNoPendingImmediates`, `unpatchedSetImmediate`) as no-ops and surfaces `globalThis.setImmediate` directly.

This commit also extends the bundle banner to expose `AsyncLocalStorage` on `globalThis` so Next's `async-local-storage.js` picks up the real implementation rather than falling back to `FakeAsyncLocalStorage` (which throws on `.run()`/`.exit()` and cascades into a confusing ``Cannot read properties of undefined (reading 'require')`` when Turbopack loads `app-page-turbo.runtime.prod.js`).

### 3. `patchPageExports` plugin (`39ab69b`)

Next 16.2.x Turbopack app-page templates set up exports on a *child* module via `esmExport(bindings, childId)`, then re-call `esmExport` for the entry module's own id. Each page chunk then does:

```js
R.m(<entryId>)
module.exports = R.m(<entryId>).exports
```

`R.m(<entryId>).exports` only carries the second call's vendored bindings — `handler` lives on the *child* module. At request time Next reads `components.ComponentMod.handler`, gets `undefined`, and crashes with ``ComponentMod.handler is not a function`` on every app route.

The fix:

1. Scan SSR `app-page` template chunks under `.next/server/chunks/ssr/` to build an entry→child module-id map by anchoring on `module.exports = [<entryId>` and `a.s([…,"handler",…], <childId>)`.
2. Add an esbuild `onLoad` plugin that matches `.next/server/app/**/page.js` and `.next/server/app/**/route.js`. When the entry id has a recorded child, replace the terminator with a merge expression that copies the entry's own-property descriptors first, then layers the child's descriptors for keys the entry doesn't define. The merged object exposes `handler` alongside the Turbopack bindings while preserving lazy getters.

The patch only touches `page.js` / `route.js`. It does not modify the Turbopack runtime, `esmExport`, or `instantiateModule`, so it cannot regress instrumentation hook loading or app-page-turbo external loading.

## Why

Without these three patches, Next.js 16.2.x on Cloudflare Workers fails on every request:

- Cold start crashes at `gc-observer.js` evaluation (perf_hooks)
- First request crashes at fast-set-immediate's `install()` (node:timers mutation)
- Every app-router request crashes at `ComponentMod.handler is not a function`

Together they make a real Next 16.2.6 app-router storefront return 200s across homepage, search, category, product, brand, and blog routes.

## Testing

Verified locally with a Next.js 16.2.6 app-router site running under `wrangler@4.90.0 dev`. Without the patches: 500 on every request. With the patches: 200 across the homepage, search, compare, category, product, brand, and blog routes.

`tsc --noEmit` and `eslint` are clean.

## Notes

- Related to #1258.
- One changeset (`patch`) covers all three fixes.
- Happy to split into three separate PRs if that's preferable for review.