### PR TITLE
fix: disable compression for worker version requests

### DIFF
--- a/.changeset/quiet-pianos-smile.md
+++ b/.changeset/quiet-pianos-smile.md
@@ -1,0 +1,7 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+fix: disable response compression for skew protection API requests
+
+Avoid truncated compressed Cloudflare API responses causing worker version lookups to fail during deployment.

--- a/packages/cloudflare/src/cli/commands/skew-protection.spec.ts
+++ b/packages/cloudflare/src/cli/commands/skew-protection.spec.ts
@@ -1,9 +1,60 @@
-import { describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import { CURRENT_VERSION_ID } from "../templates/skew-protection.js";
-import { listWorkerVersions, updateDeploymentMapping } from "./skew-protection.js";
+import { getDeploymentMapping, listWorkerVersions, updateDeploymentMapping } from "./skew-protection.js";
+
+const { MockCloudflare } = vi.hoisted(() => {
+	class MockCloudflare {
+		workers = {
+			scripts: {
+				versions: {
+					list: vi.fn(() => []),
+				},
+			},
+		};
+	}
+
+	return { MockCloudflare: vi.fn(MockCloudflare) };
+});
+
+vi.mock("@opennextjs/aws/adapters/config/util.js", () => ({
+	loadConfig: vi.fn(() => ({ deploymentId: "deployment-id" })),
+}));
+
+vi.mock("cloudflare", async (importOriginal) => {
+	const original = await importOriginal<typeof import("cloudflare")>();
+	return { ...original, Cloudflare: MockCloudflare };
+});
 
 describe("skew protection", () => {
+	describe("getDeploymentMapping", () => {
+		beforeEach(() => {
+			vi.stubEnv("CF_WORKER_NAME", "worker-name");
+			vi.stubEnv("CF_PREVIEW_DOMAIN", "example.workers.dev");
+			vi.stubEnv("CF_WORKERS_SCRIPTS_API_TOKEN", "test-token");
+			vi.stubEnv("CF_ACCOUNT_ID", "test-account-id");
+		});
+
+		afterEach(() => {
+			vi.unstubAllEnvs();
+		});
+
+		test("disables response compression for worker version requests", async () => {
+			await expect(
+				getDeploymentMapping(
+					{ appBuildOutputPath: "/tmp/app" } as never,
+					{ cloudflare: { skewProtection: { enabled: true } } },
+					{}
+				)
+			).resolves.toEqual({ "deployment-id": CURRENT_VERSION_ID });
+
+			expect(MockCloudflare).toHaveBeenCalledWith({
+				apiToken: "test-token",
+				defaultHeaders: { "Accept-Encoding": "identity" },
+			});
+		});
+	});
+
 	describe("listWorkerVersions", () => {
 		test("listWorkerVersions return versions ordered by time DESC", async () => {
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/cloudflare/src/cli/commands/skew-protection.ts
+++ b/packages/cloudflare/src/cli/commands/skew-protection.ts
@@ -96,7 +96,10 @@ export async function getDeploymentMapping(
 	const apiToken = envVars.CF_WORKERS_SCRIPTS_API_TOKEN!;
 	const accountId = envVars.CF_ACCOUNT_ID!;
 
-	const client = new Cloudflare({ apiToken });
+	const client = new Cloudflare({
+		apiToken,
+		defaultHeaders: { "Accept-Encoding": "identity" },
+	});
 	const scriptName = envVars.CF_WORKER_NAME!;
 
 	const deployedVersions = await listWorkerVersions(scriptName, {


### PR DESCRIPTION
## Summary

fixes #1296 

- request uncompressed Cloudflare API responses from the skew protection client
- cover both worker version listing and version detail requests through the shared client
- add regression coverage for the client configuration

## Testing

- `pnpm --filter @opennextjs/cloudflare exec vitest run src/cli/commands/skew-protection.spec.ts`
- `pnpm code:checks`
- `pnpm test` (33 test files, 339 tests)

