### PR TITLE
security: add remotePatterns validation to /cdn-cgi/image/ handler

### DIFF
--- a/.changeset/fix-cdn-cgi-image-ssrf.md
+++ b/.changeset/fix-cdn-cgi-image-ssrf.md
@@ -1,0 +1,14 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+fix: add remotePatterns validation to /cdn-cgi/image/ handler
+
+The `handleCdnCgiImageRequest()` handler now validates remote URLs against the
+configured `remotePatterns` before fetching, matching the behavior of
+`handleImageRequest()`. This provides defense-in-depth against SSRF in case
+`/cdn-cgi/image/` requests reach the worker through non-edge paths (e.g.,
+service binding calls). The validation is only applied when `remotePatterns`
+are configured, preserving existing development behavior.
+
+Related: CVE-2026-3125 (GHSA-c7mq-gh6q-6q7c)

--- a/packages/cloudflare/src/cli/templates/images.ts
+++ b/packages/cloudflare/src/cli/templates/images.ts
@@ -203,6 +203,23 @@ export async function handleCdnCgiImageRequest(requestURL: URL, env: CloudflareE
 		const absoluteURL = new URL(parseResult.url, requestURL);
 		imageResponse = await env.ASSETS.fetch(absoluteURL);
 	} else {
+		// Validate remote URLs against configured remote patterns (defense-in-depth).
+		// This handler is intended for development use only, but service binding requests
+		// can reach it in production, bypassing edge interception.
+		// Only validate when remotePatterns are configured; when empty (e.g. custom image
+		// loader without remotePatterns), skip the check to preserve dev emulation behavior.
+		// See: CVE-2026-3125 (GHSA-c7mq-gh6q-6q7c)
+		if (__IMAGES_REMOTE_PATTERNS__.length > 0) {
+			let parsedUrl: URL;
+			try {
+				parsedUrl = new URL(parseResult.url);
+			} catch {
+				return new Response('"url" parameter is invalid', { status: 400 });
+			}
+			if (!hasRemoteMatch(__IMAGES_REMOTE_PATTERNS__, parsedUrl)) {
+				return new Response('"url" parameter is not allowed', { status: 400 });
+			}
+		}
 		imageResponse = await fetch(parseResult.url);
 	}
 


### PR DESCRIPTION
## Summary

The handleCdnCgiImageRequest() handler in images.ts performs etch(parseResult.url) with **zero URL validation**, unlike handleImageRequest() which validates URLs via hasRemoteMatch() against emotePatterns.

This was the root cause of [CVE-2026-3125](https://github.com/opennextjs/opennextjs-cloudflare/security/advisories/GHSA-c7mq-gh6q-6q7c). The original patch blocked the backslash path normalization bypass at the edge, but did **NOT** add code-level validation to the handler.

## The Problem

handleCdnCgiImageRequest() is documented as development-only (worker.ts L27-28), but:
1. The handler is compiled into **ALL** production builds via compileImages()
2. Internal service binding requests (WORKER_SELF_REFERENCE.fetch()) bypass edge interception and reach the handler directly
3. The handler performs etch(parseResult.url) on ANY https:// URL without validation

## The Fix

This patch adds emotePatterns validation to handleCdnCgiImageRequest(), matching the validation already performed by handleImageRequest() via hasRemoteMatch(). Remote URLs that don't match the configured patterns are rejected with a 400 response.

## Related

- [CVE-2026-3125 / GHSA-c7mq-gh6q-6q7c](https://github.com/opennextjs/opennextjs-cloudflare/security/advisories/GHSA-c7mq-gh6q-6q7c)
- GitHub Issue: #1329
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opennextjs/opennextjs-cloudflare/pull/1330" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->