### PR TITLE
perf: defer regional cache writes off the response path

### DIFF
--- a/.changeset/defer-regional-cache-write.md
+++ b/.changeset/defer-regional-cache-write.md
@@ -1,0 +1,9 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+perf: defer regional cache writes so they do not block the response
+
+Next.js awaits `incrementalCache.set` while producing the response, which put the R2
+write on the critical path. The returned value is unused, so the writes now run in
+`ctx.waitUntil` — matching how the read path already defers its cache updates.

--- a/.changeset/defer-regional-cache-write.md
+++ b/.changeset/defer-regional-cache-write.md
@@ -2,7 +2,7 @@
 "@opennextjs/cloudflare": patch
 ---
 
-perf: defer regional cache writes so they do not block the response
+fix: defer regional cache writes so they do not block the response
 
 Next.js awaits `incrementalCache.set` while producing the response, which put the R2
 write on the critical path. The returned value is unused, so the writes now run in

--- a/packages/cloudflare/src/api/overrides/incremental-cache/regional-cache.spec.ts
+++ b/packages/cloudflare/src/api/overrides/incremental-cache/regional-cache.spec.ts
@@ -1,0 +1,79 @@
+import type { IncrementalCache } from "@opennextjs/aws/types/overrides.js";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { getCloudflareContext } from "../../cloudflare-context.js";
+import { withRegionalCache } from "./regional-cache.js";
+
+vi.mock("../../cloudflare-context.js", () => ({
+	getCloudflareContext: vi.fn(),
+}));
+
+const mockedStore = {
+	name: "mocked-store",
+	get: vi.fn().mockResolvedValue(null),
+	set: vi.fn().mockResolvedValue(undefined),
+	delete: vi.fn().mockResolvedValue(undefined),
+} satisfies IncrementalCache;
+
+const mockedWaitUntil = vi.fn();
+const mockedPut = vi.fn();
+
+describe("regional-cache", () => {
+	beforeEach(() => {
+		// @ts-ignore
+		globalThis.caches = {
+			open: vi.fn().mockResolvedValue({
+				put: mockedPut,
+				match: vi.fn().mockResolvedValue(undefined),
+			}),
+		};
+		vi.mocked(getCloudflareContext).mockReturnValue({
+			ctx: { waitUntil: mockedWaitUntil },
+			// @ts-ignore only `ctx` is used here
+			env: {},
+		});
+	});
+
+	afterEach(() => {
+		vi.resetAllMocks();
+	});
+
+	describe("set", () => {
+		test("does not wait for the store write to complete", async () => {
+			let resolveStoreWrite: () => void = () => {};
+			mockedStore.set.mockReturnValue(
+				new Promise<void>((resolve) => {
+					resolveStoreWrite = resolve;
+				})
+			);
+			const cache = withRegionalCache(mockedStore, { mode: "long-lived" });
+
+			await cache.set("key", { type: "route", body: "", meta: {} });
+
+			// The store write is still pending, yet `set` has already resolved.
+			expect(mockedWaitUntil).toHaveBeenCalledTimes(1);
+			resolveStoreWrite();
+			await mockedWaitUntil.mock.calls[0]![0];
+			expect(mockedStore.set).toHaveBeenCalledTimes(1);
+		});
+
+		test("writes to the store and the regional cache in the background", async () => {
+			const cache = withRegionalCache(mockedStore, { mode: "long-lived" });
+
+			await cache.set("key", { type: "route", body: "", meta: {} });
+			await mockedWaitUntil.mock.calls[0]![0];
+
+			expect(mockedStore.set).toHaveBeenCalledWith("key", { type: "route", body: "", meta: {} }, undefined);
+			expect(mockedPut).toHaveBeenCalledTimes(1);
+		});
+
+		test("does not reject when the store write fails", async () => {
+			mockedStore.set.mockRejectedValue(new Error("store is unavailable"));
+			const cache = withRegionalCache(mockedStore, { mode: "long-lived" });
+
+			await expect(cache.set("key", { type: "route", body: "", meta: {} })).resolves.toBeUndefined();
+			// A rejected promise handed to `waitUntil` would surface as an unhandled rejection.
+			await expect(mockedWaitUntil.mock.calls[0]![0]).resolves.toBeUndefined();
+		});
+	});
+});

--- a/packages/cloudflare/src/api/overrides/incremental-cache/regional-cache.ts
+++ b/packages/cloudflare/src/api/overrides/incremental-cache/regional-cache.ts
@@ -179,24 +179,31 @@ class RegionalCache implements IncrementalCache {
 		value: CacheValue<CacheType>,
 		cacheType?: CacheType
 	): Promise<void> {
-		try {
-			debugCache("RegionalCache", `set ${key}`);
+		debugCache("RegionalCache", `set ${key}`);
 
-			await this.store.set(key, value, cacheType);
+		// Next.js awaits `set` while it produces the response, so awaiting the writes here
+		// puts them on the critical path. The returned value is not used, so they can run
+		// in the background without changing what is served.
+		getCloudflareContext().ctx.waitUntil(
+			(async () => {
+				try {
+					await this.store.set(key, value, cacheType);
 
-			await this.putToCache({
-				key,
-				cacheType,
-				entry: {
-					value,
-					// Note: `Date.now()` returns the time of the last IO rather than the actual time.
-					//       See https://developers.cloudflare.com/workers/reference/security-model/
-					lastModified: Date.now(),
-				},
-			});
-		} catch (e) {
-			error(`Failed to set the regional cache`, e);
-		}
+					await this.putToCache({
+						key,
+						cacheType,
+						entry: {
+							value,
+							// Note: `Date.now()` returns the time of the last IO rather than the actual time.
+							//       See https://developers.cloudflare.com/workers/reference/security-model/
+							lastModified: Date.now(),
+						},
+					});
+				} catch (e) {
+					error(`Failed to set the regional cache`, e);
+				}
+			})()
+		);
 	}
 
 	async delete(key: string): Promise<void> {


### PR DESCRIPTION
Fixes #1343

## What

`RegionalCache.set` now hands both writes to `ctx.waitUntil` instead of awaiting them.

## Why

Next.js awaits `incrementalCache.set` while producing the response:

```
Next.js  response-cache/index.js   await incrementalCache.set(...)
  └─ OpenNext adapters/cache.ts     await globalThis.incrementalCache.set(...)
       └─ RegionalCache.set          await this.store.set(...) → r2.put()
```

So the store round-trip lands in the TTFB. `response-cache/index.js` does not use the
returned value — it returns the same entry it passed in — so the writes can be deferred
without changing what is served.

The read path already defers its cache updates the same way:

```ts
// get(): refresh the regional cache in the background
getCloudflareContext().ctx.waitUntil(this.store.get(key, cacheType).then(...))
// get(): populate the regional cache after a store hit
getCloudflareContext().ctx.waitUntil(this.putToCache({ key, cacheType, entry }))
```

This makes `set` consistent with it — `putToCache` was previously deferred when reached
from `get` and awaited when reached from `set`.

## Measured impact

Production app on Workers with the R2 incremental cache, using Workers automatic tracing.

- `r2_put` spans: median 976 ms, up to 2,048 ms (14 of 20 sampled traces)
- TTFB on ISR misses before the change: 2.4–4.6 s

We ran this as a local override on a staging deployment, four requests each on ISR misses:

| | TTFB (median) |
|---|---:|
| deferred | 1.97 s |
| awaited | 2.45 s |

Repeated requests to the same page still returned `x-opennext-cache: HIT` at 0.32–0.69 s,
so cache behaviour is unchanged.

## Trade-off

Deferring the write widens the window in which a concurrent request for the same page
misses the cache and re-renders. That window already exists for the duration of the write;
deferring shifts its start rather than creating it.

## Notes

- Errors are still caught and logged inside the deferred task, so a failing write does not
  surface as an unhandled rejection.
- Added `regional-cache.spec.ts` covering the deferred path: `set` resolves while the store
  write is still pending, both writes run in the background, and a rejected store write does
  not reject the promise handed to `waitUntil`. The tests fail against the awaiting version.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opennextjs/opennextjs-cloudflare/pull/1345" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->