### PR TITLE
fix: ignore Vercel OG traces for split functions

### DIFF
--- a/.changeset/tidy-pandas-build.md
+++ b/.changeset/tidy-pandas-build.md
@@ -1,0 +1,7 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+fix: ignore Vercel OG traces for routes assigned to split functions.
+
+Only patch Vercel OG files that are present in the default server function, preventing builds from failing when another function owns an OG route.

--- a/packages/cloudflare/src/cli/build/patches/ast/patch-vercel-og-library.spec.ts
+++ b/packages/cloudflare/src/cli/build/patches/ast/patch-vercel-og-library.spec.ts
@@ -1,14 +1,15 @@
-import { mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import path from "node:path";
 
 import { BuildOptions } from "@opennextjs/aws/build/helper.js";
 import mockFs from "mock-fs";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { patchVercelOgLibrary } from "./patch-vercel-og-library.js";
 
 const nodeModulesVercelOgDir = "node_modules/.pnpm/next@14.2.11/node_modules/next/dist/compiled/@vercel/og";
 const nextServerOgNftPath = "examples/api/.next/server/app/og/route.js.nft.json";
+const splitFunctionOgNftPath = "examples/api/.next/server/app/split/page.js.nft.json";
 const openNextFunctionDir = "examples/api/.open-next/server-functions/default/examples/api";
 const openNextOgRoutePath = path.join(openNextFunctionDir, ".next/server/app/og/route.js");
 const openNextVercelOgDir = path.join(openNextFunctionDir, "node_modules/next/dist/compiled/@vercel/og");
@@ -20,16 +21,21 @@ const buildOpts = {
 } as BuildOptions;
 
 describe("patchVercelOgLibrary", () => {
-	beforeAll(() => {
+	beforeEach(() => {
 		mockFs();
 
 		mkdirSync(nodeModulesVercelOgDir, { recursive: true });
 		mkdirSync(path.dirname(nextServerOgNftPath), { recursive: true });
+		mkdirSync(path.dirname(splitFunctionOgNftPath), { recursive: true });
 		mkdirSync(path.dirname(openNextOgRoutePath), { recursive: true });
 		mkdirSync(openNextVercelOgDir, { recursive: true });
 
 		writeFileSync(
 			nextServerOgNftPath,
+			JSON.stringify({ version: 1, files: [`../../../../../../${nodeModulesVercelOgDir}/index.node.js`] })
+		);
+		writeFileSync(
+			splitFunctionOgNftPath,
 			JSON.stringify({ version: 1, files: [`../../../../../../${nodeModulesVercelOgDir}/index.node.js`] })
 		);
 		writeFileSync(
@@ -41,9 +47,9 @@ describe("patchVercelOgLibrary", () => {
 		writeFileSync(path.join(openNextVercelOgDir, "noto-sans-v27-latin-regular.ttf"), "");
 	});
 
-	afterAll(() => mockFs.restore());
+	afterEach(() => mockFs.restore());
 
-	it("should patch the open-next files correctly", () => {
+	it("patches included routes and ignores routes assigned to another function", () => {
 		patchVercelOgLibrary(buildOpts);
 
 		expect(readdirSync(openNextVercelOgDir)).toMatchInlineSnapshot(`
@@ -67,5 +73,14 @@ describe("patchVercelOgLibrary", () => {
 		expect(readFileSync(openNextOgRoutePath, { encoding: "utf-8" })).toMatchInlineSnapshot(
 			`"e.exports=import("next/dist/compiled/@vercel/og/index.edge.js")"`
 		);
+	});
+
+	it("does not report OG usage for routes assigned to another function", () => {
+		unlinkSync(nextServerOgNftPath);
+
+		expect(existsSync(nextServerOgNftPath)).toBe(false);
+		expect(existsSync(path.join(openNextFunctionDir, ".next/server/app/split/page.js"))).toBe(false);
+		expect(patchVercelOgLibrary(buildOpts)).toBe(false);
+		expect(readdirSync(openNextVercelOgDir)).toEqual(["index.node.js", "noto-sans-v27-latin-regular.ttf"]);
 	});
 });

--- a/packages/cloudflare/src/cli/build/patches/ast/patch-vercel-og-library.ts
+++ b/packages/cloudflare/src/cli/build/patches/ast/patch-vercel-og-library.ts
@@ -32,6 +32,9 @@ export function patchVercelOgLibrary(buildOpts: BuildOptions): boolean {
 		const tracedNodePath = traceInfo.files.find((p) => p.endsWith("@vercel/og/index.node.js"));
 		if (!tracedNodePath) continue;
 
+		const routeFilePath = traceInfoPath.replace(appBuildOutputPath, packagePath).replace(".nft.json", "");
+		if (!existsSync(routeFilePath)) continue;
+
 		// If we are here, it means the application is using the @vercel/og library
 		// and there is an `index.edge.js` colocated file that we need to copy and patch.
 		useOg = true;
@@ -73,8 +76,6 @@ export function patchVercelOgLibrary(buildOpts: BuildOptions): boolean {
 		// Change node imports for the library to edge imports.
 		// This is only useful when turbopack is not used to bundle the function.
 		{
-			const routeFilePath = traceInfoPath.replace(appBuildOutputPath, packagePath).replace(".nft.json", "");
-
 			const ast = parseFile(routeFilePath);
 			const { edits } = patchVercelOgImport(ast);
 			writeFileSync(routeFilePath, ast.commitEdits(edits));


### PR DESCRIPTION
## Summary

- skip Vercel OG traces whose route is not present in the default server function
- keep OG usage detection and asset patching scoped to routes bundled into that function
- add regression coverage for mixed and split-only OG routes

## Root cause

`patchVercelOgLibrary` scanned NFT traces from the complete Next.js build, but parsed the corresponding route under `server-functions/default`. Named-function routes remain in the build traces while being intentionally absent from the default package, causing ENOENT during parsing.

## Testing

- `pnpm --filter cloudflare exec vitest --run src/cli/build/patches/ast/patch-vercel-og-library.spec.ts`
- `pnpm code:checks`
- `pnpm test` (34 test files, 343 tests)

Closes #1314