### PR TITLE
feat: support Node.js middleware (proxy.ts)

### DIFF
--- a/.changeset/proxy-node-middleware.md
+++ b/.changeset/proxy-node-middleware.md
@@ -1,0 +1,14 @@
+---
+"@opennextjs/cloudflare": minor
+---
+
+feature: support Node.js middleware (`proxy.ts`)
+
+Next.js 16 replaces `middleware.ts` with `proxy.ts` which always runs on the Node.js runtime.
+
+The Node.js middleware is now bundled into a Workers compatible `middleware/handler.mjs`:
+the OpenNext config manifests are inlined at build time (as for the edge middleware) and the
+middleware compiled by Next.js is statically bundled instead of being loaded from the
+filesystem at runtime (workerd can not access the filesystem nor load modules at runtime).
+
+The support is experimental and requires the `nodejs_compat` compatibility flag.

--- a/examples/e2e/experimental/e2e/nodeMiddleware.test.ts
+++ b/examples/e2e/experimental/e2e/nodeMiddleware.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "@playwright/test";
 
 // See https://github.com/opennextjs/opennextjs-cloudflare/issues/617
 test.describe("Node Middleware", () => {
-	test.skip("Node middleware should add headers", async ({ request }) => {
+	test("Node middleware should add headers", async ({ request }) => {
 		const resp = await request.get("/");
 		expect(resp.status()).toEqual(200);
 		const headers = resp.headers();
@@ -10,21 +10,21 @@ test.describe("Node Middleware", () => {
 		expect(headers["x-random-node"]).toBeDefined();
 	});
 
-	test.skip("Node middleware should return json", async ({ request }) => {
+	test("Node middleware should return json", async ({ request }) => {
 		const resp = await request.get("/api/hello");
 		expect(resp.status()).toEqual(200);
 		const json = await resp.json();
 		expect(json).toEqual({ name: "World" });
 	});
 
-	test.skip("Node middleware should redirect", async ({ page }) => {
+	test("Node middleware should redirect", async ({ page }) => {
 		await page.goto("/redirect");
 		await page.waitForURL("/");
 		const el = page.getByText("Incremental PPR");
 		await expect(el).toBeVisible();
 	});
 
-	test.skip("Node middleware should rewrite", async ({ page }) => {
+	test("Node middleware should rewrite", async ({ page }) => {
 		await page.goto("/rewrite");
 		const el = page.getByText("Incremental PPR");
 		await expect(el).toBeVisible();

--- a/examples/e2e/experimental/src/proxy.ts
+++ b/examples/e2e/experimental/src/proxy.ts
@@ -1,10 +1,10 @@
-// Node middleware is not supported yet in cloudflare
+// `proxy.ts` replaces `middleware.ts` in Next.js 16 and always runs on the Node.js runtime.
 // See https://github.com/opennextjs/opennextjs-cloudflare/issues/617
 
-// import crypto from "node:crypto";
+import crypto from "node:crypto";
 import { type NextRequest, NextResponse } from "next/server";
 
-export default function middleware(request: NextRequest) {
+export default function proxy(request: NextRequest) {
 	if (request.nextUrl.pathname === "/api/hello") {
 		return NextResponse.json({
 			name: "World",
@@ -20,11 +20,7 @@ export default function middleware(request: NextRequest) {
 	return NextResponse.next({
 		headers: {
 			"x-middleware-test": "1",
-			// "x-random-node": crypto.randomUUID(),
+			"x-random-node": crypto.randomUUID(),
 		},
 	});
 }
-
-// export const config = {
-//   runtime: "nodejs",
-// };

--- a/packages/cloudflare/src/cli/build/build.ts
+++ b/packages/cloudflare/src/cli/build/build.ts
@@ -12,6 +12,7 @@ import { OpenNextConfig } from "../../api/config.js";
 import type { ProjectOptions } from "../project-options.js";
 import { ensureNextjsVersionSupported } from "../utils/nextjs-support.js";
 import { bundleServer } from "./bundle-server.js";
+import { bundleNodeMiddleware } from "./open-next/bundle-node-middleware.js";
 import { compileCacheAssetsManifestSqlFile } from "./open-next/compile-cache-assets-manifest.js";
 import { compileEnvFiles } from "./open-next/compile-env-files.js";
 import { compileImages } from "./open-next/compile-images.js";
@@ -81,10 +82,11 @@ export async function build(
 		buildNextjsApp(options);
 	}
 
-	// Make sure no Node.js middleware is used
-	if (useNodeMiddleware(options)) {
-		logger.error("Node.js middleware is not currently supported. Consider switching to Edge Middleware.");
-		process.exit(1);
+	const hasNodeMiddleware = useNodeMiddleware(options);
+	if (hasNodeMiddleware) {
+		logger.warn(
+			"Node.js middleware support is experimental, make sure that `nodejs_compat` is enabled in your wrangler configuration."
+		);
 	}
 
 	// Generate deployable bundle
@@ -100,6 +102,10 @@ export async function build(
 
 	// Compile middleware
 	await createMiddleware(options, { forceOnlyBuildOnce: true });
+
+	if (hasNodeMiddleware) {
+		await bundleNodeMiddleware(options);
+	}
 
 	createStaticAssets(options, { useBasePath: true });
 

--- a/packages/cloudflare/src/cli/build/bundle-server.ts
+++ b/packages/cloudflare/src/cli/build/bundle-server.ts
@@ -62,7 +62,7 @@ export async function bundleServer(buildOpts: BuildOptions, projectOpts: Project
 
 	console.log(`\x1b[35m⚙️ Bundling the OpenNext server...\n\x1b[0m`);
 
-	await patchWebpackRuntime(buildOpts);
+	await patchWebpackRuntime(path.join(dotNextPath, "server"));
 	const useOg = patchVercelOgLibrary(buildOpts);
 
 	const outputPath = path.join(outputDir, "server-functions", "default");

--- a/packages/cloudflare/src/cli/build/open-next/bundle-node-middleware.ts
+++ b/packages/cloudflare/src/cli/build/open-next/bundle-node-middleware.ts
@@ -1,0 +1,201 @@
+/**
+ * Bundles the Node.js middleware (`proxy.ts` / `middleware.ts` with the `nodejs` runtime)
+ * into a Workers compatible `middleware/handler.mjs`.
+ *
+ * `@opennextjs/aws` bundles the external middleware for a Node.js server:
+ * the OpenNext config is read from the filesystem at runtime and the middleware compiled
+ * by Next.js is loaded with `await import("./.next/server/middleware.js")`.
+ *
+ * workerd can not access the filesystem nor load modules at runtime, so the handler
+ * built by `@opennextjs/aws` is replaced with a fully self-contained bundle:
+ *
+ * - the config manifests are inlined by `openNextEdgePlugins` (as for the edge middleware)
+ * - the middleware compiled by Next.js is statically bundled from the traced files that
+ *   `@opennextjs/aws` copies to `middleware/<package path>/.next/server/middleware.js`
+ */
+
+import { existsSync } from "node:fs";
+import { isBuiltin } from "node:module";
+import path from "node:path";
+
+import { type BuildOptions, getPackagePath } from "@opennextjs/aws/build/helper.js";
+import logger from "@opennextjs/aws/logger.js";
+import { openNextEdgePlugins } from "@opennextjs/aws/plugins/edge.js";
+import { openNextExternalMiddlewarePlugin } from "@opennextjs/aws/plugins/externalMiddleware.js";
+import { openNextReplacementPlugin } from "@opennextjs/aws/plugins/replacement.js";
+import { openNextResolvePlugin } from "@opennextjs/aws/plugins/resolve.js";
+import { getCrossPlatformPathRegex } from "@opennextjs/aws/utils/regex.js";
+import { build, type Plugin } from "esbuild";
+
+import { patchWebpackRuntime } from "../patches/ast/webpack-runtime.js";
+import { handleOptionalDependencies } from "../patches/plugins/optional-deps.js";
+
+/**
+ * Resolves the middleware compiled by Next.js to the copy created by `copyTracedFiles`.
+ */
+export function setCompiledMiddlewarePlugin(compiledMiddlewarePath: string): Plugin {
+	return {
+		name: "compiled-middleware",
+		setup(build) {
+			build.onResolve({ filter: getCrossPlatformPathRegex("./.next/server/middleware.js") }, () => ({
+				path: compiledMiddlewarePath,
+			}));
+		},
+	};
+}
+
+/**
+ * Makes the Node.js builtins used by the bundled code (i.e. `require("crypto")` or
+ * `import from "node:crypto"`) resolve to the modules workerd provides via `nodejs_compat`.
+ *
+ * `require` calls are converted into ESM imports via a virtual module. The virtual module
+ * re-exports the default export so that the interop helpers in the middleware compiled by
+ * Next.js receive the full module (`export * from ...` alone would drop the default export).
+ */
+export function nodeBuiltinsPlugin(): Plugin {
+	const namespace = "node-builtins";
+	return {
+		name: namespace,
+		setup(build) {
+			build.onResolve({ filter: /.*/ }, ({ path: specifier, kind }) => {
+				if (!isBuiltin(specifier)) {
+					return undefined;
+				}
+				const prefixed = specifier.startsWith("node:") ? specifier : `node:${specifier}`;
+				return kind === "require-call" ? { path: prefixed, namespace } : { path: prefixed, external: true };
+			});
+			build.onLoad({ filter: /.*/, namespace }, ({ path: builtin }) => ({
+				contents: `
+					import * as mod from "${builtin}";
+					export * from "${builtin}";
+					export default mod.default ?? mod;
+				`,
+				loader: "js",
+			}));
+		},
+	};
+}
+
+export async function bundleNodeMiddleware(options: BuildOptions): Promise<void> {
+	const { config, outputDir } = options;
+
+	const middlewareDir = path.join(outputDir, "middleware");
+	const dotNextServerDir = path.join(middlewareDir, getPackagePath(options), ".next/server");
+	const compiledMiddleware = path.join(dotNextServerDir, "middleware.js");
+
+	if (!existsSync(compiledMiddleware)) {
+		throw new Error(`Compiled Node.js middleware not found at ${compiledMiddleware}`);
+	}
+
+	// The middleware uses the same webpack runtime as the server, inline its dynamic requires
+	// so that the chunks are statically bundled.
+	await patchWebpackRuntime(dotNextServerDir);
+
+	logger.info("Bundling Node.js middleware...");
+
+	const middlewareConfig = config.middleware?.external ? config.middleware : undefined;
+	const overrides = {
+		...middlewareConfig?.override,
+		originResolver: middlewareConfig?.originResolver,
+	};
+	function override<T extends keyof typeof overrides>(target: T) {
+		// String and lazy loaded overrides are supported, see `buildEdgeBundle`
+		return typeof overrides[target] === "string" || typeof overrides[target] === "function"
+			? overrides[target]
+			: undefined;
+	}
+	const includeCache = config.dangerous?.enableCacheInterception;
+
+	await build({
+		entryPoints: [path.join(options.openNextDistDir, "adapters", "middleware.js")],
+		outfile: path.join(middlewareDir, "handler.mjs"),
+		allowOverwrite: true,
+		bundle: true,
+		format: "esm",
+		target: "es2022",
+		platform: "neutral",
+		minify: options.minify,
+		sourcemap: options.debug ? "inline" : false,
+		sourcesContent: false,
+		treeShaking: true,
+		conditions: ["module"],
+		mainFields: ["module", "main"],
+		external: ["node:*", "./open-next.config.mjs"],
+		define: {
+			// The base of the middleware compiled by Next.js is runtime agnostic.
+			// "edge" skips the setup of the Node.js environment (`setup-node-env.external.js`
+			// patches globals that are read-only in workerd). Node.js builtin modules used by
+			// the middleware are provided by workerd via `nodejs_compat`.
+			"process.env.NEXT_RUNTIME": '"edge"',
+			"process.env.NODE_ENV": '"production"',
+		},
+		alias: {
+			path: "node:path",
+			stream: "node:stream",
+			fs: "node:fs",
+		},
+		plugins: [
+			openNextResolvePlugin({
+				overrides: {
+					wrapper: override("wrapper") ?? "cloudflare-edge",
+					converter: override("converter") ?? "edge",
+					...(includeCache
+						? {
+								tagCache: override("tagCache"),
+								incrementalCache: override("incrementalCache"),
+								queue: override("queue"),
+							}
+						: {}),
+					originResolver: override("originResolver") ?? "pattern-env",
+					proxyExternalRequest: override("proxyExternalRequest") ?? "fetch",
+				},
+				fnName: "middleware",
+			}),
+			openNextReplacementPlugin({
+				name: "externalMiddlewareOverrides",
+				target: getCrossPlatformPathRegex("adapters/middleware.js"),
+				deletes: includeCache ? [] : ["includeCacheInMiddleware"],
+			}),
+			// Handle the middleware with the OpenNext Node.js middleware handler
+			openNextExternalMiddlewarePlugin(
+				path.join(options.openNextDistDir, "core", "nodeMiddlewareHandler.js")
+			),
+			setCompiledMiddlewarePlugin(compiledMiddleware),
+			// `next/dist/server/lib/trace/tracer.js` requires `@opentelemetry/api` in a
+			// try/catch and falls back to the copy compiled in Next.js when it throws.
+			handleOptionalDependencies(["@opentelemetry/api"]),
+			// Must be registered before `openNextEdgePlugins` to handle `require("node:*")` calls
+			nodeBuiltinsPlugin(),
+			// Inline the config manifests
+			openNextEdgePlugins({
+				nextDir: path.join(options.appBuildOutputPath, ".next"),
+				isInCloudflare: true,
+			}),
+		] as Plugin[],
+		banner: {
+			js: `
+import { Buffer } from "node:buffer";
+globalThis.Buffer = Buffer;
+
+import { AsyncLocalStorage } from "node:async_hooks";
+globalThis.AsyncLocalStorage = AsyncLocalStorage;
+
+// Next.js sets \`__import_unsupported\` on \`globalThis\` with \`configurable: false\`.
+// The middleware and the server both run this code in the same Worker, the second
+// call would throw so it is skipped.
+// See https://github.com/vercel/next.js/blob/5b7833e3/packages/next/src/server/web/globals.ts#L94-L98
+const defaultDefineProperty = Object.defineProperty;
+Object.defineProperty = function (o, p, a) {
+	if (p === "__import_unsupported" && Boolean(globalThis.__import_unsupported)) {
+		return;
+	}
+	return defaultDefineProperty(o, p, a);
+};
+
+globalThis.openNextDebug = ${options.debug};
+globalThis.openNextVersion = "${options.openNextVersion}";
+globalThis.nextVersion = "${options.nextVersion}";
+`,
+		},
+	});
+}

--- a/packages/cloudflare/src/cli/build/patches/ast/webpack-runtime.ts
+++ b/packages/cloudflare/src/cli/build/patches/ast/webpack-runtime.ts
@@ -23,7 +23,6 @@
 import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { type BuildOptions, getPackagePath } from "@opennextjs/aws/build/helper.js";
 import { patchCode } from "@opennextjs/aws/build/patch/astCodePatcher.js";
 
 // Inline the code when there are multiple chunks
@@ -73,22 +72,16 @@ fix: |
  * Fixes the webpack-runtime.js and webpack-api-runtime.js files by inlining
  * the webpack dynamic requires.
  */
-export async function patchWebpackRuntime(buildOpts: BuildOptions) {
-	const { outputDir } = buildOpts;
-
-	const dotNextServerDir = join(
-		outputDir,
-		"server-functions/default",
-		getPackagePath(buildOpts),
-		".next/server"
-	);
-
+export async function patchWebpackRuntime(dotNextServerDir: string) {
 	// Look for all the chunks.
-	const chunks = readdirSync(join(dotNextServerDir, "chunks"))
-		.filter((chunk) => /^\d+\.js$/.test(chunk))
-		.map((chunk) => {
-			return Number(chunk.replace(/\.js$/, ""));
-		});
+	const chunksDir = join(dotNextServerDir, "chunks");
+	const chunks = existsSync(chunksDir)
+		? readdirSync(chunksDir)
+				.filter((chunk) => /^\d+\.js$/.test(chunk))
+				.map((chunk) => {
+					return Number(chunk.replace(/\.js$/, ""));
+				})
+		: [];
 
 	patchFile(join(dotNextServerDir, "webpack-runtime.js"), chunks);
 	patchFile(join(dotNextServerDir, "webpack-api-runtime.js"), chunks);


### PR DESCRIPTION
Next.js 16 replaces `middleware.ts` with `proxy.ts` which always runs on the Node.js runtime. The build currently rejects such apps.

`@opennextjs/aws` compiles the external middleware for a Node.js server: the OpenNext config manifests are read from the filesystem at runtime and the middleware compiled by Next.js is loaded with a dynamic `import("./.next/server/middleware.js")` (excluded from the bundle via `external: ["./.next/*"]`). workerd can not access the filesystem nor load modules at runtime, so that handler crashes on the first request.

The Node.js middleware is now bundled on the Cloudflare side into a fully self-contained `middleware/handler.mjs`, reusing the OpenNext machinery:

- the OpenNext routing layer stays in charge of running the middleware (`adapters/middleware.js` + `nodeMiddlewareHandler.js` from `@opennextjs/aws`)
- the config manifests are inlined at build time by `openNextEdgePlugins`, exactly as for the edge middleware
- the middleware compiled by Next.js is statically bundled from the traced files copied by `copyTracedFiles`, with the webpack runtime patched to inline its dynamic chunk requires
- `NEXT_RUNTIME` is defined to "edge" so that the runtime agnostic middleware base skips `setup-node-env.external.js` which patches globals that are read-only in workerd; Node.js builtins used by the middleware are provided by workerd via `nodejs_compat`

The experimental example now uses a `proxy.ts` (with a `node:crypto` call) and the previously skipped Node middleware e2e tests are enabled.

Fixes #617
Fixes #1277