### PR TITLE
fix: normalize Windows paths in Turbopack runtime patch

### DIFF
--- a/.changeset/fuzzy-windows-turbopack.md
+++ b/.changeset/fuzzy-windows-turbopack.md
@@ -1,0 +1,7 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+fix: normalize Windows paths when patching the Turbopack runtime
+
+Ensure traced Turbopack chunks are included in the generated runtime loaders when builds run on Windows.

--- a/packages/cloudflare/src/cli/build/patches/plugins/turbopack.spec.ts
+++ b/packages/cloudflare/src/cli/build/patches/plugins/turbopack.spec.ts
@@ -3,9 +3,35 @@ import { describe, expect, test } from "vitest";
 
 import {
 	loadWasmChunkFn,
+	patchTurbopackRuntime,
 	replaceLoadWebAssemblyModuleRule,
 	replaceLoadWebAssemblyRule,
 } from "./turbopack.js";
+
+describe("patchTurbopackRuntime", () => {
+	test("normalizes Windows paths before generating chunk loaders", async () => {
+		const patch = patchTurbopackRuntime.patches[0];
+		const code = "function loadRuntimeChunkPath() {}";
+
+		const patched = await patch.patchCode({
+			code,
+			filePath: String.raw`C:\project\.open-next\server-functions\default\.next\server\chunks\ssr\[turbopack]_runtime.js`,
+			tracedFiles: [
+				String.raw`C:\project\.open-next\server-functions\default\.next\server\chunks\ssr\route.js`,
+				String.raw`C:\project\.open-next\server-functions\default\.next\server\chunks\ssr\module.wasm`,
+			],
+			manifests: {} as never,
+			buildOptions: {} as never,
+		});
+
+		expect(patched).toContain(
+			'case "server/chunks/ssr/route.js": return require("C:/project/.open-next/server-functions/default/.next/server/chunks/ssr/route.js");'
+		);
+		expect(patched).toContain(
+			'case "server/chunks/ssr/module.wasm": return (await import("C:/project/.open-next/server-functions/default/.next/server/chunks/ssr/module.wasm")).default;'
+		);
+	});
+});
 
 describe("replaceLoadWebAssemblyModuleRule", () => {
 	test("rewrites Turbopack's loadWebAssemblyModule body", () => {

--- a/packages/cloudflare/src/cli/build/patches/plugins/turbopack.ts
+++ b/packages/cloudflare/src/cli/build/patches/plugins/turbopack.ts
@@ -5,6 +5,8 @@ import { patchCode } from "@opennextjs/aws/build/patch/astCodePatcher.js";
 import type { CodePatcher } from "@opennextjs/aws/build/patch/codePatcher.js";
 import { getCrossPlatformPathRegex } from "@opennextjs/aws/utils/regex.js";
 
+import { normalizePath } from "../../../utils/normalize-path.js";
+
 const inlineChunksRule = `
 rule:
   kind: call_expression
@@ -261,6 +263,9 @@ export const patchTurbopackRuntime: CodePatcher = {
 			}),
 			contentFilter: /loadRuntimeChunkPath/,
 			patchCode: async ({ code, tracedFiles, filePath }) => {
+				tracedFiles = tracedFiles.map(normalizePath);
+				filePath = normalizePath(filePath);
+
 				const mappings = discoverExternalModuleMappings(filePath);
 				const externalImportRule = buildExternalImportRule(mappings, tracedFiles, code);
 				let patched = patchCode(code, externalImportRule);

--- a/packages/cloudflare/src/cli/utils/normalize-path.spec.ts
+++ b/packages/cloudflare/src/cli/utils/normalize-path.spec.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "vitest";
+
+import { normalizePath } from "./normalize-path.js";
+
+describe("normalizePath", () => {
+	test("normalizes Windows path separators on every platform", () => {
+		expect(normalizePath(String.raw`C:\project\.next\server\chunk.js`)).toBe(
+			"C:/project/.next/server/chunk.js"
+		);
+	});
+
+	test("leaves POSIX paths unchanged", () => {
+		expect(normalizePath("/project/.next/server/chunk.js")).toBe("/project/.next/server/chunk.js");
+	});
+});

--- a/packages/cloudflare/src/cli/utils/normalize-path.ts
+++ b/packages/cloudflare/src/cli/utils/normalize-path.ts
@@ -1,5 +1,3 @@
-import { posix, sep } from "node:path";
-
 export function normalizePath(path: string) {
-	return path.replaceAll(sep, posix.sep);
+	return path.replaceAll("\\", "/");
 }


### PR DESCRIPTION
## Summary

- normalize traced file and runtime paths before applying Turbopack patches
- preserve statically analyzable forward-slash chunk imports on Windows
- add regression coverage for generated JavaScript and WebAssembly chunk loaders

Refs #1305

## Testing

- `pnpm code:checks`
- `pnpm test`
