### PR TITLE
docs: clarify Cloudflare Access setup in populate-cache comment

### DIFF
--- a/packages/cloudflare/src/cli/commands/populate-cache.ts
+++ b/packages/cloudflare/src/cli/commands/populate-cache.ts
@@ -406,11 +406,17 @@ async function sendEntryToR2Worker(options: {
 						"x-opennext-cache-key": key,
 						"content-length": fs.statSync(filename).size.toString(),
 						// Include Access Client ID and Secret if they are set in the environment,
-						// to allow the worker to authenticate with the Cloudflare API when writing to R2.
+						// so the helper worker can be reached through Cloudflare Access.
 						//
-						// The Application at "open-next-cache-populate.<account>.workers.dev" should have a policy with:
-						// - "Action" set to "Service Auth"
-						// - "Any Access Service Token" or "Service Token" + a specific service token
+						// If the workers.dev subdomain (or a parent route) is behind Cloudflare Access,
+						// attach a "Service Auth" policy to the *existing* Access application that already
+						// covers "open-next-cache-populate.<account>.workers.dev" — typically the
+						// "*.<account>.workers.dev" wildcard application. Creating a separate application
+						// scoped to this hostname has been observed to block the upload, even alongside
+						// the wildcard app. The policy should have:
+						//   - Action set to "Service Auth"
+						//   - An Include rule for "Any Access Service Token" or a specific Service Token
+						// See: https://opennext.js.org/cloudflare/cli#populating-remote-bindings-when-workers-are-protected-by-cloudflare-access
 						...(process.env.CLOUDFLARE_ACCESS_CLIENT_ID && process.env.CLOUDFLARE_ACCESS_CLIENT_SECRET
 							? {
 									"CF-Access-Client-Id": process.env.CLOUDFLARE_ACCESS_CLIENT_ID,


### PR DESCRIPTION
## Summary

- Rewrites the in-code comment in `packages/cloudflare/src/cli/commands/populate-cache.ts` that documents how the `CLOUDFLARE_ACCESS_CLIENT_ID` / `CLOUDFLARE_ACCESS_CLIENT_SECRET` env vars are used.
- Mirrors the wording added to the docs site in opennextjs/docs#218.

## Why

The original comment (introduced in #1261) was reused verbatim in the v1.19.10 changelog and turned out to be ambiguous:

> The Application at "open-next-cache-populate.<account>.workers.dev" should have a policy with: …

Multiple users in #1171 read this as "create a new Access application for that hostname" and ended up with a setup that blocks the upload. The user that eventually got it working in [#1171 (comment)](https://github.com/opennextjs/opennextjs-cloudflare/issues/1171#issuecomment-4460317679) reported that the Service Auth policy needs to be attached to the **existing** Access application that already covers the hostname (typically the `*.<account>.workers.dev` wildcard). Creating a separate application for the helper-worker hostname was observed to block the upload even alongside the wildcard app.

This PR restates the comment so the next maintainer who reads it (or copies it into a future changeset) reflects the working setup, and links out to the new docs section.

## Notes

- Comment-only change — no behaviour change.
- No changeset per `AGENTS.md` (doc tweak — exempt).
- `pnpm code:checks` and `pnpm --filter cloudflare test populate-cache` both pass locally.
- Companion docs PR: opennextjs/docs#218.
- Refs: #1171, #1261.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opennextjs/opennextjs-cloudflare/pull/1267" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->