### PR TITLE
fix: remove type: "bytes" from ReadableStream for flight data

### DIFF
--- a/.changeset/shy-laws-wonder.md
+++ b/.changeset/shy-laws-wonder.md
@@ -1,0 +1,10 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+fix: patch the createInlinedDataReadableStream function not to use the type: "bytes" option in ReadableStream constructor
+
+workerd seems not to correctly support the type: "bytes" option in ReadableStream constructor, that breaks inlined flight data streaming over 4kB.
+By removing the type: "bytes" option, the inlined flight data will not be split into multiple chunks, and the streaming will work correctly.
+
+(fixes #1225)

--- a/packages/cloudflare/src/cli/build/open-next/createServerBundle.ts
+++ b/packages/cloudflare/src/cli/build/open-next/createServerBundle.ts
@@ -27,6 +27,7 @@ import type { Plugin } from "esbuild";
 
 import { getOpenNextConfig } from "../../../api/config.js";
 import { normalizePath } from "../../utils/normalize-path.js";
+import { patchFlightReadableStreamType } from "../patches/plugins/flight-readable-stream-type.js";
 import { patchResRevalidate } from "../patches/plugins/res-revalidate.js";
 import { patchTurbopackRuntime } from "../patches/plugins/turbopack.js";
 import { patchUseCacheIO } from "../patches/plugins/use-cache.js";
@@ -209,6 +210,7 @@ async function generateBundle(
 		awsPatches.patchBackgroundRevalidation,
 		awsPatches.patchNodeEnvironment,
 		// Cloudflare specific patches
+		patchFlightReadableStreamType,
 		patchResRevalidate,
 		patchUseCacheIO,
 		patchTurbopackRuntime,

--- a/packages/cloudflare/src/cli/build/patches/plugins/flight-readable-stream-type.spec.ts
+++ b/packages/cloudflare/src/cli/build/patches/plugins/flight-readable-stream-type.spec.ts
@@ -1,0 +1,25 @@
+import { patchCode } from "@opennextjs/aws/build/patch/astCodePatcher.js";
+import { describe, expect, test } from "vitest";
+
+import { rule } from "./flight-readable-stream-type.js";
+
+describe("patchFlightReadableStreamType", () => {
+	test("removes type property", () => {
+		const code = `
+function tl(e,t,r){
+  let n = t ? '<script nonce="">' : "<script>";
+  return new ReadableStream({type: "bytes", start(e){ e.enqueue(n); }});
+}
+`;
+
+		expect(patchCode(code, rule)).toMatchInlineSnapshot(
+			`
+      "function tl(e,t,r){
+        let n = t ? '<script nonce="">' : "<script>";
+        return new ReadableStream({start(e){ e.enqueue(n); }});
+      }
+      "
+      `
+		);
+	});
+});

--- a/packages/cloudflare/src/cli/build/patches/plugins/flight-readable-stream-type.spec.ts
+++ b/packages/cloudflare/src/cli/build/patches/plugins/flight-readable-stream-type.spec.ts
@@ -4,19 +4,31 @@ import { describe, expect, test } from "vitest";
 import { rule } from "./flight-readable-stream-type.js";
 
 describe("patchFlightReadableStreamType", () => {
-	test("removes type property", () => {
+	test("removes type property of ReadableStream constructor only in createInlinedDataReadableStream", () => {
 		const code = `
+new ReadableStream({type: "bytes", start(e){ e.enqueue(n); }});
+
 function tl(e,t,r){
   let n = t ? '<script nonce="">' : "<script>";
+  return new ReadableStream({type: "bytes", start(e){ e.enqueue(n); }});
+}
+
+function tl2(e,t,r){
   return new ReadableStream({type: "bytes", start(e){ e.enqueue(n); }});
 }
 `;
 
 		expect(patchCode(code, rule)).toMatchInlineSnapshot(
 			`
-      "function tl(e,t,r){
+      "new ReadableStream({type: "bytes", start(e){ e.enqueue(n); }});
+
+      function tl(e,t,r){
         let n = t ? '<script nonce="">' : "<script>";
         return new ReadableStream({start(e){ e.enqueue(n); }});
+      }
+
+      function tl2(e,t,r){
+        return new ReadableStream({type: "bytes", start(e){ e.enqueue(n); }});
       }
       "
       `

--- a/packages/cloudflare/src/cli/build/patches/plugins/flight-readable-stream-type.ts
+++ b/packages/cloudflare/src/cli/build/patches/plugins/flight-readable-stream-type.ts
@@ -32,6 +32,7 @@ rule:
       field: constructor
       pattern: ReadableStream
     inside:
+      kind: function_declaration
       stopBy: end
       has:
         regex: "<script>"

--- a/packages/cloudflare/src/cli/build/patches/plugins/flight-readable-stream-type.ts
+++ b/packages/cloudflare/src/cli/build/patches/plugins/flight-readable-stream-type.ts
@@ -1,0 +1,40 @@
+/**
+ * This patch will remove the `type: "bytes"` option from the `ReadableStream` constructor in the
+ * createInlinedDataReadableStream function, which provides inline script tag chunks for writing hydration data to the client.
+ * Since workerd has no enough support for the `bytes` type, this patch will remove it to avoid errors related to RSC Flight streams.
+ */
+
+import { patchCode } from "@opennextjs/aws/build/patch/astCodePatcher.js";
+import type { CodePatcher } from "@opennextjs/aws/build/patch/codePatcher.js";
+import { getCrossPlatformPathRegex } from "@opennextjs/aws/utils/regex.js";
+
+export const patchFlightReadableStreamType: CodePatcher = {
+	name: "patch-flight-readable-stream-type",
+	patches: [
+		{
+			pathFilter: getCrossPlatformPathRegex(String.raw`next-server/.*\.runtime\.prod\.js$`, {
+				escape: false,
+			}),
+			contentFilter: /new ReadableStream\(\{type:"bytes",/,
+			patchCode: async ({ code }) => patchCode(code, rule),
+		},
+	],
+};
+
+export const rule = `
+rule:
+  kind: object
+  pattern: "{ type: \\"bytes\\", $$$REST }"
+  inside:
+    stopBy: end
+    kind: new_expression
+    has:
+      field: constructor
+      pattern: ReadableStream
+    inside:
+      stopBy: end
+      has:
+        regex: "<script>"
+
+fix: "{$$$REST}"
+`;


### PR DESCRIPTION
# Summary

This PR fixes the "Connection closed" error caused by corrupted RSC flight data streams on Cloudflare Workers.

Next.js generates inline `<script>` tags for embedding flight data in the [`createInlinedDataReadableStream`](https://github.com/vercel/next.js/blob/d4b234030d24b8b4f4c29aa3aac27962d42739bc/packages/next/src/server/app-render/use-flight-response.tsx#L165-L178) function, which reconstructs a `ReadableStream` using the `type: "bytes"` (BYOB) option.

However, `workerd` splits the `ReadableStream` in BYOB mode into 4KB chunks and this can occasionally cause the data chunks to be read in the wrong order. When using nested or parallel `<Suspense>`, this behavior results in the flight data generated by multiple `<Suspense>` components getting mixed up. This corruption of the `<script>` tag payload triggers the "Connection closed" hydration error (as detailed in https://github.com/opennextjs/opennextjs-cloudflare/issues/1225#issuecomment-4335815843).

To resolve this issue, I implemented the patch for the `createInlinedDataReadableStream` function to remove the `type: "bytes"` option, using the default stream mode without chunk splitting. While the underlying bug seems to be within `workerd` itself, applying this patch serves as immediate workaround rather than waiting for an upstream fix in the runtime.

# Validation

- [X] `pnpm code:checks` passed
- [X] `pnpm test` passed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opennextjs/opennextjs-cloudflare/pull/1293" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->