### PR TITLE
chore: bump `@opennextjs/cloudflare` and `wrangler` in the c3 template

### DIFF
--- a/create-cloudflare/next/package.json
+++ b/create-cloudflare/next/package.json
@@ -13,7 +13,7 @@
 		"cf-typegen": "wrangler types --env-interface CloudflareEnv ./cloudflare-env.d.ts"
 	},
 	"dependencies": {
-		"@opennextjs/cloudflare": "^1.19.9",
+		"@opennextjs/cloudflare": "^1.20.3",
 		"next": "16.3.3",
 		"react": "^19.1.7",
 		"react-dom": "^19.1.7"
@@ -28,6 +28,6 @@
 		"eslint-config-next": "16.3.3",
 		"tailwindcss": "^4",
 		"typescript": "^5.7.4",
-		"wrangler": "^4.86.0"
+		"wrangler": "^4.125.0"
 	}
 }


### PR DESCRIPTION
Pushed early to get CI going ~but I'll test with C3.~

Tested and validated locally with this branch:

```
Cloning template from: github:opennextjs/opennextjs-cloudflare/create-cloudflare/next#vicb/c3
```


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opennextjs/opennextjs-cloudflare/pull/1364" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->