### PR TITLE
fix(cloudflare): declare esbuild as runtime dependency

### DIFF
--- a/.changeset/esbuild-dependency-82f9a43d.md
+++ b/.changeset/esbuild-dependency-82f9a43d.md
@@ -1,0 +1,7 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+fix: declare esbuild as runtime dependency
+
+esbuild is imported at build time by the Cloudflare adapter but was only in devDependencies, so consumers relied on hoisting from @opennextjs/aws. Add it to dependencies so builds work under npm ci and with hoist conflicts.

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -59,6 +59,7 @@
 		"cloudflare": "^4.4.1",
 		"comment-json": "^4.5.1",
 		"enquirer": "^2.4.1",
+		"esbuild": "catalog:",
 		"glob": "catalog:",
 		"ts-tqdm": "^0.8.6",
 		"yargs": "catalog:"
@@ -73,7 +74,6 @@
 		"@types/rclone.js": "^0.6.1",
 		"@types/yargs": "catalog:",
 		"diff": "^8.0.2",
-		"esbuild": "catalog:",
 		"eslint": "catalog:",
 		"eslint-plugin-import": "catalog:",
 		"eslint-plugin-simple-import-sort": "catalog:",

--- a/packages/cloudflare/src/cli/build/build-deps.spec.ts
+++ b/packages/cloudflare/src/cli/build/build-deps.spec.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * Regression test for https://github.com/opennextjs/opennextjs-cloudflare/issues/1339
+ *
+ * `esbuild` is imported at build time (see src/cli/build/bundle-server.ts and
+ * src/cli/build/open-next/*.ts) but used to be declared only in devDependencies,
+ * so consumers only got it by npm hoisting accident. It must be a real runtime
+ * `dependency` of the published package.
+ */
+const packageJsonPath = resolve(dirname(fileURLToPath(import.meta.url)), "../../../package.json");
+
+describe("build-time dependencies", () => {
+	it("declares esbuild as a runtime dependency", () => {
+		const { dependencies } = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
+			dependencies?: Record<string, string>;
+		};
+
+		expect(dependencies).toBeDefined();
+		expect(dependencies?.["esbuild"]).toBeDefined();
+	});
+});


### PR DESCRIPTION
Fixes #1339

**Problem**
`@opennextjs/cloudflare` imports `esbuild` at build time (`src/cli/build/bundle-server.ts`, `src/cli/build/open-next/*.ts`) but declared it only in `devDependencies`. Consumers only resolved it via hoisting from `@opennextjs/aws` (0.25.4), which breaks when the hoist slot is claimed (e.g. `@vitejs/plugin-react` optional peer) and leaves `npm ci` with `extraneous: true`.

**Approach**
- Move `esbuild: catalog:` from `devDependencies` to `dependencies` in `packages/cloudflare/package.json` (catalog already `^0.27.0`).
- Add regression test `build-deps.spec.ts` that asserts `dependencies.esbuild` is defined (TDD: RED before fix, GREEN after).
- Add changeset patch.

**Tests**
- RED: `build-deps.spec.ts` fails with `expected undefined to be defined` before fix (1 failed, 342 passed).
- GREEN: 343/343 passed, 35 files after fix.
- `pnpm -C packages/cloudflare lint:check` and `ts:check` pass (import sorted).

**Risk**
Low. No runtime behavior change; only ensures published package carries its build-time dependency.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opennextjs/opennextjs-cloudflare/pull/1353" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->