### PR TITLE
fix(cache-purge): spread SQLite bindings in BucketCachePurge alarm so tag purges run

### DIFF
--- a/.changeset/fix-bucket-cache-purge-bindings.md
+++ b/.changeset/fix-bucket-cache-purge-bindings.md
@@ -1,0 +1,17 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+fix: spread SQLite bindings in BucketCachePurge alarm so tag purges run
+
+`BucketCachePurge.alarm()` passed its tag bindings to `SqlStorage.exec` as a
+single array. `exec(query, ...bindings)` is variadic over its bindings, so for a
+multi-tag `DELETE ... WHERE tag IN (?, ?, …)` the binding count (1) disagreed
+with the placeholder count (N) and `exec` threw "Wrong number of parameter
+bindings" on every flush. On-demand `revalidateTag` purges therefore never
+reached the Cloudflare cache, and with `bypassTagCacheOnCacheHit` enabled pages
+served stale until the ISR TTL expired.
+
+Spread the bindings, normalise the `INSERT` to the same variadic form, and
+tighten the drain loop's guard from `while (tags.length >= 0)` (which never
+exits via the condition) to `while (tags.length > 0)`.

--- a/packages/cloudflare/src/api/durable-objects/bucket-cache-purge.spec.ts
+++ b/packages/cloudflare/src/api/durable-objects/bucket-cache-purge.spec.ts
@@ -50,12 +50,12 @@ describe("BucketCachePurge", () => {
 			// @ts-expect-error - testing private method
 			expect(cache.ctx.storage.sql.exec).toHaveBeenCalledWith(
 				expect.stringContaining("INSERT OR REPLACE INTO cache_purge"),
-				[tags[0]]
+				tags[0]
 			);
 			// @ts-expect-error - testing private method
 			expect(cache.ctx.storage.sql.exec).toHaveBeenCalledWith(
 				expect.stringContaining("INSERT OR REPLACE INTO cache_purge"),
-				[tags[1]]
+				tags[1]
 			);
 		});
 
@@ -86,8 +86,19 @@ describe("BucketCachePurge", () => {
 				toArray: () => [{ tag: "tag1" }, { tag: "tag2" }],
 			});
 			await cache.alarm();
+			// SqlStorage.exec(query, ...bindings) is variadic: each placeholder needs
+			// its own binding argument. Passing the tags as a single array made the
+			// binding count (1) disagree with the placeholder count (N), so exec threw
+			// "Wrong number of parameter bindings" and the purge never ran (#1288). The
+			// bindings must be spread.
 			// @ts-expect-error - testing private method
 			expect(cache.ctx.storage.sql.exec).toHaveBeenCalledWith(
+				expect.stringContaining("DELETE FROM cache_purge"),
+				"tag1",
+				"tag2"
+			);
+			// @ts-expect-error - testing private method
+			expect(cache.ctx.storage.sql.exec).not.toHaveBeenCalledWith(
 				expect.stringContaining("DELETE FROM cache_purge"),
 				["tag1", "tag2"]
 			);

--- a/packages/cloudflare/src/api/durable-objects/bucket-cache-purge.ts
+++ b/packages/cloudflare/src/api/durable-objects/bucket-cache-purge.ts
@@ -33,7 +33,7 @@ export class BucketCachePurge extends DurableObject<CloudflareEnv> {
 				`
         INSERT OR REPLACE INTO cache_purge (tag)
         VALUES (?)`,
-				[tag]
+				tag
 			);
 		}
 		const nextAlarm = await this.ctx.storage.getAlarm();
@@ -75,7 +75,7 @@ export class BucketCachePurge extends DurableObject<CloudflareEnv> {
         DELETE FROM cache_purge
         WHERE tag IN (${tags.map(() => "?").join(",")})
       `,
-				tags.map((row) => row.tag)
+				...tags.map((row) => row.tag)
 			);
 			if (tags.length < MAX_NUMBER_OF_TAGS_PER_PURGE) {
 				// If we have less than MAX_NUMBER_OF_TAGS_PER_PURGE tags, we can stop
@@ -90,6 +90,6 @@ export class BucketCachePurge extends DurableObject<CloudflareEnv> {
 					)
 					.toArray();
 			}
-		} while (tags.length >= 0);
+		} while (tags.length > 0);
 	}
 }


### PR DESCRIPTION
## What & why

`BucketCachePurge.alarm()` passed its tag bindings to `SqlStorage.exec` as a **single array**. `exec(query, ...bindings)` is variadic over its bindings, so a multi-tag `DELETE ... WHERE tag IN (?, ?, …)` received 1 binding for N placeholders and threw **"Wrong number of parameter bindings"** on every flush.

The consequence is silent: on-demand `revalidateTag` purges never reached the Cloudflare cache, and with `bypassTagCacheOnCacheHit` enabled, pages served stale until the ISR TTL expired. The `INSERT` survived only because it has a single placeholder (1 binding, 1 placeholder).

## Changes

- **Spread the `DELETE` bindings** (`...tags.map((row) => row.tag)`) — the actual crash.
- **Normalise the `INSERT`** binding to the same variadic form (`tag` instead of `[tag]`).
- **Tighten the drain-loop guard** `while (tags.length >= 0)` → `while (tags.length > 0)`. The `>= 0` form never exits via the condition; the loop only terminated via the early `return` at the top, leaving a latent infinite-loop guard.
- **Spec:** the existing `alarm` assertions encoded the buggy array form (`["tag1", "tag2"]`); corrected them to the spread form and added a regression guard (`.not.toHaveBeenCalledWith([...])`) referencing this bug.
- **Changeset:** `patch`.

## Repro

Trigger `revalidateTag` for ≥2 tags so the alarm's `DELETE ... IN (?, ?)` has >1 placeholder → the DO `alarm()` throws and the purge never runs. Affects `@opennextjs/cloudflare@1.19.11`.

Fixes #1288

---
<sub>Implemented with AI assistance (Claude), reviewed and verified by me before submitting.</sub>
