### PR TITLE
fix: upgrade OpenNext AWS encoded path handling

### DIFF
--- a/.changeset/curly-pandas-protect.md
+++ b/.changeset/curly-pandas-protect.md
@@ -1,0 +1,7 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+fix: handle encoded middleware and cache paths safely
+
+Upgrade `@opennextjs/aws` to prevent encoded paths from bypassing middleware matching or selecting partially decoded cache entries.

--- a/examples/middleware/app/[...slug]/page.tsx
+++ b/examples/middleware/app/[...slug]/page.tsx
@@ -1,0 +1,9 @@
+export function generateStaticParams() {
+	return [{ slug: ["admin", "%ZZ"] }];
+}
+
+export default async function CatchAllPage({ params }: { params: Promise<{ slug: string[] }> }) {
+	const { slug } = await params;
+
+	return <h1>Protected content: {slug.join("/")}</h1>;
+}

--- a/examples/middleware/e2e/base.spec.ts
+++ b/examples/middleware/e2e/base.spec.ts
@@ -29,6 +29,21 @@ test.describe("middleware", () => {
 		expect(await page.textContent("h1")).toContain("Via middleware");
 	});
 
+	test("malformed paths cannot select protected cached routes", async ({ request }) => {
+		const res = await request.get("/%61dmin/%ZZ");
+
+		expect(res.status()).not.toEqual(200);
+		expect(res.headers()["x-opennext-cache"]).toBeUndefined();
+		expect(await res.text()).not.toContain("Protected content");
+	});
+
+	test("middleware matches encoded paths", async ({ request }) => {
+		const res = await request.get("/encoded-m%69ddleware");
+
+		expect(res.status()).toEqual(200);
+		await expect(res.text()).resolves.toEqual("Middleware matched encoded path");
+	});
+
 	// Test for https://github.com/opennextjs/opennextjs-cloudflare/issues/201
 	test("clerk middleware", async ({ page }) => {
 		const res = await page.request.post("/clerk", { data: "some body" });

--- a/examples/middleware/middleware.ts
+++ b/examples/middleware/middleware.ts
@@ -5,6 +5,12 @@ import { getCloudflareContext } from "@opennextjs/cloudflare";
 
 export function middleware(request: NextRequest, event: NextFetchEvent) {
 	console.log("middleware");
+	if (request.nextUrl.pathname.startsWith("/admin")) {
+		return new NextResponse("Authentication required", { status: 401 });
+	}
+	if (request.nextUrl.pathname === "/encoded-m%69ddleware") {
+		return new NextResponse("Middleware matched encoded path");
+	}
 	if (request.nextUrl.pathname === "/about") {
 		return NextResponse.redirect(new URL("/redirected", request.url));
 	}
@@ -34,5 +40,12 @@ export function middleware(request: NextRequest, event: NextFetchEvent) {
 }
 
 export const config = {
-	matcher: ["/about/:path*", "/another/:path*", "/middleware/:path*", "/clerk"],
+	matcher: [
+		"/about/:path*",
+		"/another/:path*",
+		"/middleware/:path*",
+		"/encoded-middleware",
+		"/admin/:path*",
+		"/clerk",
+	],
 };

--- a/examples/middleware/open-next.config.ts
+++ b/examples/middleware/open-next.config.ts
@@ -1,3 +1,7 @@
 import { defineCloudflareConfig } from "@opennextjs/cloudflare";
+import staticAssetsIncrementalCache from "@opennextjs/cloudflare/overrides/incremental-cache/static-assets-incremental-cache";
 
-export default defineCloudflareConfig();
+export default defineCloudflareConfig({
+	incrementalCache: staticAssetsIncrementalCache,
+	enableCacheInterception: true,
+});

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -54,7 +54,7 @@
 	"dependencies": {
 		"@ast-grep/napi": "^0.40.5",
 		"@dotenvx/dotenvx": "catalog:",
-		"@opennextjs/aws": "4.0.2",
+		"@opennextjs/aws": "https://pkg.pr.new/@opennextjs/aws@1200",
 		"ci-info": "^4.2.0",
 		"cloudflare": "^4.4.1",
 		"comment-json": "^4.5.1",

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -54,7 +54,7 @@
 	"dependencies": {
 		"@ast-grep/napi": "^0.40.5",
 		"@dotenvx/dotenvx": "catalog:",
-		"@opennextjs/aws": "https://pkg.pr.new/@opennextjs/aws@1200",
+		"@opennextjs/aws": "4.1.0",
 		"ci-info": "^4.2.0",
 		"cloudflare": "^4.4.1",
 		"comment-json": "^4.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1081,8 +1081,8 @@ importers:
         specifier: 'catalog:'
         version: 1.31.0
       '@opennextjs/aws':
-        specifier: https://pkg.pr.new/@opennextjs/aws@1200
-        version: https://pkg.pr.new/@opennextjs/aws@1200(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+        specifier: 4.1.0
+        version: 4.1.0(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       ci-info:
         specifier: ^4.2.0
         version: 4.2.0
@@ -3448,8 +3448,8 @@ packages:
   '@octokit/types@13.10.0':
     resolution: {integrity: sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==}
 
-  '@opennextjs/aws@https://pkg.pr.new/@opennextjs/aws@1200':
-    resolution: {integrity: sha512-9k27Q7I32YsPRH+D+DKMsz+fv83mMyRtn/pQQigUHA5zexCg8KvFv6D1U2sYwKUvFFo9oW0+8QSjiq2BLuXPtA==, tarball: https://pkg.pr.new/@opennextjs/aws@1200}
+  '@opennextjs/aws@4.1.0':
+    resolution: {integrity: sha512-9k27Q7I32YsPRH+D+DKMsz+fv83mMyRtn/pQQigUHA5zexCg8KvFv6D1U2sYwKUvFFo9oW0+8QSjiq2BLuXPtA==, tarball: 4.1.0}
     version: 4.0.3
     hasBin: true
     peerDependencies:
@@ -12557,7 +12557,7 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 24.2.0
 
-  '@opennextjs/aws@https://pkg.pr.new/@opennextjs/aws@1200(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@opennextjs/aws@4.1.0(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
       '@ast-grep/napi': 0.40.5
       '@aws-sdk/client-cloudfront': 3.984.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1081,8 +1081,8 @@ importers:
         specifier: 'catalog:'
         version: 1.31.0
       '@opennextjs/aws':
-        specifier: 4.0.2
-        version: 4.0.2(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+        specifier: https://pkg.pr.new/@opennextjs/aws@1200
+        version: https://pkg.pr.new/@opennextjs/aws@1200(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       ci-info:
         specifier: ^4.2.0
         version: 4.2.0
@@ -3448,8 +3448,9 @@ packages:
   '@octokit/types@13.10.0':
     resolution: {integrity: sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==}
 
-  '@opennextjs/aws@4.0.2':
-    resolution: {integrity: sha512-nXQPT8GZDV+NWMJV9mD/Ywxyo+tCZfFvrR6jpEOYNcxK/AqiEDlJzPybGOrHUDWAYdR1b6tmh+MoR3VbqIao3w==}
+  '@opennextjs/aws@https://pkg.pr.new/@opennextjs/aws@1200':
+    resolution: {integrity: sha512-9k27Q7I32YsPRH+D+DKMsz+fv83mMyRtn/pQQigUHA5zexCg8KvFv6D1U2sYwKUvFFo9oW0+8QSjiq2BLuXPtA==, tarball: https://pkg.pr.new/@opennextjs/aws@1200}
+    version: 4.0.3
     hasBin: true
     peerDependencies:
       next: '>=15.5.18 <16 || >=16.2.6'
@@ -12556,7 +12557,7 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 24.2.0
 
-  '@opennextjs/aws@4.0.2(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@opennextjs/aws@https://pkg.pr.new/@opennextjs/aws@1200(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
       '@ast-grep/napi': 0.40.5
       '@aws-sdk/client-cloudfront': 3.984.0


### PR DESCRIPTION
## Summary

- upgrade `@opennextjs/aws` to the PR #1200 prerelease containing the encoded-path fixes
- add Worker regressions for encoded middleware matching and malformed cache paths
- enable cache interception in the middleware fixture with a static-assets cache

The prerelease should be replaced with the next stable patch release once published.

## Validation

- `pnpm --filter middleware e2e --project "middleware - chromium" --grep "malformed|middleware matches encoded"` (2 passed)
- `pnpm --filter middleware e2e:dev --project "middleware - chromium" --grep "malformed|middleware matches encoded"` (2 passed)