### PR TITLE
chore: bump Next.js to 15.5.21 and 16.2.11

### DIFF
--- a/.changeset/fresh-rivers-smile.md
+++ b/.changeset/fresh-rivers-smile.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+chore: bump the Next.js peer dependency to 15.5.21 / 16.2.11

--- a/create-cloudflare/next/package.json
+++ b/create-cloudflare/next/package.json
@@ -14,7 +14,7 @@
 	},
 	"dependencies": {
 		"@opennextjs/cloudflare": "^1.19.9",
-		"next": "16.2.6",
+		"next": "16.2.11",
 		"react": "^19.1.7",
 		"react-dom": "^19.1.7"
 	},
@@ -25,7 +25,7 @@
 		"@types/react": "^19.1.7",
 		"@types/react-dom": "^19.1.7",
 		"eslint": "^9",
-		"eslint-config-next": "16.2.6",
+		"eslint-config-next": "16.2.11",
 		"tailwindcss": "^4",
 		"typescript": "^5.7.4",
 		"wrangler": "^4.86.0"

--- a/examples/bugs/gh-119/package.json
+++ b/examples/bugs/gh-119/package.json
@@ -14,7 +14,7 @@
 		"cf-typegen": "wrangler types --env-interface CloudflareEnv"
 	},
 	"dependencies": {
-		"next": "15.5.18",
+		"next": "15.5.21",
 		"react-dom": "^19.0.6",
 		"react": "^19.0.6"
 	},

--- a/examples/bugs/gh-219/package.json
+++ b/examples/bugs/gh-219/package.json
@@ -28,7 +28,7 @@
 		"nanoid": "^5.0.9",
 		"next-auth": "^4.24.11",
 		"next-themes": "^0.4.4",
-		"next": "15.5.18",
+		"next": "15.5.21",
 		"qrcode.react": "^4.2.0",
 		"react-dom": "^19.0.6",
 		"react-hook-form": "^7.54.2",

--- a/examples/bugs/gh-223/package.json
+++ b/examples/bugs/gh-223/package.json
@@ -16,7 +16,7 @@
 	"dependencies": {
 		"@aws-sdk/client-s3": "^3.971.0",
 		"@aws-sdk/s3-request-presigner": "^3.971.0",
-		"next": "15.5.18",
+		"next": "15.5.21",
 		"react": "^19.0.6",
 		"react-dom": "^19.0.6"
 	},

--- a/examples/playground16/package.json
+++ b/examples/playground16/package.json
@@ -17,7 +17,7 @@
 		"cf-typegen": "wrangler types --env-interface CloudflareEnv"
 	},
 	"dependencies": {
-		"next": "16.2.6",
+		"next": "16.2.11",
 		"react-dom": "^19.2.6",
 		"react": "^19.2.6",
 		"shiki": "^3.22.0"

--- a/examples/ssg-app/package.json
+++ b/examples/ssg-app/package.json
@@ -15,7 +15,7 @@
 	"dependencies": {
 		"react": "^19.0.6",
 		"react-dom": "^19.0.6",
-		"next": "15.5.18"
+		"next": "15.5.21"
 	},
 	"devDependencies": {
 		"@opennextjs/cloudflare": "workspace:*",

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -89,7 +89,7 @@
 		"vitest": "catalog:"
 	},
 	"peerDependencies": {
-		"next": ">=15.5.18 <16 || >=16.2.6",
+		"next": ">=15.5.21 <16 || >=16.2.11",
 		"rclone.js": "^0.6.6",
 		"wrangler": "catalog:"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,8 +61,8 @@ catalogs:
       specifier: ^5.4.1
       version: 5.4.1
     next:
-      specifier: ^15.5.18
-      version: 15.5.18
+      specifier: ^15.5.21
+      version: 15.5.21
     react:
       specifier: 19.0.6
       version: 19.0.6
@@ -104,8 +104,8 @@ catalogs:
       specifier: 10.4.15
       version: 10.4.15
     next:
-      specifier: 16.2.6
-      version: 16.2.6
+      specifier: 16.2.11
+      version: 16.2.11
     postcss:
       specifier: 8.4.27
       version: 8.4.27
@@ -157,8 +157,8 @@ importers:
   examples/bugs/gh-119:
     dependencies:
       next:
-        specifier: 15.5.18
-        version: 15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 15.5.21
+        version: 15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
         specifier: ^19.0.6
         version: 19.2.6
@@ -239,11 +239,11 @@ importers:
         specifier: ^5.0.9
         version: 5.0.9
       next:
-        specifier: 15.5.18
-        version: 15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 15.5.21
+        version: 15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next-auth:
         specifier: ^4.24.11
-        version: 4.24.11(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 4.24.11(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next-themes:
         specifier: ^0.4.4
         version: 0.4.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -336,8 +336,8 @@ importers:
         specifier: ^3.971.0
         version: 3.971.0
       next:
-        specifier: 15.5.18
-        version: 15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 15.5.21
+        version: 15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
         specifier: ^19.0.6
         version: 19.2.6
@@ -386,7 +386,7 @@ importers:
     dependencies:
       next:
         specifier: 'catalog:'
-        version: 15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.0.6(react@19.0.6))(react@19.0.6)
+        version: 15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.0.6(react@19.0.6))(react@19.0.6)
       react:
         specifier: 'catalog:'
         version: 19.0.6
@@ -438,7 +438,7 @@ importers:
         version: link:../../../packages/cloudflare
       next:
         specifier: catalog:e2e
-        version: 16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.0.6(react@19.0.6))(react@19.0.6)
+        version: 16.2.11(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.0.6(react@19.0.6))(react@19.0.6)
       react:
         specifier: catalog:e2e
         version: 19.0.6
@@ -484,7 +484,7 @@ importers:
         version: link:../../../packages/cloudflare
       next:
         specifier: catalog:e2e
-        version: 16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.0.6(react@19.0.6))(react@19.0.6)
+        version: 16.2.11(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.0.6(react@19.0.6))(react@19.0.6)
       react:
         specifier: catalog:e2e
         version: 19.0.6
@@ -527,7 +527,7 @@ importers:
         version: link:../../../packages/cloudflare
       next:
         specifier: catalog:e2e
-        version: 16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.0.6(react@19.0.6))(react@19.0.6)
+        version: 16.2.11(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.0.6(react@19.0.6))(react@19.0.6)
       react:
         specifier: catalog:e2e
         version: 19.0.6
@@ -564,7 +564,7 @@ importers:
         version: link:../../../packages/cloudflare
       next:
         specifier: catalog:e2e
-        version: 16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.0.6(react@19.0.6))(react@19.0.6)
+        version: 16.2.11(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.0.6(react@19.0.6))(react@19.0.6)
       react:
         specifier: catalog:e2e
         version: 19.0.6
@@ -604,7 +604,7 @@ importers:
     dependencies:
       next:
         specifier: catalog:e2e
-        version: 16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.0.6(react@19.0.6))(react@19.0.6)
+        version: 16.2.11(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.0.6(react@19.0.6))(react@19.0.6)
       react:
         specifier: catalog:e2e
         version: 19.0.6
@@ -623,10 +623,10 @@ importers:
     dependencies:
       '@clerk/nextjs':
         specifier: 6.9.6
-        version: 6.9.6(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.0.6(react@19.0.6))(react@19.0.6))(react-dom@19.0.6(react@19.0.6))(react@19.0.6)
+        version: 6.9.6(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.0.6(react@19.0.6))(react@19.0.6))(react-dom@19.0.6(react@19.0.6))(react@19.0.6)
       next:
         specifier: 'catalog:'
-        version: 15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.0.6(react@19.0.6))(react@19.0.6)
+        version: 15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.0.6(react@19.0.6))(react@19.0.6)
       react:
         specifier: 'catalog:'
         version: 19.0.6
@@ -663,7 +663,7 @@ importers:
     dependencies:
       next:
         specifier: catalog:e2e
-        version: 16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.0.6(react@19.0.6))(react@19.0.6)
+        version: 16.2.11(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.0.6(react@19.0.6))(react@19.0.6)
       react:
         specifier: catalog:e2e
         version: 19.0.6
@@ -697,7 +697,7 @@ importers:
     dependencies:
       next:
         specifier: catalog:e2e
-        version: 16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.0.6(react@19.0.6))(react@19.0.6)
+        version: 16.2.11(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.0.6(react@19.0.6))(react@19.0.6)
       react:
         specifier: catalog:e2e
         version: 19.0.6
@@ -731,7 +731,7 @@ importers:
     dependencies:
       next:
         specifier: catalog:e2e
-        version: 16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.0.6(react@19.0.6))(react@19.0.6)
+        version: 16.2.11(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.0.6(react@19.0.6))(react@19.0.6)
       react:
         specifier: catalog:e2e
         version: 19.0.6
@@ -765,7 +765,7 @@ importers:
     dependencies:
       next:
         specifier: catalog:e2e
-        version: 16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.0.6(react@19.0.6))(react@19.0.6)
+        version: 16.2.11(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.0.6(react@19.0.6))(react@19.0.6)
       react:
         specifier: catalog:e2e
         version: 19.0.6
@@ -799,7 +799,7 @@ importers:
     dependencies:
       next:
         specifier: catalog:e2e
-        version: 16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.0.6(react@19.0.6))(react@19.0.6)
+        version: 16.2.11(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.0.6(react@19.0.6))(react@19.0.6)
       react:
         specifier: catalog:e2e
         version: 19.0.6
@@ -833,7 +833,7 @@ importers:
     dependencies:
       next:
         specifier: 'catalog:'
-        version: 15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.0.6(react@19.0.6))(react@19.0.6)
+        version: 15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.0.6(react@19.0.6))(react@19.0.6)
       react:
         specifier: 'catalog:'
         version: 19.0.6
@@ -863,8 +863,8 @@ importers:
   examples/playground16:
     dependencies:
       next:
-        specifier: 16.2.6
-        version: 16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 16.2.11
+        version: 16.2.11(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -913,7 +913,7 @@ importers:
         version: 6.7.0(prisma@6.7.0(typescript@5.9.3))(typescript@5.9.3)
       next:
         specifier: catalog:e2e
-        version: 16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.0.6(react@19.0.6))(react@19.0.6)
+        version: 16.2.11(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.0.6(react@19.0.6))(react@19.0.6)
       react:
         specifier: catalog:e2e
         version: 19.0.6
@@ -953,7 +953,7 @@ importers:
         version: 7.8.0(prisma@7.8.0(@types/react-dom@19.0.6(@types/react@19.0.6))(@types/react@19.0.6)(better-sqlite3@11.8.1)(react-dom@19.0.6(react@19.0.6))(react@19.0.6)(typescript@5.9.3))(typescript@5.9.3)
       next:
         specifier: catalog:e2e
-        version: 16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.0.6(react@19.0.6))(react@19.0.6)
+        version: 16.2.11(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.0.6(react@19.0.6))(react@19.0.6)
       react:
         specifier: catalog:e2e
         version: 19.0.6
@@ -986,8 +986,8 @@ importers:
   examples/ssg-app:
     dependencies:
       next:
-        specifier: 15.5.18
-        version: 15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 15.5.21
+        version: 15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
         specifier: ^19.0.6
         version: 19.2.6
@@ -1030,7 +1030,7 @@ importers:
         version: 4.0.3
       next:
         specifier: 'catalog:'
-        version: 15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.0.6(react@19.0.6))(react@19.0.6)
+        version: 15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.0.6(react@19.0.6))(react@19.0.6)
       react:
         specifier: 'catalog:'
         version: 19.0.6
@@ -1082,7 +1082,7 @@ importers:
         version: 1.31.0
       '@opennextjs/aws':
         specifier: 4.0.2
-        version: 4.0.2(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+        version: 4.0.2(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       ci-info:
         specifier: ^4.2.0
         version: 4.2.0
@@ -1158,7 +1158,7 @@ importers:
         version: 5.4.1
       next:
         specifier: 'catalog:'
-        version: 15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       picomatch:
         specifier: ^4.0.2
         version: 4.0.2
@@ -1814,9 +1814,6 @@ packages:
 
   '@emnapi/core@1.9.2':
     resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
-
-  '@emnapi/runtime@1.7.1':
-    resolution: {integrity: sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==}
 
   '@emnapi/runtime@1.9.2':
     resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
@@ -3230,11 +3227,11 @@ packages:
   '@neon-rs/load@0.0.4':
     resolution: {integrity: sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==}
 
-  '@next/env@15.5.18':
-    resolution: {integrity: sha512-hAV85Ckd9QR6RvH04MEKwsfLTksvFpO47j9xwtoIuvuPnlwecpSi+uZTtm8HirVbtlI2Fnz//xpcSTjFdyJk+g==}
+  '@next/env@15.5.21':
+    resolution: {integrity: sha512-hjJI/GfrjWHgNguRIBzItjRRu0m3Nrz17GhxsjuHfjIvg9hyg3239REd2dpI+bpMTFuVrVprHzEQ19m++cDtbw==}
 
-  '@next/env@16.2.6':
-    resolution: {integrity: sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==}
+  '@next/env@16.2.11':
+    resolution: {integrity: sha512-0do5A3BJ2gxWr0ZCMcD6BhW+e595jyxdTl3rXTS6lOtD8ektMiW6CO+EPwt1Eca1DBnm90r/7GdiKWBKxH++DA==}
 
   '@next/eslint-plugin-next@14.2.14':
     resolution: {integrity: sha512-kV+OsZ56xhj0rnTn6HegyTGkoa16Mxjrpk7pjWumyB2P8JVQb8S9qtkjy/ye0GnTr4JWtWG4x/2qN40lKZ3iVQ==}
@@ -3248,106 +3245,106 @@ packages:
   '@next/eslint-plugin-next@15.5.16':
     resolution: {integrity: sha512-pXa+4smRrgzea94YeAR8txf2CYg4pc1HkcoLUigrE5a0j70dVdUYMKfsOGCe8ulDSLvqnm2keMoxKss5RxHokg==}
 
-  '@next/swc-darwin-arm64@15.5.18':
-    resolution: {integrity: sha512-w0WvQf1n+txiwns/9pwIQteCJpZTbxzO2SE0FLcwuD4v0WEh1JPOjdyxWL21XwJsdpx8cFRjyzxzCS/siP7HcQ==}
+  '@next/swc-darwin-arm64@15.5.21':
+    resolution: {integrity: sha512-ZfjqPEdi6TRC/fWx7UDbwb1fbVgyh2uD5tVTRKIDZDlYM+UNuE/LafDG2fwuAoZilADpABh46OY/F5qf9JjqLQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-arm64@16.2.6':
-    resolution: {integrity: sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==}
+  '@next/swc-darwin-arm64@16.2.11':
+    resolution: {integrity: sha512-wryL4pjKmDwGv2ox6+GZDFxvmtSRLqApBR8kL1j4+vhB7Z5vJC/zAnXpiR9Xkfzl0AS8WLMnsuGV/UKI67/rrw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@15.5.18':
-    resolution: {integrity: sha512-znn71QmDuxm+BOaglihMZfvyySMnNljkVIY5Z2TCssBmm+WqL6c19VhtH5ktFkHa8EZ2bnTUpcNcmNSQsg67og==}
+  '@next/swc-darwin-x64@15.5.21':
+    resolution: {integrity: sha512-TlCf1NpxgQLzTrexuev75xwmNCJMd1/qkJpTVP1GRRcih93hlIBn1P72hkh8T0gnRFr6BmWksQtbyG3jT6jnww==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.2.6':
-    resolution: {integrity: sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==}
+  '@next/swc-darwin-x64@16.2.11':
+    resolution: {integrity: sha512-aZl2j4f/fLyjQvOhv0Oe9UaMAQHolYpKhctsoYzplSumKJKPUmgjcf6545aBtysLTcu994TREd0+pSgNE4ohmg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@15.5.18':
-    resolution: {integrity: sha512-yPPe5MNL+igZUa+OsqQJisqSfh6oarIuA1Q0BDxljGJhRQyZeP+WRHh7rs/jZUGMh5aY0YdIjXZG0VohkKkUdw==}
+  '@next/swc-linux-arm64-gnu@15.5.21':
+    resolution: {integrity: sha512-LXRsq1p+HvHSi7ygwNcSEEcK0zuo5jS75ZlqFHtOH+LF7qntXAJVJxah+1Pi/GyBm7EpkwU7m4EgbvIKrMqm9A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-arm64-gnu@16.2.6':
-    resolution: {integrity: sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==}
+  '@next/swc-linux-arm64-gnu@16.2.11':
+    resolution: {integrity: sha512-5jEriyEnH/LWFy27L2ZG0XaLlyEJIjhsImEsiS9P563PKEVp2BVups/xfOucIrsvVntp11oNcZwjHvaDPYVB5g==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-arm64-musl@15.5.18':
-    resolution: {integrity: sha512-glaCczEWIrHsokFZ3pP08U4BpKxwIdnT+txdOM32OBgpL9Yw4aqx8NejmgtZQZOdstQ5f0L3CasIZudzCuD+nw==}
+  '@next/swc-linux-arm64-musl@15.5.21':
+    resolution: {integrity: sha512-hyGixhFxpDKjqoev6l4KlcRBlt9AXWrGhDZwmwg49sMJM5tnKQPSi+SEj9+e5n+l/bthRGZUdh59GKIs6lQPRw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-arm64-musl@16.2.6':
-    resolution: {integrity: sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==}
+  '@next/swc-linux-arm64-musl@16.2.11':
+    resolution: {integrity: sha512-eIjcpx2fnnFSSkZDbTxy74KnokUXDjfoLClpWelfgHLf621aTqswhwXQ7GkD5K5rplrS6LZ/Bj+mVuvzluBOEg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-x64-gnu@15.5.18':
-    resolution: {integrity: sha512-oUfg2EgJmU3R0OCOWiokGFUTvZiPfXtriXiuF3YNxRoROCdgvTedHIzYoeKH34gsZxS/V7mHbfq2hpAHwhH1/A==}
+  '@next/swc-linux-x64-gnu@15.5.21':
+    resolution: {integrity: sha512-qfE+YfOba6S2+13e8qn1/UozDVNZ2clBlrs8UtDoax4s8ediu6sq93z66OEHUYlb69Tffh5JTNkgtsAKiSuugg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-x64-gnu@16.2.6':
-    resolution: {integrity: sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==}
+  '@next/swc-linux-x64-gnu@16.2.11':
+    resolution: {integrity: sha512-8WgzpaWMs46qJT9kiV47cje86L0x/Mu9t8/Gwj+pnbgW3rETVfCnaScPjlYUwNScpOozdcIMHWmAvuZJUonR2w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-x64-musl@15.5.18':
-    resolution: {integrity: sha512-JLxSP3KTd9iu/bvUMQxH7RJo9xKSHf55/6RPE4a6FTSZygGn7uvZbCej0AHXydwkggQGSD9UddSjwv6Xz5ESfA==}
+  '@next/swc-linux-x64-musl@15.5.21':
+    resolution: {integrity: sha512-BXLGG+EvIwp/Rrgl6HY8sqvD6BOUOIRz8/naDbeLNX7mlA5H2XRcL6MW/0IGnJISfj5BA9gNhFyJj5yOoiIDJQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-x64-musl@16.2.6':
-    resolution: {integrity: sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==}
+  '@next/swc-linux-x64-musl@16.2.11':
+    resolution: {integrity: sha512-I3UgPds7G4ZYnTb/H+5GBGuUT2DhAk6j0mL6A4s63RjFs74wB2hOWP0vaxsK+3NJraExt3eYEPQ/UtT0x/64Nw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-win32-arm64-msvc@15.5.18':
-    resolution: {integrity: sha512-ir1v7enP52K2HNz3tQQvwF+x7VNxBk1ciiZ18WBPvxf4C59IqdfmHPJYK3vH7rSxpuCVw/8C712wTXNAtEp+NA==}
+  '@next/swc-win32-arm64-msvc@15.5.21':
+    resolution: {integrity: sha512-tNGNOlT0Wn7E4IMsSnufjXN/l2L2/AGdLLpa2vzS89SYCBuihgLn3ngLsIrvndAnWo9nAkus+4gZHTI/Ijx9HA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-arm64-msvc@16.2.6':
-    resolution: {integrity: sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==}
+  '@next/swc-win32-arm64-msvc@16.2.11':
+    resolution: {integrity: sha512-n89CjtcThnjrwgJMAiI5xbqwLY51zvwC9tSlArmVndAJLYVl9T9UAdlkXTmZvE++idoXe8KdglQlhNRdUp1c6g==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@15.5.18':
-    resolution: {integrity: sha512-LIu5me6QTANCd25E7I5uIEfvgQ06RK7tvHAbYo3zCb3VpxQEPvMcSpd87NwUABDT6MbGPdEGR5VRiK4PPTJhQg==}
+  '@next/swc-win32-x64-msvc@15.5.21':
+    resolution: {integrity: sha512-DmIdWmC9p4rdNIiQqo8ap0+Cnj6kKtTZnuSCxoYydSc8sgpDgAg9wFhxplunak9imLV0pTvc5WVCOHwm5eHLtQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.2.6':
-    resolution: {integrity: sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==}
+  '@next/swc-win32-x64-msvc@16.2.11':
+    resolution: {integrity: sha512-md8CLNggS1Dx9pUgApzps5uAf+N8GN9xywzmNx9vHAWo94HtBwCCqkSnhIrdfQe83Dhz8Lfo/20Nb1Zxal092w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -7724,8 +7721,8 @@ packages:
       react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
       react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
-  next@15.5.18:
-    resolution: {integrity: sha512-eKL8zUJkX9Y5lE+RX/2YJoItVdGlIscyVyboeD9wSpp0PaGqjoA4tTpT2qPqz9ax+5IzGESyLSeZ/RCwbSZ2uQ==}
+  next@15.5.21:
+    resolution: {integrity: sha512-/TsdBtkWLhkl+NVL3Uqws2UphNd6IPzOtzSk1fHaf+0P7GQKLZDUytyhns/Ykbzdy9+YRjwG7ONvrHaaTDdFqQ==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
     hasBin: true
     peerDependencies:
@@ -7745,8 +7742,8 @@ packages:
       sass:
         optional: true
 
-  next@16.2.6:
-    resolution: {integrity: sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==}
+  next@16.2.11:
+    resolution: {integrity: sha512-B339zaqbyK8cmxhoAvLrcwoabwCP1wz21zSzfqxqXAemTu2BXnH7tQnfcglKv1vnMUIDBc+Hth7XODQriTZiRQ==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -11052,14 +11049,14 @@ snapshots:
       react-dom: 19.0.6(react@19.0.6)
       tslib: 2.4.1
 
-  '@clerk/nextjs@6.9.6(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.0.6(react@19.0.6))(react@19.0.6))(react-dom@19.0.6(react@19.0.6))(react@19.0.6)':
+  '@clerk/nextjs@6.9.6(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.0.6(react@19.0.6))(react@19.0.6))(react-dom@19.0.6(react@19.0.6))(react@19.0.6)':
     dependencies:
       '@clerk/backend': 1.21.4(react-dom@19.0.6(react@19.0.6))(react@19.0.6)
       '@clerk/clerk-react': 5.21.0(react-dom@19.0.6(react@19.0.6))(react@19.0.6)
       '@clerk/shared': 2.20.4(react-dom@19.0.6(react@19.0.6))(react@19.0.6)
       '@clerk/types': 4.40.0
       crypto-js: 4.2.0
-      next: 15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.0.6(react@19.0.6))(react@19.0.6)
+      next: 15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.0.6(react@19.0.6))(react@19.0.6)
       react: 19.0.6
       react-dom: 19.0.6(react@19.0.6)
       server-only: 0.0.1
@@ -11157,11 +11154,6 @@ snapshots:
   '@emnapi/core@1.9.2':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/runtime@1.7.1':
-    dependencies:
       tslib: 2.8.1
     optional: true
 
@@ -12202,7 +12194,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.34.5':
     dependencies:
-      '@emnapi/runtime': 1.7.1
+      '@emnapi/runtime': 1.9.2
     optional: true
 
   '@img/sharp-win32-arm64@0.34.5':
@@ -12379,9 +12371,9 @@ snapshots:
 
   '@neon-rs/load@0.0.4': {}
 
-  '@next/env@15.5.18': {}
+  '@next/env@15.5.21': {}
 
-  '@next/env@16.2.6': {}
+  '@next/env@16.2.11': {}
 
   '@next/eslint-plugin-next@14.2.14':
     dependencies:
@@ -12399,52 +12391,52 @@ snapshots:
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/swc-darwin-arm64@15.5.18':
+  '@next/swc-darwin-arm64@15.5.21':
     optional: true
 
-  '@next/swc-darwin-arm64@16.2.6':
+  '@next/swc-darwin-arm64@16.2.11':
     optional: true
 
-  '@next/swc-darwin-x64@15.5.18':
+  '@next/swc-darwin-x64@15.5.21':
     optional: true
 
-  '@next/swc-darwin-x64@16.2.6':
+  '@next/swc-darwin-x64@16.2.11':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@15.5.18':
+  '@next/swc-linux-arm64-gnu@15.5.21':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.2.6':
+  '@next/swc-linux-arm64-gnu@16.2.11':
     optional: true
 
-  '@next/swc-linux-arm64-musl@15.5.18':
+  '@next/swc-linux-arm64-musl@15.5.21':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.2.6':
+  '@next/swc-linux-arm64-musl@16.2.11':
     optional: true
 
-  '@next/swc-linux-x64-gnu@15.5.18':
+  '@next/swc-linux-x64-gnu@15.5.21':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.2.6':
+  '@next/swc-linux-x64-gnu@16.2.11':
     optional: true
 
-  '@next/swc-linux-x64-musl@15.5.18':
+  '@next/swc-linux-x64-musl@15.5.21':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.2.6':
+  '@next/swc-linux-x64-musl@16.2.11':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@15.5.18':
+  '@next/swc-win32-arm64-msvc@15.5.21':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.2.6':
+  '@next/swc-win32-arm64-msvc@16.2.11':
     optional: true
 
-  '@next/swc-win32-x64-msvc@15.5.18':
+  '@next/swc-win32-x64-msvc@15.5.21':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.2.6':
+  '@next/swc-win32-x64-msvc@16.2.11':
     optional: true
 
   '@noble/ciphers@1.3.0': {}
@@ -12556,7 +12548,7 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 24.2.0
 
-  '@opennextjs/aws@4.0.2(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@opennextjs/aws@4.0.2(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
       '@ast-grep/napi': 0.40.5
       '@aws-sdk/client-cloudfront': 3.984.0
@@ -12572,7 +12564,7 @@ snapshots:
       cookie: 1.0.2
       esbuild: 0.25.4
       express: 5.2.1
-      next: 15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       path-to-regexp: 6.3.0
       urlpattern-polyfill: 10.1.0
       yaml: 2.8.2
@@ -18264,13 +18256,13 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  next-auth@4.24.11(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  next-auth@4.24.11(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@babel/runtime': 7.25.7
       '@panva/hkdf': 1.2.1
       cookie: 0.7.1
       jose: 4.15.9
-      next: 15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       oauth: 0.9.15
       openid-client: 5.7.1
       preact: 10.25.4
@@ -18284,9 +18276,9 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.0.6(react@19.0.6))(react@19.0.6):
+  next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.0.6(react@19.0.6))(react@19.0.6):
     dependencies:
-      '@next/env': 15.5.18
+      '@next/env': 15.5.21
       '@swc/helpers': 0.5.15
       caniuse-lite: 1.0.30001717
       postcss: 8.4.31
@@ -18294,14 +18286,14 @@ snapshots:
       react-dom: 19.0.6(react@19.0.6)
       styled-jsx: 5.1.6(react@19.0.6)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 15.5.18
-      '@next/swc-darwin-x64': 15.5.18
-      '@next/swc-linux-arm64-gnu': 15.5.18
-      '@next/swc-linux-arm64-musl': 15.5.18
-      '@next/swc-linux-x64-gnu': 15.5.18
-      '@next/swc-linux-x64-musl': 15.5.18
-      '@next/swc-win32-arm64-msvc': 15.5.18
-      '@next/swc-win32-x64-msvc': 15.5.18
+      '@next/swc-darwin-arm64': 15.5.21
+      '@next/swc-darwin-x64': 15.5.21
+      '@next/swc-linux-arm64-gnu': 15.5.21
+      '@next/swc-linux-arm64-musl': 15.5.21
+      '@next/swc-linux-x64-gnu': 15.5.21
+      '@next/swc-linux-x64-musl': 15.5.21
+      '@next/swc-win32-arm64-msvc': 15.5.21
+      '@next/swc-win32-x64-msvc': 15.5.21
       '@opentelemetry/api': 1.9.0
       '@playwright/test': 1.51.1
       sharp: 0.34.5
@@ -18309,9 +18301,9 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
-      '@next/env': 15.5.18
+      '@next/env': 15.5.21
       '@swc/helpers': 0.5.15
       caniuse-lite: 1.0.30001717
       postcss: 8.4.31
@@ -18319,14 +18311,14 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
       styled-jsx: 5.1.6(react@19.2.6)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 15.5.18
-      '@next/swc-darwin-x64': 15.5.18
-      '@next/swc-linux-arm64-gnu': 15.5.18
-      '@next/swc-linux-arm64-musl': 15.5.18
-      '@next/swc-linux-x64-gnu': 15.5.18
-      '@next/swc-linux-x64-musl': 15.5.18
-      '@next/swc-win32-arm64-msvc': 15.5.18
-      '@next/swc-win32-x64-msvc': 15.5.18
+      '@next/swc-darwin-arm64': 15.5.21
+      '@next/swc-darwin-x64': 15.5.21
+      '@next/swc-linux-arm64-gnu': 15.5.21
+      '@next/swc-linux-arm64-musl': 15.5.21
+      '@next/swc-linux-x64-gnu': 15.5.21
+      '@next/swc-linux-x64-musl': 15.5.21
+      '@next/swc-win32-arm64-msvc': 15.5.21
+      '@next/swc-win32-x64-msvc': 15.5.21
       '@opentelemetry/api': 1.9.0
       '@playwright/test': 1.51.1
       sharp: 0.34.5
@@ -18334,9 +18326,9 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.0.6(react@19.0.6))(react@19.0.6):
+  next@16.2.11(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.0.6(react@19.0.6))(react@19.0.6):
     dependencies:
-      '@next/env': 16.2.6
+      '@next/env': 16.2.11
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.13
       caniuse-lite: 1.0.30001717
@@ -18345,14 +18337,14 @@ snapshots:
       react-dom: 19.0.6(react@19.0.6)
       styled-jsx: 5.1.6(react@19.0.6)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.2.6
-      '@next/swc-darwin-x64': 16.2.6
-      '@next/swc-linux-arm64-gnu': 16.2.6
-      '@next/swc-linux-arm64-musl': 16.2.6
-      '@next/swc-linux-x64-gnu': 16.2.6
-      '@next/swc-linux-x64-musl': 16.2.6
-      '@next/swc-win32-arm64-msvc': 16.2.6
-      '@next/swc-win32-x64-msvc': 16.2.6
+      '@next/swc-darwin-arm64': 16.2.11
+      '@next/swc-darwin-x64': 16.2.11
+      '@next/swc-linux-arm64-gnu': 16.2.11
+      '@next/swc-linux-arm64-musl': 16.2.11
+      '@next/swc-linux-x64-gnu': 16.2.11
+      '@next/swc-linux-x64-musl': 16.2.11
+      '@next/swc-win32-arm64-msvc': 16.2.11
+      '@next/swc-win32-x64-msvc': 16.2.11
       '@opentelemetry/api': 1.9.0
       '@playwright/test': 1.51.1
       sharp: 0.34.5
@@ -18360,9 +18352,9 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  next@16.2.11(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
-      '@next/env': 16.2.6
+      '@next/env': 16.2.11
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.13
       caniuse-lite: 1.0.30001717
@@ -18371,14 +18363,14 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
       styled-jsx: 5.1.6(react@19.2.6)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.2.6
-      '@next/swc-darwin-x64': 16.2.6
-      '@next/swc-linux-arm64-gnu': 16.2.6
-      '@next/swc-linux-arm64-musl': 16.2.6
-      '@next/swc-linux-x64-gnu': 16.2.6
-      '@next/swc-linux-x64-musl': 16.2.6
-      '@next/swc-win32-arm64-msvc': 16.2.6
-      '@next/swc-win32-x64-msvc': 16.2.6
+      '@next/swc-darwin-arm64': 16.2.11
+      '@next/swc-darwin-x64': 16.2.11
+      '@next/swc-linux-arm64-gnu': 16.2.11
+      '@next/swc-linux-arm64-musl': 16.2.11
+      '@next/swc-linux-x64-gnu': 16.2.11
+      '@next/swc-linux-x64-musl': 16.2.11
+      '@next/swc-win32-arm64-msvc': 16.2.11
+      '@next/swc-win32-x64-msvc': 16.2.11
       '@opentelemetry/api': 1.9.0
       '@playwright/test': 1.51.1
       sharp: 0.34.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,7 +26,7 @@ catalog:
   glob: ^12.0.0
   globals: ^15.9.0
   mock-fs: ^5.4.1
-  next: ^15.5.18
+  next: ^15.5.21
   package-manager-detector: ^0.2.0
   react: 19.0.6
   react-dom: 19.0.6
@@ -44,7 +44,7 @@ catalogs:
     "@types/react": 19.0.6
     "@types/react-dom": 19.0.6
     autoprefixer: 10.4.15
-    next: 16.2.6
+    next: 16.2.11
     postcss: 8.4.27
     react: 19.0.6
     react-dom: 19.0.6


### PR DESCRIPTION
## Summary

- raise the supported Next.js peer dependency floors to 15.5.21 and 16.2.11, the latest npm releases for each supported major
- update the matching workspace catalogs, examples, and create-cloudflare template
- add a patch changeset

## Testing

- pnpm code:checks
- pnpm test