### PR TITLE
fix: retrieveCompiledConfig should respect buildOutputPath

### DIFF
--- a/.changeset/retrieve-compiled-config-build-output-path.md
+++ b/.changeset/retrieve-compiled-config-build-output-path.md
@@ -1,0 +1,17 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+Fix `deploy`/`preview`/`upload`/`populateCache` failing when `buildOutputPath` is set
+
+`retrieveCompiledConfig` looked for the compiled config under a hardcoded
+`<cwd>/.open-next/.build/`, which does not follow the `buildOutputPath` config.
+Every command that goes through it therefore exited with `Could not find
+compiled Open Next config, did you run the build command?` right after a
+successful build. `build` itself was unaffected because it compiles the config
+from source, so the failure only showed up at deploy time.
+
+The compiled path cannot simply be prefixed with `buildOutputPath` — that value
+lives in the very config being loaded. When the file is missing, the config is
+now recompiled from source instead (the same path `build` takes;
+`compileOpenNextConfig` emits to a temp dir, so nothing lands in the project).

--- a/.changeset/retrieve-compiled-config-build-output-path.md
+++ b/.changeset/retrieve-compiled-config-build-output-path.md
@@ -2,16 +2,20 @@
 "@opennextjs/cloudflare": patch
 ---
 
-Fix `deploy`/`preview`/`upload`/`populateCache` failing when `buildOutputPath` is set
+fix: make `retrieveCompiledConfig` respect `buildOutputPath`
 
 `retrieveCompiledConfig` looked for the compiled config under a hardcoded
 `<cwd>/.open-next/.build/`, which does not follow the `buildOutputPath` config.
-Every command that goes through it therefore exited with `Could not find
-compiled Open Next config, did you run the build command?` right after a
-successful build. `build` itself was unaffected because it compiles the config
-from source, so the failure only showed up at deploy time.
+Every command that goes through it — `deploy`, `preview`, `upload` and
+`populateCache` — therefore exited with `Could not find compiled Open Next
+config, did you run the build command?` right after a successful build. `build`
+itself was unaffected because it compiles the config from source, so the failure
+only showed up at deploy time.
 
 The compiled path cannot simply be prefixed with `buildOutputPath` — that value
-lives in the very config being loaded. When the file is missing, the config is
-now recompiled from source instead (the same path `build` takes;
-`compileOpenNextConfig` emits to a temp dir, so nothing lands in the project).
+lives in the very config being loaded. When the compiled file is missing, the
+config is now recompiled from source instead (the same path `build` takes;
+`compileOpenNextConfig` emits to a temp dir, so nothing lands in the project),
+and the resolved output directory is then checked for the built worker. Running
+these commands without building still fails with the same actionable error,
+whether the source config is missing or the build was never run.

--- a/packages/cloudflare/src/cli/commands/utils/utils.spec.ts
+++ b/packages/cloudflare/src/cli/commands/utils/utils.spec.ts
@@ -1,9 +1,10 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import logger from "@opennextjs/aws/logger.js";
+import { beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
 
 import { askConfirmation } from "../../utils/ask-confirmation.js";
 import { createOpenNextConfigFile, findOpenNextConfig } from "../../utils/create-open-next-config.js";
 import { isNonInteractiveOrCI } from "../../utils/is-interactive.js";
-import { compileConfig } from "./utils.js";
+import { compileConfig, retrieveCompiledConfig } from "./utils.js";
 
 const { mockExistsSync } = vi.hoisted(() => ({
 	mockExistsSync: vi.fn(),
@@ -74,6 +75,11 @@ vi.mock("@opennextjs/aws/build/utils.js", () => ({
 // Mock build helper
 vi.mock("@opennextjs/aws/build/helper.js", () => ({
 	normalizeOptions: vi.fn(() => ({})),
+}));
+
+// Mock the worker path helper
+vi.mock("../../build/bundle-server.js", () => ({
+	getOutputWorkerPath: vi.fn(() => "/build-output/worker.js"),
 }));
 
 describe("compileConfig", () => {
@@ -160,5 +166,72 @@ describe("compileConfig", () => {
 
 		expect(askConfirmation).toHaveBeenCalledOnce();
 		expect(createOpenNextConfigFile).toHaveBeenCalledOnce();
+	});
+});
+
+describe("retrieveCompiledConfig", () => {
+	// The compiled config only lives under `<cwd>/.open-next/.build/` when `buildOutputPath` is
+	// left at its default, so these tests drive the two lookups independently.
+	function mockPaths({ compiledConfig, worker }: { compiledConfig: boolean; worker: boolean }) {
+		mockExistsSync.mockImplementation((p: string) => {
+			if (String(p).includes(".open-next/.build/")) return compiledConfig;
+			if (String(p).endsWith("worker.js")) return worker;
+			// The source config, checked by `compileConfig`.
+			return true;
+		});
+	}
+
+	let exitSpy: MockInstance<typeof process.exit>;
+
+	beforeEach(() => {
+		exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+			throw new Error("process.exit");
+		});
+	});
+
+	it("should recompile from source when a custom buildOutputPath moved the compiled config", async () => {
+		mockPaths({ compiledConfig: false, worker: true });
+		vi.mocked(findOpenNextConfig).mockReturnValue("/app/open-next.config.ts");
+
+		const result = await retrieveCompiledConfig();
+
+		expect(mockCompileOpenNextConfig).toHaveBeenCalledWith("/app/open-next.config.ts", {
+			compileEdge: true,
+		});
+		expect(result.config).toEqual({ default: {} });
+	});
+
+	it("should report a missing build when there is no source config either", async () => {
+		mockPaths({ compiledConfig: false, worker: false });
+		vi.mocked(findOpenNextConfig).mockReturnValue(undefined);
+
+		await expect(retrieveCompiledConfig()).rejects.toThrowError("process.exit");
+
+		expect(logger.error).toHaveBeenCalledWith(
+			"Could not find compiled Open Next config, did you run the build command?"
+		);
+		expect(exitSpy).toHaveBeenCalledWith(1);
+	});
+
+	it("should report a missing build when the source config exists but the app was never built", async () => {
+		mockPaths({ compiledConfig: false, worker: false });
+		vi.mocked(findOpenNextConfig).mockReturnValue("/app/open-next.config.ts");
+
+		await expect(retrieveCompiledConfig()).rejects.toThrowError("process.exit");
+
+		expect(logger.error).toHaveBeenCalledWith(
+			"Could not find compiled Open Next config, did you run the build command?"
+		);
+		expect(exitSpy).toHaveBeenCalledWith(1);
+	});
+
+	it("should never create a config file — these commands must not write to the project", async () => {
+		mockPaths({ compiledConfig: false, worker: false });
+		vi.mocked(findOpenNextConfig).mockReturnValue(undefined);
+
+		await expect(retrieveCompiledConfig()).rejects.toThrowError("process.exit");
+
+		expect(askConfirmation).not.toHaveBeenCalled();
+		expect(createOpenNextConfigFile).not.toHaveBeenCalled();
 	});
 });

--- a/packages/cloudflare/src/cli/commands/utils/utils.ts
+++ b/packages/cloudflare/src/cli/commands/utils/utils.ts
@@ -98,8 +98,11 @@ export async function retrieveCompiledConfig() {
 	const configPath = path.join(nextAppDir, ".open-next/.build/open-next.config.edge.mjs");
 
 	if (!existsSync(configPath)) {
-		logger.error("Could not find compiled Open Next config, did you run the build command?");
-		process.exit(1);
+		// The path above does not follow a custom `buildOutputPath`, which moves the compiled
+		// config out of `<cwd>/.open-next`. It cannot be resolved here either -- it lives in
+		// the very config we are trying to load. Recompile from the source config instead:
+		// `compileOpenNextConfig` emits to a temp dir, so nothing lands in the project.
+		return compileConfig(undefined);
 	}
 
 	const config = await import(url.pathToFileURL(configPath).href).then((mod) => mod.default);

--- a/packages/cloudflare/src/cli/commands/utils/utils.ts
+++ b/packages/cloudflare/src/cli/commands/utils/utils.ts
@@ -11,6 +11,7 @@ import { unstable_readConfig } from "wrangler";
 import type yargs from "yargs";
 
 import type { OpenNextConfig } from "../../../api/config.js";
+import { getOutputWorkerPath } from "../../build/bundle-server.js";
 import { ensureCloudflareConfig } from "../../build/utils/ensure-cf-config.js";
 import { askConfirmation } from "../../utils/ask-confirmation.js";
 import {
@@ -89,26 +90,48 @@ export async function compileConfig(configPath: string | undefined) {
 	return { config, buildDir };
 }
 
+const MISSING_BUILD_ERROR = "Could not find compiled Open Next config, did you run the build command?";
+
 /**
  * Retrieve a compiled OpenNext config, and ensure it is for Cloudflare.
  *
  * @returns OpenNext config.
  */
 export async function retrieveCompiledConfig() {
-	const configPath = path.join(nextAppDir, ".open-next/.build/open-next.config.edge.mjs");
+	const compiledConfigPath = path.join(nextAppDir, ".open-next/.build/open-next.config.edge.mjs");
 
-	if (!existsSync(configPath)) {
-		// The path above does not follow a custom `buildOutputPath`, which moves the compiled
-		// config out of `<cwd>/.open-next`. It cannot be resolved here either -- it lives in
-		// the very config we are trying to load. Recompile from the source config instead:
-		// `compileOpenNextConfig` emits to a temp dir, so nothing lands in the project.
-		return compileConfig(undefined);
+	if (existsSync(compiledConfigPath)) {
+		const config = await import(url.pathToFileURL(compiledConfigPath).href).then((mod) => mod.default);
+		ensureCloudflareConfig(config);
+
+		return { config };
 	}
 
-	const config = await import(url.pathToFileURL(configPath).href).then((mod) => mod.default);
-	ensureCloudflareConfig(config);
+	// The path above does not follow a custom `buildOutputPath`, and that value cannot be resolved
+	// here -- it lives in the very config we are trying to load. Recompile from the source config
+	// to find out where the build output actually is; `compileOpenNextConfig` emits to a temp dir,
+	// so nothing lands in the project.
+	//
+	// `findOpenNextConfig` is checked first so that a missing source config never reaches
+	// `compileConfig`, which would offer to create one -- these commands must not write to the
+	// project, and "no config at all" means the app was never built.
+	const sourceConfigPath = findOpenNextConfig(nextAppDir);
 
-	return { config };
+	if (!sourceConfigPath) {
+		logger.error(MISSING_BUILD_ERROR);
+		process.exit(1);
+	}
+
+	const { config, buildDir } = await compileConfig(sourceConfigPath);
+
+	// A source config on its own does not mean the app was built, so check for the worker the
+	// build emits. Without this, forgetting to build would surface as an obscure failure later.
+	if (!existsSync(getOutputWorkerPath(getNormalizedOptions(config)))) {
+		logger.error(MISSING_BUILD_ERROR);
+		process.exit(1);
+	}
+
+	return { config, buildDir };
 }
 
 /**


### PR DESCRIPTION
## What

`retrieveCompiledConfig` resolves the compiled config from a hardcoded path:

https://github.com/opennextjs/opennextjs-cloudflare/blob/main/packages/cloudflare/src/cli/commands/utils/utils.ts#L98

`<cwd>/.open-next/.build/` does not follow the `buildOutputPath` config, so with `buildOutputPath` set, every command that goes through this function — `deploy`, `preview`, `upload`, `populateCache` — exits immediately after a successful build:

```
┌──────────────────────────────┐
│ OpenNext — Cloudflare deploy │
└──────────────────────────────┘

ERROR Could not find compiled Open Next config, did you run the build command?
```

`build` is unaffected because it compiles the config from source via `compileConfig`, which is why this only surfaces at deploy time.

## Approach

The path can't simply be prefixed with `buildOutputPath`: that value lives in the very config being loaded, so it isn't known at this point. Instead, when the compiled file is missing, this falls back to recompiling from the source config — the same `compileConfig` path `build` takes. `compileOpenNextConfig` emits to `os.tmpdir()`, so nothing is written into the project.

Kept as a fallback rather than replacing the fast path, so projects without a custom `buildOutputPath` behave exactly as before.

If you'd rather have the command layer resolve `buildOutputPath` first and keep a single load path, I'm happy to rework it that way — just let me know.

## Related

`@opennextjs/aws` has the same class of bug in `getBundlerRuntime`, which breaks the *build* under a custom `buildOutputPath`. Fixed in opennextjs/opennextjs-aws#1208. Both are needed for `buildOutputPath` to work end to end — with only one of them applied you get a green build and a broken deploy, or no build at all.

## Testing

Verified against a monorepo Next.js 16.3.0 app (Turbopack) with `buildOutputPath: ".cache"`, using both patches:

```
opennextjs-cloudflare build          → Worker saved in `.cache/.open-next/worker.js`
opennextjs-cloudflare deploy --dry-run
  → Populating Workers static assets... Successfully populated
  → Read 143 files from the assets directory .../.cache/.open-next/assets
  → --dry-run: exiting now.
```

`pnpm lint:check`, `pnpm ts:check`, `pnpm test` (342 tests) and `prettier --check` all pass locally.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opennextjs/opennextjs-cloudflare/pull/1332" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->