### PR TITLE
feat: support Next.js 16 proxy.ts / Node.js middleware (rebase of #1309)

### DIFF
--- a/.changeset/proxy-node-middleware.md
+++ b/.changeset/proxy-node-middleware.md
@@ -1,0 +1,14 @@
+---
+"@opennextjs/cloudflare": minor
+---
+
+feature: support Node.js middleware (`proxy.ts`)
+
+Next.js 16 replaces `middleware.ts` with `proxy.ts` which always runs on the Node.js runtime.
+
+The Node.js middleware is now bundled into a Workers compatible `middleware/handler.mjs`:
+the OpenNext config manifests are inlined at build time (as for the edge middleware) and the
+middleware compiled by Next.js is statically bundled instead of being loaded from the
+filesystem at runtime (workerd can not access the filesystem nor load modules at runtime).
+
+The support is experimental and requires the `nodejs_compat` compatibility flag.

--- a/.changeset/proxy-node-middleware.md
+++ b/.changeset/proxy-node-middleware.md
@@ -1,8 +1,8 @@
 ---
-"@opennextjs/cloudflare": minor
+"@opennextjs/cloudflare": patch
 ---
 
-feature: support Node.js middleware (`proxy.ts`)
+feature: experimental support for Node.js middleware (`proxy.ts`)
 
 Next.js 16 replaces `middleware.ts` with `proxy.ts` which always runs on the Node.js runtime.
 

--- a/examples/e2e/experimental/e2e/nodeMiddleware.test.ts
+++ b/examples/e2e/experimental/e2e/nodeMiddleware.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "@playwright/test";
 
 // See https://github.com/opennextjs/opennextjs-cloudflare/issues/617
 test.describe("Node Middleware", () => {
-	test.skip("Node middleware should add headers", async ({ request }) => {
+	test("Node middleware should add headers", async ({ request }) => {
 		const resp = await request.get("/");
 		expect(resp.status()).toEqual(200);
 		const headers = resp.headers();
@@ -10,21 +10,21 @@ test.describe("Node Middleware", () => {
 		expect(headers["x-random-node"]).toBeDefined();
 	});
 
-	test.skip("Node middleware should return json", async ({ request }) => {
+	test("Node middleware should return json", async ({ request }) => {
 		const resp = await request.get("/api/hello");
 		expect(resp.status()).toEqual(200);
 		const json = await resp.json();
 		expect(json).toEqual({ name: "World" });
 	});
 
-	test.skip("Node middleware should redirect", async ({ page }) => {
+	test("Node middleware should redirect", async ({ page }) => {
 		await page.goto("/redirect");
 		await page.waitForURL("/");
 		const el = page.getByText("Incremental PPR");
 		await expect(el).toBeVisible();
 	});
 
-	test.skip("Node middleware should rewrite", async ({ page }) => {
+	test("Node middleware should rewrite", async ({ page }) => {
 		await page.goto("/rewrite");
 		const el = page.getByText("Incremental PPR");
 		await expect(el).toBeVisible();

--- a/examples/e2e/experimental/src/proxy.ts
+++ b/examples/e2e/experimental/src/proxy.ts
@@ -1,10 +1,10 @@
-// Node middleware is not supported yet in cloudflare
+// `proxy.ts` replaces `middleware.ts` in Next.js 16 and always runs on the Node.js runtime.
 // See https://github.com/opennextjs/opennextjs-cloudflare/issues/617
 
-// import crypto from "node:crypto";
+import crypto from "node:crypto";
 import { type NextRequest, NextResponse } from "next/server";
 
-export default function middleware(request: NextRequest) {
+export default function proxy(request: NextRequest) {
 	if (request.nextUrl.pathname === "/api/hello") {
 		return NextResponse.json({
 			name: "World",
@@ -20,11 +20,7 @@ export default function middleware(request: NextRequest) {
 	return NextResponse.next({
 		headers: {
 			"x-middleware-test": "1",
-			// "x-random-node": crypto.randomUUID(),
+			"x-random-node": crypto.randomUUID(),
 		},
 	});
 }
-
-// export const config = {
-//   runtime: "nodejs",
-// };

--- a/packages/cloudflare/src/cli/build/build.ts
+++ b/packages/cloudflare/src/cli/build/build.ts
@@ -12,6 +12,7 @@ import { OpenNextConfig } from "../../api/config.js";
 import type { ProjectOptions } from "../project-options.js";
 import { ensureNextjsVersionSupported } from "../utils/nextjs-support.js";
 import { bundleServer } from "./bundle-server.js";
+import { bundleNodeMiddleware } from "./open-next/bundle-node-middleware.js";
 import { compileCacheAssetsManifestSqlFile } from "./open-next/compile-cache-assets-manifest.js";
 import { compileEnvFiles } from "./open-next/compile-env-files.js";
 import { compileImages } from "./open-next/compile-images.js";
@@ -81,10 +82,11 @@ export async function build(
 		buildNextjsApp(options);
 	}
 
-	// Make sure no Node.js middleware is used
-	if (useNodeMiddleware(options)) {
-		logger.error("Node.js middleware is not currently supported. Consider switching to Edge Middleware.");
-		process.exit(1);
+	const hasNodeMiddleware = useNodeMiddleware(options);
+	if (hasNodeMiddleware) {
+		logger.warn(
+			"Node.js middleware support is experimental, make sure that `nodejs_compat` is enabled in your wrangler configuration."
+		);
 	}
 
 	// Generate deployable bundle
@@ -100,6 +102,10 @@ export async function build(
 
 	// Compile middleware
 	await createMiddleware(options, { forceOnlyBuildOnce: true });
+
+	if (hasNodeMiddleware) {
+		await bundleNodeMiddleware(options);
+	}
 
 	createStaticAssets(options, { useBasePath: true });
 

--- a/packages/cloudflare/src/cli/build/bundle-server.ts
+++ b/packages/cloudflare/src/cli/build/bundle-server.ts
@@ -62,7 +62,7 @@ export async function bundleServer(buildOpts: BuildOptions, projectOpts: Project
 
 	console.log(`\x1b[35m⚙️ Bundling the OpenNext server...\n\x1b[0m`);
 
-	await patchWebpackRuntime(buildOpts);
+	await patchWebpackRuntime(path.join(dotNextPath, "server"));
 	const useOg = patchVercelOgLibrary(buildOpts);
 
 	const outputPath = path.join(outputDir, "server-functions", "default");

--- a/packages/cloudflare/src/cli/build/open-next/bundle-node-middleware.ts
+++ b/packages/cloudflare/src/cli/build/open-next/bundle-node-middleware.ts
@@ -54,7 +54,8 @@ async function inlineMiddlewareChunks(options: BuildOptions, dotNextServerDir: s
 	}
 
 	// The Turbopack runtime resolves the chunks relative to the `.next` directory.
-	const tracedFiles = await glob(path.join(dotNextServerDir, "**/*.js"), {
+	// `.wasm` chunks are needed too: they are inlined as static imports by `loadWasmChunk`.
+	const tracedFiles = await glob(path.join(dotNextServerDir, "**/*.{js,wasm}"), {
 		windowsPathsNoEscape: true,
 	});
 
@@ -229,7 +230,8 @@ globalThis.AsyncLocalStorage = AsyncLocalStorage;
 const defaultDefineProperty = Object.defineProperty;
 Object.defineProperty = function (o, p, a) {
 	if (p === "__import_unsupported" && Boolean(globalThis.__import_unsupported)) {
-		return;
+		// \`Object.defineProperty\` returns the object it was passed.
+		return o;
 	}
 	return defaultDefineProperty(o, p, a);
 };

--- a/packages/cloudflare/src/cli/build/open-next/bundle-node-middleware.ts
+++ b/packages/cloudflare/src/cli/build/open-next/bundle-node-middleware.ts
@@ -14,11 +14,11 @@
  *   `@opennextjs/aws` copies to `middleware/<package path>/.next/server/middleware.js`
  */
 
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { isBuiltin } from "node:module";
 import path from "node:path";
 
-import { type BuildOptions, getPackagePath } from "@opennextjs/aws/build/helper.js";
+import { type BuildOptions, getBundlerRuntime, getPackagePath } from "@opennextjs/aws/build/helper.js";
 import logger from "@opennextjs/aws/logger.js";
 import { openNextEdgePlugins } from "@opennextjs/aws/plugins/edge.js";
 import { openNextExternalMiddlewarePlugin } from "@opennextjs/aws/plugins/externalMiddleware.js";
@@ -26,8 +26,47 @@ import { openNextReplacementPlugin } from "@opennextjs/aws/plugins/replacement.j
 import { openNextResolvePlugin } from "@opennextjs/aws/plugins/resolve.js";
 import { getCrossPlatformPathRegex } from "@opennextjs/aws/utils/regex.js";
 import { build, type Plugin } from "esbuild";
+import { glob } from "glob";
 
+import { normalizePath } from "../../utils/normalize-path.js";
 import { patchWebpackRuntime } from "../patches/ast/webpack-runtime.js";
+import { patchTurbopackRuntimeCode } from "../patches/plugins/turbopack.js";
+import { setWranglerExternal } from "../patches/plugins/wrangler-external.js";
+
+/**
+ * Inlines the chunks of the middleware compiled by Next.js.
+ *
+ * Both the webpack and the Turbopack runtimes resolve the chunks they need at runtime,
+ * which workerd does not support. The same patches as for the server are used to inline them.
+ *
+ * @param options Build options.
+ * @param dotNextServerDir The `.next/server` directory of the middleware output.
+ */
+async function inlineMiddlewareChunks(options: BuildOptions, dotNextServerDir: string): Promise<void> {
+	if (getBundlerRuntime(options) !== "turbopack") {
+		await patchWebpackRuntime(dotNextServerDir);
+		return;
+	}
+
+	const runtimePath = path.join(dotNextServerDir, "chunks/[turbopack]_runtime.js");
+	if (!existsSync(runtimePath)) {
+		throw new Error(`Turbopack runtime not found at ${runtimePath}`);
+	}
+
+	// The Turbopack runtime resolves the chunks relative to the `.next` directory.
+	const tracedFiles = await glob(path.join(dotNextServerDir, "**/*.js"), {
+		windowsPathsNoEscape: true,
+	});
+
+	writeFileSync(
+		runtimePath,
+		patchTurbopackRuntimeCode({
+			code: readFileSync(runtimePath, "utf-8"),
+			filePath: normalizePath(runtimePath),
+			tracedFiles,
+		})
+	);
+}
 
 /**
  * Resolves the middleware compiled by Next.js to the copy created by `copyTracedFiles`.
@@ -86,9 +125,9 @@ export async function bundleNodeMiddleware(options: BuildOptions): Promise<void>
 		throw new Error(`Compiled Node.js middleware not found at ${compiledMiddleware}`);
 	}
 
-	// The middleware uses the same webpack runtime as the server, inline its dynamic requires
-	// so that the chunks are statically bundled.
-	await patchWebpackRuntime(dotNextServerDir);
+	// The bundler runtime resolves the chunks of the middleware at runtime, which workerd does
+	// not support. Inline the chunks so that they are statically bundled.
+	await inlineMiddlewareChunks(options, dotNextServerDir);
 
 	logger.info("Bundling Node.js middleware...");
 
@@ -165,6 +204,8 @@ export async function bundleNodeMiddleware(options: BuildOptions): Promise<void>
 				path.join(options.openNextDistDir, "core", "nodeMiddlewareHandler.js")
 			),
 			setCompiledMiddlewarePlugin(compiledMiddleware),
+			// `.wasm` and `.bin` files are bundled by wrangler, not by this build
+			setWranglerExternal(),
 			// Must be registered before `openNextEdgePlugins` to handle `require("node:*")` calls
 			nodeBuiltinsPlugin(),
 			// Inline the config manifests

--- a/packages/cloudflare/src/cli/build/open-next/bundle-node-middleware.ts
+++ b/packages/cloudflare/src/cli/build/open-next/bundle-node-middleware.ts
@@ -1,0 +1,202 @@
+/**
+ * Bundles the Node.js middleware (`proxy.ts` / `middleware.ts` with the `nodejs` runtime)
+ * into a Workers compatible `middleware/handler.mjs`.
+ *
+ * `@opennextjs/aws` bundles the external middleware for a Node.js server:
+ * the OpenNext config is read from the filesystem at runtime and the middleware compiled
+ * by Next.js is loaded with `await import("./.next/server/middleware.js")`.
+ *
+ * workerd can not access the filesystem nor load modules at runtime, so the handler
+ * built by `@opennextjs/aws` is replaced with a fully self-contained bundle:
+ *
+ * - the config manifests are inlined by `openNextEdgePlugins` (as for the edge middleware)
+ * - the middleware compiled by Next.js is statically bundled from the traced files that
+ *   `@opennextjs/aws` copies to `middleware/<package path>/.next/server/middleware.js`
+ */
+
+import { existsSync } from "node:fs";
+import { isBuiltin } from "node:module";
+import path from "node:path";
+
+import { type BuildOptions, getPackagePath } from "@opennextjs/aws/build/helper.js";
+import logger from "@opennextjs/aws/logger.js";
+import { openNextEdgePlugins } from "@opennextjs/aws/plugins/edge.js";
+import { openNextExternalMiddlewarePlugin } from "@opennextjs/aws/plugins/externalMiddleware.js";
+import { openNextReplacementPlugin } from "@opennextjs/aws/plugins/replacement.js";
+import { openNextResolvePlugin } from "@opennextjs/aws/plugins/resolve.js";
+import { getCrossPlatformPathRegex } from "@opennextjs/aws/utils/regex.js";
+import { build, type Plugin } from "esbuild";
+
+import { patchWebpackRuntime } from "../patches/ast/webpack-runtime.js";
+
+/**
+ * Resolves the middleware compiled by Next.js to the copy created by `copyTracedFiles`.
+ */
+export function setCompiledMiddlewarePlugin(compiledMiddlewarePath: string): Plugin {
+	return {
+		name: "compiled-middleware",
+		setup(build) {
+			build.onResolve({ filter: getCrossPlatformPathRegex("./.next/server/middleware.js") }, () => ({
+				path: compiledMiddlewarePath,
+			}));
+		},
+	};
+}
+
+/**
+ * Makes the Node.js builtins used by the bundled code (i.e. `require("crypto")` or
+ * `import from "node:crypto"`) resolve to the modules workerd provides via `nodejs_compat`.
+ *
+ * `require` calls are converted into ESM imports via a virtual module. The virtual module
+ * re-exports the default export so that the interop helpers in the middleware compiled by
+ * Next.js receive the full module (`export * from ...` alone would drop the default export).
+ */
+export function nodeBuiltinsPlugin(): Plugin {
+	const namespace = "node-builtins";
+	return {
+		name: namespace,
+		setup(build) {
+			build.onResolve({ filter: /.*/ }, ({ path: specifier, kind }) => {
+				if (!isBuiltin(specifier)) {
+					return undefined;
+				}
+				const prefixed = specifier.startsWith("node:") ? specifier : `node:${specifier}`;
+				return kind === "require-call" ? { path: prefixed, namespace } : { path: prefixed, external: true };
+			});
+			build.onLoad({ filter: /.*/, namespace }, ({ path: builtin }) => ({
+				contents: `
+					import * as mod from "${builtin}";
+					export * from "${builtin}";
+					export default mod.default ?? mod;
+				`,
+				loader: "js",
+			}));
+		},
+	};
+}
+
+export async function bundleNodeMiddleware(options: BuildOptions): Promise<void> {
+	const { config, outputDir } = options;
+
+	const middlewareDir = path.join(outputDir, "middleware");
+	const dotNextServerDir = path.join(middlewareDir, getPackagePath(options), ".next/server");
+	const compiledMiddleware = path.join(dotNextServerDir, "middleware.js");
+
+	if (!existsSync(compiledMiddleware)) {
+		throw new Error(`Compiled Node.js middleware not found at ${compiledMiddleware}`);
+	}
+
+	// The middleware uses the same webpack runtime as the server, inline its dynamic requires
+	// so that the chunks are statically bundled.
+	await patchWebpackRuntime(dotNextServerDir);
+
+	logger.info("Bundling Node.js middleware...");
+
+	const middlewareConfig = config.middleware?.external ? config.middleware : undefined;
+	const overrides = {
+		...middlewareConfig?.override,
+		originResolver: middlewareConfig?.originResolver,
+	};
+	function override<T extends keyof typeof overrides>(target: T) {
+		// String and lazy loaded overrides are supported, see `buildEdgeBundle`
+		return typeof overrides[target] === "string" || typeof overrides[target] === "function"
+			? overrides[target]
+			: undefined;
+	}
+	const includeCache = config.dangerous?.enableCacheInterception;
+
+	await build({
+		entryPoints: [path.join(options.openNextDistDir, "adapters", "middleware.js")],
+		outfile: path.join(middlewareDir, "handler.mjs"),
+		allowOverwrite: true,
+		bundle: true,
+		format: "esm",
+		target: "es2022",
+		platform: "neutral",
+		minify: options.minify,
+		sourcemap: options.debug ? "inline" : false,
+		sourcesContent: false,
+		treeShaking: true,
+		conditions: ["module"],
+		mainFields: ["module", "main"],
+		external: ["node:*", "./open-next.config.mjs"],
+		define: {
+			// The base of the middleware compiled by Next.js is runtime agnostic.
+			// "edge" skips the setup of the Node.js environment (`setup-node-env.external.js`
+			// patches globals that are read-only in workerd). Node.js builtin modules used by
+			// the middleware are provided by workerd via `nodejs_compat`.
+			"process.env.NEXT_RUNTIME": '"edge"',
+			"process.env.NODE_ENV": '"production"',
+		},
+		alias: {
+			path: "node:path",
+			stream: "node:stream",
+			fs: "node:fs",
+			// `next/dist/server/lib/trace/tracer.js` requires `@opentelemetry/api`, an optional
+			// dependency that most apps do not install. On the Node.js runtime Next.js falls back
+			// to its own compiled copy when the require throws, but not on the edge runtime.
+			// Use the compiled copy, which is always present.
+			"@opentelemetry/api": "next/dist/compiled/@opentelemetry/api",
+		},
+		plugins: [
+			openNextResolvePlugin({
+				overrides: {
+					wrapper: override("wrapper") ?? "cloudflare-edge",
+					converter: override("converter") ?? "edge",
+					...(includeCache
+						? {
+								tagCache: override("tagCache"),
+								incrementalCache: override("incrementalCache"),
+								queue: override("queue"),
+							}
+						: {}),
+					originResolver: override("originResolver") ?? "pattern-env",
+					proxyExternalRequest: override("proxyExternalRequest") ?? "fetch",
+				},
+				fnName: "middleware",
+			}),
+			openNextReplacementPlugin({
+				name: "externalMiddlewareOverrides",
+				target: getCrossPlatformPathRegex("adapters/middleware.js"),
+				deletes: includeCache ? [] : ["includeCacheInMiddleware"],
+			}),
+			// Handle the middleware with the OpenNext Node.js middleware handler
+			openNextExternalMiddlewarePlugin(
+				path.join(options.openNextDistDir, "core", "nodeMiddlewareHandler.js")
+			),
+			setCompiledMiddlewarePlugin(compiledMiddleware),
+			// Must be registered before `openNextEdgePlugins` to handle `require("node:*")` calls
+			nodeBuiltinsPlugin(),
+			// Inline the config manifests
+			openNextEdgePlugins({
+				nextDir: path.join(options.appBuildOutputPath, ".next"),
+				isInCloudflare: true,
+			}),
+		] as Plugin[],
+		banner: {
+			js: `
+import { Buffer } from "node:buffer";
+globalThis.Buffer = Buffer;
+
+import { AsyncLocalStorage } from "node:async_hooks";
+globalThis.AsyncLocalStorage = AsyncLocalStorage;
+
+// Next.js sets \`__import_unsupported\` on \`globalThis\` with \`configurable: false\`.
+// The middleware and the server both run this code in the same Worker, the second
+// call would throw so it is skipped.
+// See https://github.com/vercel/next.js/blob/5b7833e3/packages/next/src/server/web/globals.ts#L94-L98
+const defaultDefineProperty = Object.defineProperty;
+Object.defineProperty = function (o, p, a) {
+	if (p === "__import_unsupported" && Boolean(globalThis.__import_unsupported)) {
+		return;
+	}
+	return defaultDefineProperty(o, p, a);
+};
+
+globalThis.openNextDebug = ${options.debug};
+globalThis.openNextVersion = "${options.openNextVersion}";
+globalThis.nextVersion = "${options.nextVersion}";
+`,
+		},
+	});
+}

--- a/packages/cloudflare/src/cli/build/patches/ast/webpack-runtime.ts
+++ b/packages/cloudflare/src/cli/build/patches/ast/webpack-runtime.ts
@@ -23,7 +23,6 @@
 import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { type BuildOptions, getPackagePath } from "@opennextjs/aws/build/helper.js";
 import { patchCode } from "@opennextjs/aws/build/patch/astCodePatcher.js";
 
 // Inline the code when there are multiple chunks
@@ -73,22 +72,16 @@ fix: |
  * Fixes the webpack-runtime.js and webpack-api-runtime.js files by inlining
  * the webpack dynamic requires.
  */
-export async function patchWebpackRuntime(buildOpts: BuildOptions) {
-	const { outputDir } = buildOpts;
-
-	const dotNextServerDir = join(
-		outputDir,
-		"server-functions/default",
-		getPackagePath(buildOpts),
-		".next/server"
-	);
-
+export async function patchWebpackRuntime(dotNextServerDir: string) {
 	// Look for all the chunks.
-	const chunks = readdirSync(join(dotNextServerDir, "chunks"))
-		.filter((chunk) => /^\d+\.js$/.test(chunk))
-		.map((chunk) => {
-			return Number(chunk.replace(/\.js$/, ""));
-		});
+	const chunksDir = join(dotNextServerDir, "chunks");
+	const chunks = existsSync(chunksDir)
+		? readdirSync(chunksDir)
+				.filter((chunk) => /^\d+\.js$/.test(chunk))
+				.map((chunk) => {
+					return Number(chunk.replace(/\.js$/, ""));
+				})
+		: [];
 
 	patchFile(join(dotNextServerDir, "webpack-runtime.js"), chunks);
 	patchFile(join(dotNextServerDir, "webpack-api-runtime.js"), chunks);

--- a/packages/cloudflare/src/cli/build/patches/plugins/turbopack.ts
+++ b/packages/cloudflare/src/cli/build/patches/plugins/turbopack.ts
@@ -253,6 +253,40 @@ function discoverExternalSubpaths(mappings: Map<string, string>, tracedFiles: st
 	return subpaths;
 }
 
+/**
+ * Inline the dynamic chunk requires of the Turbopack runtime.
+ *
+ * The runtime resolves the chunks it needs at runtime, which workerd does not support.
+ * The chunks are inlined so that they are statically bundled.
+ *
+ * @param code The code of the Turbopack runtime.
+ * @param filePath Path to the Turbopack runtime, in the OpenNext output.
+ * @param tracedFiles The files traced by Next.js, copied next to the runtime.
+ * @returns The patched code.
+ */
+export function patchTurbopackRuntimeCode({
+	code,
+	filePath,
+	tracedFiles,
+}: {
+	code: string;
+	filePath: string;
+	tracedFiles: string[];
+}): string {
+	tracedFiles = tracedFiles.map(normalizePath);
+	filePath = normalizePath(filePath);
+
+	const mappings = discoverExternalModuleMappings(filePath);
+	const externalImportRule = buildExternalImportRule(mappings, tracedFiles, code);
+	let patched = patchCode(code, externalImportRule);
+	patched = patchCode(patched, inlineChunksRule);
+	patched = patchCode(patched, replaceLoadWebAssemblyModuleRule);
+	patched = patchCode(patched, replaceLoadWebAssemblyRule);
+
+	return `${patched}
+${inlineChunksFn(tracedFiles)}\n${loadWasmChunkFn(tracedFiles)}`;
+}
+
 export const patchTurbopackRuntime: CodePatcher = {
 	name: "inline-turbopack-chunks",
 	patches: [
@@ -262,20 +296,8 @@ export const patchTurbopackRuntime: CodePatcher = {
 				escape: false,
 			}),
 			contentFilter: /loadRuntimeChunkPath/,
-			patchCode: async ({ code, tracedFiles, filePath }) => {
-				tracedFiles = tracedFiles.map(normalizePath);
-				filePath = normalizePath(filePath);
-
-				const mappings = discoverExternalModuleMappings(filePath);
-				const externalImportRule = buildExternalImportRule(mappings, tracedFiles, code);
-				let patched = patchCode(code, externalImportRule);
-				patched = patchCode(patched, inlineChunksRule);
-				patched = patchCode(patched, replaceLoadWebAssemblyModuleRule);
-				patched = patchCode(patched, replaceLoadWebAssemblyRule);
-
-				return `${patched}
-${inlineChunksFn(tracedFiles)}\n${loadWasmChunkFn(tracedFiles)}`;
-			},
+			patchCode: async ({ code, tracedFiles, filePath }) =>
+				patchTurbopackRuntimeCode({ code, filePath, tracedFiles }),
 		},
 	],
 };


### PR DESCRIPTION
## Summary

Ships Next.js 16 `proxy.ts` / Node.js middleware support on the **currently published** `@opennextjs/cloudflare` package.

This is a rebased, merge-ready continuation of @ScienHAC's work in #1309 (credit fully theirs), brought onto latest `main` (`da4b7fc` / 1.20.2) so it can land without waiting for the adapters-api cutover.

Closes #617  
Closes #1277  
Related: #962, #1082, opennextjs/adapters-api#20, opennextjs/adapters-api#38

> **Why this repo, not only adapters-api?**  
> npm still publishes `@opennextjs/cloudflare` from **this** repository (latest `1.20.2` on 2026-07-21). adapters-api#38 is the longer-term path but is stacked on #35, currently dirty, and does not yet publish the live package. Until cutover, Next 16 apps stay broken on every release unless this lands here.

## What

After OpenNext builds the external Node middleware for a Node server, Cloudflare re-bundles it into a self-contained `middleware/handler.mjs` that workerd can run (no FS, no runtime `import()` of `.next/*`):

- keep OpenNext routing (`adapters/middleware.js` + `nodeMiddlewareHandler`)
- statically bundle compiled middleware from traced files
- inline manifests via existing edge plugins
- `NEXT_RUNTIME="edge"` so read-only workerd globals aren't patched
- webpack + Turbopack chunk inlining
- experimental warning + require `nodejs_compat`

No behavior change when the app has no Node middleware.

## Test plan (executed locally on this branch)

```bash
pnpm install
cd examples/e2e/experimental
node ../../../packages/cloudflare/dist/cli/index.js build
node ../../../packages/cloudflare/dist/cli/index.js preview -- --port 8801
```

**Build:** succeeds with:

```text
ƒ Proxy (Middleware)
WARN Node.js middleware support is experimental...
Bundling Node.js middleware...
Worker saved in `.open-next/worker.js`
```

**Runtime (`proxy.ts` uses `node:crypto.randomUUID()`):**

| Request | Result |
| --- | --- |
| `HEAD /` | `200`, `x-middleware-test: 1`, `x-random-node: <uuid>` |
| `HEAD /redirect` | `307` → `/` |
| `GET /api/hello` | `200` `{"name":"World"}` |
| `HEAD /rewrite` | `200` (rewritten to `/`) |

Baseline without this change still fails with:

```text
ERROR Node.js middleware is not currently supported. Consider switching to Edge Middleware.
```

## Notes for maintainers

- Original PR: #1309 (author @ScienHAC; conico974 said 2026-07-28 they'd look)
- I only rebased onto current main and re-verified build+runtime end-to-end
- Happy to add more e2e coverage or adjust the experimental warning wording
- If the project decision is truly "only adapters-api", please say so on #617 with a ship date — right now that path cannot unblock npm users


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opennextjs/opennextjs-cloudflare/pull/1320" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->