### PR TITLE
fix: skip non-upload-triggered worker versions in skew-protection

### DIFF
--- a/.changeset/skew-protection-filter-non-upload-versions.md
+++ b/.changeset/skew-protection-filter-non-upload-versions.md
@@ -1,0 +1,9 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+fix: skip non-upload-triggered worker versions when building skew-protection deployment mapping
+
+Worker versions created by metadata-only operations (e.g. Cloudflare API secret updates) do not include the static assets bundle. Previously, such versions could become the "latest" target in the skew-protection mapping, causing `/_next/static/*` requests to return 404 on past deployments. Versions are now filtered to those with `workers/triggered_by` in `{upload, version_upload}`.
+
+Closes #1230

--- a/packages/cloudflare/src/cli/commands/skew-protection.spec.ts
+++ b/packages/cloudflare/src/cli/commands/skew-protection.spec.ts
@@ -49,6 +49,89 @@ describe("skew protection", () => {
 				},
 			]);
 		});
+
+		test("listWorkerVersions filters out non-upload-triggered versions", async () => {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const client: any = {
+				workers: {
+					scripts: {
+						versions: {
+							list: () => [],
+						},
+					},
+				},
+			};
+
+			const now = Date.now();
+
+			client.workers.scripts.versions.list = vi.fn().mockReturnValue([
+				{
+					id: "secret-version",
+					metadata: {
+						created_on: new Date(now),
+						annotations: { "workers/triggered_by": "secret" },
+					},
+				},
+				{
+					id: "upload-version",
+					metadata: {
+						created_on: new Date(now - 1000),
+						annotations: { "workers/triggered_by": "upload" },
+					},
+				},
+				{
+					id: "version-upload",
+					metadata: {
+						created_on: new Date(now - 2000),
+						annotations: { "workers/triggered_by": "version_upload" },
+					},
+				},
+				{
+					id: "legacy-no-annotation",
+					metadata: { created_on: new Date(now - 3000) },
+				},
+			]);
+
+			expect(await listWorkerVersions("scriptName", { client, accountId: "accountId" })).toMatchObject([
+				{ id: "upload-version", createdOnMs: now - 1000 },
+				{ id: "version-upload", createdOnMs: now - 2000 },
+				{ id: "legacy-no-annotation", createdOnMs: now - 3000 },
+			]);
+		});
+
+		test("listWorkerVersions returns [] when the newest versions are all secret-triggered", async () => {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const client: any = {
+				workers: {
+					scripts: {
+						versions: {
+							list: () => [],
+						},
+					},
+				},
+			};
+
+			const now = Date.now();
+
+			client.workers.scripts.versions.list = vi.fn().mockReturnValue([
+				{
+					id: "secret-A",
+					metadata: {
+						created_on: new Date(now),
+						annotations: { "workers/triggered_by": "secret" },
+					},
+				},
+				{
+					id: "secret-B",
+					metadata: {
+						created_on: new Date(now - 1000),
+						annotations: { "workers/triggered_by": "secret" },
+					},
+				},
+			]);
+
+			expect(await listWorkerVersions("scriptName", { client, accountId: "accountId" })).toEqual([]);
+		});
 	});
 });
 

--- a/packages/cloudflare/src/cli/commands/skew-protection.ts
+++ b/packages/cloudflare/src/cli/commands/skew-protection.ts
@@ -40,6 +40,9 @@ const MAX_NUMBER_OF_VERSIONS = 20;
 const MAX_VERSION_AGE_DAYS = 7;
 const MS_PER_DAY = 24 * 3600 * 1000;
 
+/** Worker-version trigger types that produce a full upload (assets + code). */
+const UPLOAD_TRIGGER_TYPES = new Set(["upload", "version_upload"]);
+
 /**
  * Compute the deployment mapping for a deployment.
  *
@@ -244,11 +247,18 @@ export async function listWorkerVersions(
 		})) {
 			const id = version.id;
 			const createdOn = version.metadata?.created_on;
+			const triggeredBy = (version.metadata as any)?.annotations?.["workers/triggered_by"];
 
 			if (id && createdOn) {
 				const createdOnMs = new Date(createdOn).getTime();
 				if (createdOnMs < afterTimeMs) {
 					break;
+				}
+				// Skip metadata-only versions (e.g. secret/service_token triggers)
+				// that lack the static assets bundle. Versions with no annotation
+				// are kept for backward compatibility.
+				if (triggeredBy !== undefined && !UPLOAD_TRIGGER_TYPES.has(triggeredBy)) {
+					continue;
 				}
 				versions.push({ id, createdOnMs });
 				if (versions.length >= maxNumberOfVersions) {


### PR DESCRIPTION
Worker versions created by metadata-only operations (e.g. Cloudflare API secret updates with `triggered_by=secret`) do not include the static assets bundle. Previously, such a version could be picked as the "latest" target when replacing the "current" sentinel in the deployment mapping, causing `/_next/static/*` requests to return 404 on past deployments.

`listWorkerVersions` now skips versions whose metadata.annotations["workers/triggered_by"] is not in `{upload, version_upload}`. Versions with no annotation are kept for backward compatibility.

Closes #1230
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opennextjs/opennextjs-cloudflare/pull/1270" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->