### PR TITLE
fix(patches): include preview-props.json in loadManifest glob for Next.js 16.4

### DIFF
--- a/.changeset/fix-preview-props-manifest.md
+++ b/.changeset/fix-preview-props-manifest.md
@@ -1,0 +1,14 @@
+---
+"@opennextjs/cloudflare": patch
+---
+
+fix(patches): include `preview-props.json` in loadManifest build-time inlining
+
+Next.js 16.4 moved preview props out of `prerender-manifest.json` into a standalone
+`.next/server/preview-props.json` (`PREVIEW_PROPS_MANIFEST`), loaded unconditionally by
+`NextNodeServer.getPreviewProps()` from the `Server` constructor. The file exists in the build
+output but wasn't matched by the glob pattern `*-manifest.json`, so the patched `loadManifest()`
+threw at runtime and every dynamic route returned a 500.
+
+It is inlined rather than falling back to `{}` because it holds the actual draft-mode
+id and signing/encryption keys.

--- a/packages/cloudflare/src/cli/build/patches/plugins/load-manifest.ts
+++ b/packages/cloudflare/src/cli/build/patches/plugins/load-manifest.ts
@@ -39,8 +39,13 @@ async function getLoadManifestRule(buildOpts: BuildOptions) {
 	const baseDir = join(outputDir, "server-functions/default", getPackagePath(buildOpts));
 	const dotNextDir = join(baseDir, ".next");
 
+	// Most server manifests are named `*-manifest.json`, but a few are not:
+	// `required-server-files.json`, `prefetch-hints.json` (Next 16.2+) and
+	// `server/preview-props.json` (Next 16.4+, previously inlined in the
+	// prerender manifest). They are loaded unconditionally by `NextNodeServer`,
+	// so they must be inlined rather than falling back to `{}`.
 	const manifests = await glob(
-		join(dotNextDir, "**/{*-manifest,required-server-files,prefetch-hints}.json"),
+		join(dotNextDir, "**/{*-manifest,required-server-files,prefetch-hints,preview-props}.json"),
 		{
 			windowsPathsNoEscape: true,
 		}


### PR DESCRIPTION
## Problem

Next.js 16.4 moved preview props out of `prerender-manifest.json` into a standalone `.next/server/preview-props.json`, loaded unconditionally by `NextNodeServer.getPreviewProps()`. Its name doesn't end in `-manifest`, so the glob in `load-manifest.ts` misses it and every dynamic route 500s with `Unexpected loadManifest(/.next/server/preview-props.json) call!`.

## Fix

Add `preview-props` to the glob, as #1160 did for `prefetch-hints`. Not the `return {}` fallback from #1151 — that's for optional manifests; this one is loaded unconditionally and holds the real draft-mode keys, so it has to be inlined.

Fixes #1355.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opennextjs/opennextjs-cloudflare/pull/1356" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->