### PR TITLE
fix(api): guard initOpenNextCloudflareForDev against duplicate calls

### DIFF
--- a/.changeset/init-open-next-cloudflare-for-dev-duplicate-call-guard.md
+++ b/.changeset/init-open-next-cloudflare-for-dev-duplicate-call-guard.md
@@ -1,0 +1,9 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+fix: throw a user-actionable error when `initOpenNextCloudflareForDev` is called more than once in the same process
+
+Calling `initOpenNextCloudflareForDev` twice in the Next.js config file used to spawn two competing miniflare instances and fail with an obscure workerd `SQLITE_BUSY` error. The function now tracks its own invocation and throws an error that points the user at the config file the moment the second call happens, instead of letting the failure surface deep inside the Workers runtime.
+
+Closes #1251

--- a/packages/cloudflare/src/api/cloudflare-context.spec.ts
+++ b/packages/cloudflare/src/api/cloudflare-context.spec.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { initOpenNextCloudflareForDev as InitOpenNextCloudflareForDev } from "./cloudflare-context.js";
+
+/**
+ * Regression test for https://github.com/opennextjs/opennextjs-cloudflare/issues/1251.
+ *
+ * Calling `initOpenNextCloudflareForDev` more than once in the same Node.js process previously
+ * surfaced as an obscure `SQLITE_BUSY` workerd error because two miniflare instances raced for the
+ * same on-disk state. The function now tracks its own invocation and throws a user-actionable
+ * error on the second call.
+ */
+describe("initOpenNextCloudflareForDev duplicate-call guard", () => {
+	let initOpenNextCloudflareForDev: typeof InitOpenNextCloudflareForDev;
+
+	beforeEach(async () => {
+		// Re-import fresh per test so the module-level "has been called" flag resets between cases.
+		vi.resetModules();
+
+		// AsyncLocalStorage must be absent on globalThis so `shouldContextInitializationRun` short-
+		// circuits before any wrangler / miniflare setup tries to run, isolating the duplicate-call
+		// guard from the rest of the initialization path.
+		vi.stubGlobal("AsyncLocalStorage", undefined);
+
+		({ initOpenNextCloudflareForDev } = await import("./cloudflare-context.js"));
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("resolves on the first call", async () => {
+		await expect(initOpenNextCloudflareForDev()).resolves.toBeUndefined();
+	});
+
+	it("throws a user-actionable error on the second call in the same process", async () => {
+		await initOpenNextCloudflareForDev();
+		await expect(initOpenNextCloudflareForDev()).rejects.toThrow(
+			/`initOpenNextCloudflareForDev` was called more than once in the same process/
+		);
+	});
+
+	it("mentions the SQLITE_BUSY workerd symptom and points the user at the config file", async () => {
+		await initOpenNextCloudflareForDev();
+		await expect(initOpenNextCloudflareForDev()).rejects.toThrowError(
+			expect.objectContaining({
+				message: expect.stringMatching(/Next\.js config file/),
+			})
+		);
+		await expect(initOpenNextCloudflareForDev()).rejects.toThrowError(
+			expect.objectContaining({
+				message: expect.stringMatching(/SQLITE_BUSY/),
+			})
+		);
+	});
+
+	it("treats each fresh module load as its own process for the purpose of the guard", async () => {
+		await initOpenNextCloudflareForDev();
+		await expect(initOpenNextCloudflareForDev()).rejects.toThrow();
+
+		// Simulating a new process boundary: re-import the module and call once - it should resolve
+		// because the module-level flag is fresh.
+		vi.resetModules();
+		const fresh = await import("./cloudflare-context.js");
+		await expect(fresh.initOpenNextCloudflareForDev()).resolves.toBeUndefined();
+	});
+});

--- a/packages/cloudflare/src/api/cloudflare-context.spec.ts
+++ b/packages/cloudflare/src/api/cloudflare-context.spec.ts
@@ -35,19 +35,19 @@ describe("initOpenNextCloudflareForDev duplicate-call guard", () => {
 
 	it("throws a user-actionable error on the second call in the same process", async () => {
 		await initOpenNextCloudflareForDev();
-		await expect(initOpenNextCloudflareForDev()).rejects.toThrow(
+		expect(() => initOpenNextCloudflareForDev()).toThrow(
 			/`initOpenNextCloudflareForDev` was called more than once in the same process/
 		);
 	});
 
 	it("mentions the SQLITE_BUSY workerd symptom and points the user at the config file", async () => {
 		await initOpenNextCloudflareForDev();
-		await expect(initOpenNextCloudflareForDev()).rejects.toThrowError(
+		expect(() => initOpenNextCloudflareForDev()).toThrowError(
 			expect.objectContaining({
 				message: expect.stringMatching(/Next\.js config file/),
 			})
 		);
-		await expect(initOpenNextCloudflareForDev()).rejects.toThrowError(
+		expect(() => initOpenNextCloudflareForDev()).toThrowError(
 			expect.objectContaining({
 				message: expect.stringMatching(/SQLITE_BUSY/),
 			})
@@ -56,7 +56,7 @@ describe("initOpenNextCloudflareForDev duplicate-call guard", () => {
 
 	it("treats each fresh module load as its own process for the purpose of the guard", async () => {
 		await initOpenNextCloudflareForDev();
-		await expect(initOpenNextCloudflareForDev()).rejects.toThrow();
+		expect(() => initOpenNextCloudflareForDev()).toThrow();
 
 		// Simulating a new process boundary: re-import the module and call once - it should resolve
 		// because the module-level flag is fresh.

--- a/packages/cloudflare/src/api/cloudflare-context.ts
+++ b/packages/cloudflare/src/api/cloudflare-context.ts
@@ -250,10 +250,12 @@ let initOpenNextCloudflareForDevHasBeenCalled = false;
  * Performs some initial setup to integrate as best as possible the local Next.js dev server (run via `next dev`)
  * with the open-next Cloudflare adapter
  *
- * Note: this function should only be called inside the Next.js config file, and although async it doesn't need to be `await`ed
+ * Note: this function should only be called inside the Next.js config file. Although it returns a
+ * promise it doesn't need to be `await`ed: the duplicate-call guard throws synchronously, so a second
+ * unawaited call fails at the call site instead of as an unhandled promise rejection.
  * @param options options on how the function should operate and if/where to persist the platform data
  */
-export async function initOpenNextCloudflareForDev(options?: GetPlatformProxyOptions) {
+export function initOpenNextCloudflareForDev(options?: GetPlatformProxyOptions): Promise<void> {
 	if (initOpenNextCloudflareForDevHasBeenCalled) {
 		throw new Error(
 			`\n\nERROR: \`initOpenNextCloudflareForDev\` was called more than once in the same process.\n` +
@@ -263,6 +265,10 @@ export async function initOpenNextCloudflareForDev(options?: GetPlatformProxyOpt
 	}
 	initOpenNextCloudflareForDevHasBeenCalled = true;
 
+	return initOpenNextCloudflareForDevImpl(options);
+}
+
+async function initOpenNextCloudflareForDevImpl(options?: GetPlatformProxyOptions) {
 	const shouldInitializationRun = shouldContextInitializationRun();
 	if (!shouldInitializationRun) return;
 

--- a/packages/cloudflare/src/api/cloudflare-context.ts
+++ b/packages/cloudflare/src/api/cloudflare-context.ts
@@ -239,6 +239,14 @@ async function getCloudflareContextAsync<
 }
 
 /**
+ * Tracks whether {@link initOpenNextCloudflareForDev} has already been called in the current Node.js
+ * process. Calling it more than once spawns competing workerd instances and surfaces as an obscure
+ * `SQLITE_BUSY` failure (see https://github.com/opennextjs/opennextjs-cloudflare/issues/1251), so we
+ * surface a user-actionable error before any setup runs.
+ */
+let initOpenNextCloudflareForDevHasBeenCalled = false;
+
+/**
  * Performs some initial setup to integrate as best as possible the local Next.js dev server (run via `next dev`)
  * with the open-next Cloudflare adapter
  *
@@ -246,6 +254,15 @@ async function getCloudflareContextAsync<
  * @param options options on how the function should operate and if/where to persist the platform data
  */
 export async function initOpenNextCloudflareForDev(options?: GetPlatformProxyOptions) {
+	if (initOpenNextCloudflareForDevHasBeenCalled) {
+		throw new Error(
+			`\n\nERROR: \`initOpenNextCloudflareForDev\` was called more than once in the same process.\n` +
+				`It should be called exactly once, at the top of your Next.js config file.\n` +
+				`Multiple calls start competing Workers runtimes, which fail with an obscure workerd \`SQLITE_BUSY\` error.\n`
+		);
+	}
+	initOpenNextCloudflareForDevHasBeenCalled = true;
+
 	const shouldInitializationRun = shouldContextInitializationRun();
 	if (!shouldInitializationRun) return;
 


### PR DESCRIPTION
Closes #1251.

Calling `initOpenNextCloudflareForDev` more than once in the same Node.js process used to spawn two competing miniflare instances and fail with the obscure workerd `SQLITE_BUSY` error captured in the issue. The existing `shouldContextInitializationRun` guard only protects across the two processes that `next dev` spawns, not against repeated calls in the same one.

Picking Option 1 from the issue (hard fail with a friendly message), per @vicb's comment.

This PR:

- adds a module-scope flag in `packages/cloudflare/src/api/cloudflare-context.ts` that flips to `true` on the first invocation of `initOpenNextCloudflareForDev`
- on every subsequent call within the same process it throws an error that names the function, points the user at the Next.js config file, and surfaces the `SQLITE_BUSY` symptom so a future user with the same workerd output can search and find this guard
- the existing cross-process guard runs unchanged, after the new check, so the function still no-ops in the secondary `next dev` process

Verification:

- new spec at `packages/cloudflare/src/api/cloudflare-context.spec.ts` covers four cases: first call resolves, second call rejects with the expected message shape, error mentions both the config file and `SQLITE_BUSY`, and a fresh module import resets the guard so we are not accidentally relying on global state that would survive a real new process
- `vi.stubGlobal("AsyncLocalStorage", undefined)` is used to short-circuit `shouldContextInitializationRun` in the spec so the test isolates the duplicate-call guard from the wrangler / miniflare setup
- RED baseline: reverting `cloudflare-context.ts` to `main` makes 3 of the 4 new tests fail with the expected mismatch, applying the fix turns them green
- `pnpm code:checks` clean (prettier + eslint + tsc)
- full `pnpm --filter cloudflare test` suite green: 33 files, 332 tests, 0 regressions
- changeset added at `.changeset/init-open-next-cloudflare-for-dev-duplicate-call-guard.md` (`@opennextjs/cloudflare: patch`)